### PR TITLE
Pinned Frames and 0.8.11alpha main release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Framed Changelog
 
+## [Unreleased]
+
+- **Pinned Frames** — up to 9 standalone frames that track specific group members by name, following players across roster reshuffles. Supports Focus / Focus Target / name-target slots. Role-grouped class-colored assignment dropdown (Settings card, empty-slot placeholder click, and hover-gear icon on assigned pins). First-class aura configuration across all 10 aura sub-panels. Per-preset; absent in Solo
+- EditMode integration for Pinned Frames — drag to position (CENTER anchor convention matches the settings panel), click in edit mode to open the inline Pinned panel
+- Bridge `PLAYER_REGEN_ENABLED` through `EventBus` so combat-deferred listeners can register via `F.EventBus:Register` instead of maintaining their own frames
+
 ## v0.8.10-alpha
 
 - Add **Frame Preview Card** — every Frame settings panel (player/target/party/raid/boss/arena/pet/solo) now renders a live unit frame preview at the top of the panel using your current config, pinned next to a summary card that stays in view while the settings scroll

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -8,6 +8,14 @@ local GetAuraDataBySlot = C_UnitAuras and C_UnitAuras.GetAuraDataBySlot
 local GetAuraDataByAuraInstanceID = C_UnitAuras and C_UnitAuras.GetAuraDataByAuraInstanceID
 local IsAuraFilteredOutByInstanceID = C_UnitAuras and C_UnitAuras.IsAuraFilteredOutByInstanceID
 
+-- Compound unit tokens (e.g. 'party2target', 'playertarget', 'focustarget')
+-- are rejected by C_UnitAuras.GetAuraSlots. Pinned target-chain slots can
+-- produce these tokens — skip aura queries for them rather than erroring.
+local function isCompoundUnit(unit)
+	if(not unit or unit == 'target' or unit == 'pet') then return false end
+	return unit:match('target$') ~= nil or unit:match('pet$') ~= nil
+end
+
 local function isHelpfulAura(unit, aura)
 	if(not aura or not aura.auraInstanceID) then return false end
 
@@ -121,6 +129,7 @@ function AuraState:FullRefresh(unit)
 	self:MarkHarmfulDirty()
 
 	if(not unit or not GetAuraSlots or not GetAuraDataBySlot) then return end
+	if(isCompoundUnit(unit)) then return end
 
 	local helpfulResults = { GetAuraSlots(unit, 'HELPFUL') }
 	for i = 2, #helpfulResults do

--- a/Core/EventBus.lua
+++ b/Core/EventBus.lua
@@ -95,6 +95,7 @@ local BRIDGED_WOW_EVENTS = {
 	'GROUP_ROSTER_UPDATE',
 	'PLAYER_ROLES_ASSIGNED',
 	'PLAYER_REGEN_ENABLED',
+	'PLAYER_REGEN_DISABLED',
 }
 
 local bridgeFrame = CreateFrame('Frame')

--- a/Core/EventBus.lua
+++ b/Core/EventBus.lua
@@ -94,6 +94,7 @@ end
 local BRIDGED_WOW_EVENTS = {
 	'GROUP_ROSTER_UPDATE',
 	'PLAYER_ROLES_ASSIGNED',
+	'PLAYER_REGEN_ENABLED',
 }
 
 local bridgeFrame = CreateFrame('Frame')

--- a/Core/SecretValues.lua
+++ b/Core/SecretValues.lua
@@ -5,7 +5,6 @@ local F = Framed
 -- Secret Value Utilities
 -- Central location for all secret value checks.
 -- Every file uses these — never bare issecretvalue().
--- Based on feedback from Cell PR #462/#463 code reviews.
 -- ============================================================
 
 --- Check if a value is non-secret and safe for Lua-level operations.

--- a/EditMode/EditMode.lua
+++ b/EditMode/EditMode.lua
@@ -44,6 +44,7 @@ local FRAME_KEYS = {
 	{ key = 'raid',         label = 'Raid Frames',      isGroup = true,  getter = function() return F.Units.Raid and F.Units.Raid.header end },
 	{ key = 'boss',         label = 'Boss Frames',      isGroup = true,  getter = function() return F.Units.Boss and F.Units.Boss.frames and F.Units.Boss.frames[1] end },
 	{ key = 'arena',        label = 'Arena Frames',     isGroup = true,  getter = function() return F.Units.Arena and F.Units.Arena.frames and F.Units.Arena.frames[1] end },
+	{ key = 'pinned',       label = 'Pinned Frames',    isGroup = false, getter = function() return F.Units.Pinned and F.Units.Pinned.anchor end },
 }
 
 EditMode.FRAME_KEYS = FRAME_KEYS

--- a/Elements/Auras/PrivateAuras.lua
+++ b/Elements/Auras/PrivateAuras.lua
@@ -24,6 +24,9 @@ local DISPEL_TYPE_SUPPORTED =
 --- @param element table  The FramedPrivateAuras element
 --- @param unit string    Unit token
 local function RegisterAnchors(element, unit)
+	-- Pinned frames may be spawned without a unit (empty slot).
+	-- AddPrivateAuraAnchor throws on a nil unitToken.
+	if(not unit) then return end
 	local iconSize = element._iconSize
 	for idx = 1, #element._pool do
 		local slot = element._pool[idx]

--- a/Elements/Core/Health.lua
+++ b/Elements/Core/Health.lua
@@ -449,10 +449,14 @@ function F.Elements.Health.Setup(self, width, height, config)
 	-- health bar boundary.
 	-- --------------------------------------------------------
 
-	local needsPrediction = config.healPrediction or config.damageAbsorb
-		or config.healAbsorb or config.overAbsorb
-
-	if(needsPrediction) then
+	-- Prediction sub-widgets are always created so live toggles can show/hide
+	-- without rebuilding the Health element. oUF's Enable only registers
+	-- UNIT_ABSORB_AMOUNT_CHANGED / UNIT_HEAL_ABSORB_AMOUNT_CHANGED if the
+	-- corresponding .DamageAbsorb / .HealAbsorb is set at Enable time;
+	-- creating bars later and wiring them at toggle time leaves those events
+	-- unregistered. Always-create + always-assign + Show/Hide is the only
+	-- reliable pattern.
+	do
 		local healthBarTexture = health:GetStatusBarTexture()
 		health._healBarTexRef = healthBarTexture
 		local predWidth = width - 2
@@ -484,8 +488,11 @@ function F.Elements.Health.Setup(self, width, height, config)
 			end
 		end
 
-		-- Always create absorb bars so live toggles can show/hide them
-		local dc = config.damageAbsorbColor
+		-- Always create absorb bars so live toggles can show/hide them.
+		-- Fallbacks mirror baseUnitConfig defaults — needed for callers
+		-- (e.g. Party.lua pet frames) that pass a stripped healthCfg.
+		local dc = config.damageAbsorbColor or { 1, 1, 1, 0.6 }
+		local STRIPE_TILE = 64
 		local absorbBar = CreateFrame('StatusBar', nil, health)
 		absorbBar:SetFrameLevel(health:GetFrameLevel() + 2)
 		absorbBar:SetStatusBarTexture([[Interface\BUTTONS\WHITE8x8]])
@@ -493,15 +500,30 @@ function F.Elements.Health.Setup(self, width, height, config)
 		absorbBar:SetAllPoints(health)
 		absorbBar:SetReverseFill(true)
 
-		-- Stripe overlay — a plain Texture with SetHorizTile/SetVertTile.
-		-- Unlike StatusBar textures, plain Texture tiling uses actual
-		-- rendered pixel size, so stripes stay consistent at any width.
-		local stripeOverlay = absorbBar:CreateTexture(nil, 'OVERLAY')
-		stripeOverlay:SetTexture([[Interface\AddOns\Framed\Media\Textures\Stripe]])
+		-- Stripe rendered via a fixed-size overlay inside a clip frame:
+		-- the clip tracks the absorb fill (so the stripe is revealed only
+		-- where the shield exists), but the stripe texture itself has
+		-- stable full-bar geometry, so its SetTexCoord tile count is a
+		-- plain number. Computing tile count from the dynamic fill texture
+		-- would read a secret-tainted width in combat.
+		local stripeClip = CreateFrame('Frame', nil, absorbBar)
+		stripeClip:SetAllPoints(absorbBar:GetStatusBarTexture())
+		stripeClip:SetClipsChildren(true)
+		stripeClip:SetFrameLevel(absorbBar:GetFrameLevel())
+
+		local stripeHost = CreateFrame('Frame', nil, stripeClip)
+		stripeHost:SetAllPoints(absorbBar)
+
+		local stripeOverlay = stripeHost:CreateTexture(nil, 'OVERLAY')
+		stripeOverlay:SetTexture([[Interface\AddOns\Framed\Media\Textures\Stripe]], 'REPEAT', 'REPEAT')
 		stripeOverlay:SetVertexColor(dc[1], dc[2], dc[3], dc[4])
-		stripeOverlay:SetHorizTile(true)
-		stripeOverlay:SetVertTile(true)
-		stripeOverlay:SetAllPoints(absorbBar:GetStatusBarTexture())
+		stripeOverlay:SetAllPoints(stripeHost)
+		local function updateDamageStripeCoords()
+			local w, h = absorbBar:GetSize()
+			stripeOverlay:SetTexCoord(0, w / STRIPE_TILE, 0, h / STRIPE_TILE)
+		end
+		absorbBar:HookScript('OnSizeChanged', updateDamageStripeCoords)
+		updateDamageStripeCoords()
 		health._damageAbsorbBar = absorbBar
 
 		local overAbsorbFrame = CreateFrame('Frame', nil, health._wrapper)
@@ -518,15 +540,18 @@ function F.Elements.Health.Setup(self, width, height, config)
 		overAbsorb:SetPoint('BOTTOMRIGHT', health, 'BOTTOMRIGHT')
 		health._overDamageAbsorbIndicator = overAbsorb
 
-		if(config.damageAbsorb) then
-			health.DamageAbsorb = absorbBar
-			health.OverDamageAbsorbIndicator = overAbsorb
-		else
+		-- Always assign DamageAbsorb / OverDamageAbsorbIndicator so oUF's Enable
+		-- registers UNIT_ABSORB_AMOUNT_CHANGED. Toggling off would nil these
+		-- after Enable has already skipped that registration, so shields cast
+		-- after a live enable would never refresh.
+		health.DamageAbsorb = absorbBar
+		health.OverDamageAbsorbIndicator = overAbsorb
+		if(not config.damageAbsorb) then
 			absorbBar:Hide()
 			overAbsorb:Hide()
 		end
 
-		local hac = config.healAbsorbColor
+		local hac = config.healAbsorbColor or { 0.7, 0.1, 0.1, 0.5 }
 		local healAbsorbBar = CreateFrame('StatusBar', nil, health)
 		healAbsorbBar:SetFrameLevel(health:GetFrameLevel() + 2)
 		healAbsorbBar:SetStatusBarTexture([[Interface\BUTTONS\WHITE8x8]])
@@ -534,12 +559,24 @@ function F.Elements.Health.Setup(self, width, height, config)
 		healAbsorbBar:SetReverseFill(true)
 		healAbsorbBar:SetAllPoints(health)
 
-		local healStripeOverlay = healAbsorbBar:CreateTexture(nil, 'OVERLAY')
-		healStripeOverlay:SetTexture([[Interface\AddOns\Framed\Media\Textures\Stripe]])
+		local healStripeClip = CreateFrame('Frame', nil, healAbsorbBar)
+		healStripeClip:SetAllPoints(healAbsorbBar:GetStatusBarTexture())
+		healStripeClip:SetClipsChildren(true)
+		healStripeClip:SetFrameLevel(healAbsorbBar:GetFrameLevel())
+
+		local healStripeHost = CreateFrame('Frame', nil, healStripeClip)
+		healStripeHost:SetAllPoints(healAbsorbBar)
+
+		local healStripeOverlay = healStripeHost:CreateTexture(nil, 'OVERLAY')
+		healStripeOverlay:SetTexture([[Interface\AddOns\Framed\Media\Textures\Stripe]], 'REPEAT', 'REPEAT')
 		healStripeOverlay:SetVertexColor(hac[1], hac[2], hac[3], hac[4])
-		healStripeOverlay:SetHorizTile(true)
-		healStripeOverlay:SetVertTile(true)
-		healStripeOverlay:SetAllPoints(healAbsorbBar:GetStatusBarTexture())
+		healStripeOverlay:SetAllPoints(healStripeHost)
+		local function updateHealStripeCoords()
+			local w, h = healAbsorbBar:GetSize()
+			healStripeOverlay:SetTexCoord(0, w / STRIPE_TILE, 0, h / STRIPE_TILE)
+		end
+		healAbsorbBar:HookScript('OnSizeChanged', updateHealStripeCoords)
+		updateHealStripeCoords()
 		health._healAbsorbBar = healAbsorbBar
 
 		local overHealAbsorb = (self._iconOverlay or health._wrapper):CreateTexture(nil, 'OVERLAY')

--- a/Elements/Core/Health.lua
+++ b/Elements/Core/Health.lua
@@ -251,16 +251,18 @@ function F.Elements.Health.Setup(self, width, height, config)
 			self._textOverlay = textOverlay
 		end
 		local text = Widgets.CreateFontString(textOverlay, config.fontSize, C.Colors.textActive, config.outline, config.shadow)
+		-- Record the detached anchor values even when attachedToName is on,
+		-- so a later live toggle off can restore the text to its config
+		-- position without crashing on nil (_anchorX/_anchorY).
+		text._anchorPoint = config.textAnchor
+		text._anchorX     = config.textAnchorX
+		text._anchorY     = config.textAnchorY
 		if(config.attachedToName) then
 			-- Don't anchor here; StyleBuilder will anchor to Name text
 			health._attachedToName = true
 		else
 			local ap = config.textAnchor
 			text:SetPoint(ap, health._wrapper, ap, config.textAnchorX + 1, config.textAnchorY)
-			-- Store for live config updates
-			text._anchorPoint = ap
-			text._anchorX     = config.textAnchorX
-			text._anchorY     = config.textAnchorY
 		end
 		health.text = text
 	end

--- a/Elements/Core/Name.lua
+++ b/Elements/Core/Name.lua
@@ -91,6 +91,23 @@ function F.Elements.Name.Setup(self, config)
 	nameText._anchorX     = anchor[4] or 0
 	nameText._anchorY     = anchor[5] or 0
 
+	-- Native C-level auto-ellipsis on overflow. Our Lua-side TruncateUTF8
+	-- in ApplyNameUpdate runs inside a HookScript('OnAttributeChanged'),
+	-- which fires BEFORE oUF's [name] tag writes the new unit's name —
+	-- it truncates stale text that the tag then overwrites with an
+	-- untruncated long name (visibly spilling past the frame, especially
+	-- on narrow pinned frames). SetWordWrap(false) + a bounded width makes
+	-- the renderer append '...' on every SetText regardless of caller.
+	nameText:SetWordWrap(false)
+	local function updateNameWidth()
+		local w = self:GetWidth() or 0
+		if(w > 8) then
+			nameText:SetWidth(w - 8)
+		end
+	end
+	updateNameWidth()
+	self:HookScript('OnSizeChanged', updateNameWidth)
+
 	-- --------------------------------------------------------
 	-- Apply initial color for non-class modes
 	-- (class color is applied in PostUpdate after unit is known)

--- a/Elements/Indicators/Icon.lua
+++ b/Elements/Indicators/Icon.lua
@@ -278,7 +278,7 @@ function F.Indicators.Icon.Create(parent, size, config)
 
 	-- 1. Border via backdrop bg. The bgFile masks overlapping content
 	--    when icons use negative spacing. Content inset by 1 physical pixel
-	--    so the black bg shows as a border (matching how Cell handles block indicators).
+	--    so the black bg shows as a border.
 	local scale = parent:GetEffectiveScale()
 	local pf = 768.0 / select(2, GetPhysicalScreenSize())
 	local P = pf / scale  -- 1 physical pixel for both edge and content inset

--- a/Elements/Status/MouseoverHighlight.lua
+++ b/Elements/Status/MouseoverHighlight.lua
@@ -8,7 +8,6 @@ F.Elements.MouseoverHighlight = {}
 -- ============================================================
 -- Enable / Disable
 -- OnEnter / OnLeave are the sole mechanism — no event polling.
--- Cell uses the same approach: direct Show/Hide, no events.
 -- ============================================================
 
 local function Enable(self, unit)

--- a/Elements/Status/RoleIcon.lua
+++ b/Elements/Status/RoleIcon.lua
@@ -56,6 +56,24 @@ local function getConfiguredStyle()
 	return 2
 end
 
+--- Resolve the role to display for a unit.
+--- UnitGroupRolesAssigned returns the LFG-assigned role, which is the role
+--- the player queued as — it's sticky in follower dungeons and certain
+--- manually-formed groups and does not follow spec swaps. For the player
+--- unit specifically we can do better: GetSpecializationRole() reflects
+--- the current spec and updates synchronously with PLAYER_SPECIALIZATION_CHANGED.
+--- Other units have no queryable spec, so we fall back to the LFG role.
+local function resolveRole(unit)
+	if(unit == 'player') then
+		local specIndex = GetSpecialization()
+		local specRole = specIndex and GetSpecializationRole(specIndex)
+		if(specRole == 'TANK' or specRole == 'HEALER' or specRole == 'DAMAGER') then
+			return specRole
+		end
+	end
+	return UnitGroupRolesAssigned(unit)
+end
+
 --- Override for oUF's GroupRoleIndicator update.
 --- Sets the texture and tex coords based on the unit's assigned role.
 --- @param self Frame  The oUF unit frame
@@ -66,7 +84,7 @@ local function Override(self, event)
 		element:PreUpdate()
 	end
 
-	local role = UnitGroupRolesAssigned(self.unit)
+	local role = resolveRole(self.unit)
 	if(role == 'TANK' or role == 'HEALER' or role == 'DAMAGER') then
 		local style = getConfiguredStyle()
 		element:SetTexture(getRoleTexturePath(style))

--- a/Elements/Status/StatusText.lua
+++ b/Elements/Status/StatusText.lua
@@ -33,7 +33,7 @@ local GRADIENT_TEXTURE = F.Media.GetTexture('GradientH')
 -- Drink buff detection
 -- ============================================================
 
--- Known drink spell IDs (same list as Cell)
+-- Known drink spell IDs
 local drinkSpellIds = {
 	170906, -- Food & Drink
 	167152, -- Refreshment

--- a/Elements/Status/StatusText.lua
+++ b/Elements/Status/StatusText.lua
@@ -61,11 +61,20 @@ local function getDrinkNames()
 	return drinkNames
 end
 
+-- C_UnitAuras.GetAuraSlots rejects compound unit tokens (e.g. playertarget,
+-- party1target). Pinned frames can point at target chains via SetAttribute,
+-- so guard before calling.
+local function isCompoundUnit(unit)
+	if(not unit or unit == 'target' or unit == 'pet') then return false end
+	return unit:match('target$') ~= nil or unit:match('pet$') ~= nil
+end
+
 local function checkDrinking(unit)
 	-- Player-combat early-out: you can't drink in combat, and if the player
 	-- is in combat, party members are almost certainly too (so their aura
 	-- names will be secret anyway). Skip the scan entirely.
 	if(InCombatLockdown()) then return false end
+	if(isCompoundUnit(unit)) then return false end
 	local names = getDrinkNames()
 	if(not next(names)) then return false end
 	local slots = { C_UnitAuras.GetAuraSlots(unit, 'HELPFUL') }

--- a/Framed.toc
+++ b/Framed.toc
@@ -119,6 +119,7 @@ Units/Party.lua
 Units/Raid.lua
 Units/Boss.lua
 Units/Arena.lua
+Units/Pinned.lua
 Units/LiveUpdate/FrameConfigShared.lua
 Units/LiveUpdate/FrameConfigLayout.lua
 Units/LiveUpdate/FrameConfigElements.lua

--- a/Framed.toc
+++ b/Framed.toc
@@ -127,6 +127,7 @@ Units/LiveUpdate/FrameConfigHealth.lua
 Units/LiveUpdate/FrameConfigText.lua
 Units/LiveUpdate/FrameConfigPreset.lua
 Units/LiveUpdate/FrameConfigPets.lua
+Units/LiveUpdate/FrameConfigPinned.lua
 Units/LiveUpdate/AuraConfig.lua
 
 # Click Casting

--- a/Framed.toc
+++ b/Framed.toc
@@ -205,6 +205,7 @@ Settings/Panels/TargetOfTarget.lua
 Settings/Panels/Focus.lua
 Settings/Panels/Pet.lua
 Settings/Panels/Boss.lua
+Settings/Panels/Pinned.lua
 Settings/Panels/PartyFrames.lua
 Settings/Panels/Buffs.lua
 Settings/Panels/Debuffs.lua

--- a/Framed.toc
+++ b/Framed.toc
@@ -180,6 +180,7 @@ Settings/Cards/StatusIcons.lua
 Settings/Cards/PartyPets.lua
 Settings/Cards/About.lua
 Settings/Cards/Backups.lua
+Settings/Cards/Pinned.lua
 Settings/Cards/Appearance/Theme.lua
 Settings/Cards/Appearance/UIScale.lua
 Settings/Cards/Appearance/TargetHighlight.lua

--- a/Init.lua
+++ b/Init.lua
@@ -292,6 +292,36 @@ SlashCmdList['FRAMED'] = function(msg)
 		F.Config:PrintDebug()
 	elseif(cmd == 'events') then
 		F.EventBus:PrintDebug()
+	elseif(cmd == 'pinstate') then
+		local stored = FramedCharDB and FramedCharDB.pinnedGroup
+		print('|cff00ccff[Framed/pin]|r stored state:')
+		if(not stored) then
+			print('  (pinnedGroup key missing from FramedCharDB)')
+		else
+			print('  inGroup = ' .. tostring(stored.inGroup))
+			local n = 0
+			for name in next, (stored.names or {}) do
+				n = n + 1
+				print('  name[' .. n .. '] = ' .. tostring(name))
+			end
+			if(n == 0) then print('  (no names stored)') end
+		end
+		print('|cff00ccff[Framed/pin]|r live state:')
+		print('  IsInGroup = ' .. tostring(IsInGroup()))
+		print('  IsInRaid = ' .. tostring(IsInRaid()))
+		print('  GetNumGroupMembers = ' .. tostring(GetNumGroupMembers()))
+		print('|cff00ccff[Framed/pin]|r saved pinned slots:')
+		local presets = F.Config and F.Config:Get('presets')
+		if(presets) then
+			for presetName, preset in next, presets do
+				local pinned = preset.unitConfigs and preset.unitConfigs.pinned
+				if(pinned and pinned.slots) then
+					local count = 0
+					for _ in next, pinned.slots do count = count + 1 end
+					print('  ' .. presetName .. ': ' .. count .. ' slot(s)')
+				end
+			end
+		end
 	elseif(cmd == 'edit') then
 		if(F.EditMode.IsActive()) then
 			F.EditMode.RequestCancel()

--- a/Init.lua
+++ b/Init.lua
@@ -128,6 +128,7 @@ oUF:Factory(function(self)
 	F.Units.Raid.Spawn()
 	F.Units.Boss.Spawn()
 	F.Units.Arena.Spawn()
+	F.Units.Pinned.Spawn()
 
 	-- Force initial element updates on all spawned frames.
 	-- oUF's initObject enables elements but doesn't call UpdateAllElements;

--- a/Libs/oUF/elements/health.lua
+++ b/Libs/oUF/elements/health.lua
@@ -220,7 +220,12 @@ local function Update(self, event, unit)
 		element:PreUpdate(unit)
 	end
 
-	UnitGetDetailedHealPrediction(unit, 'player', element.values)
+	-- Pass nil casterFilter (not 'player') so DamageAbsorb/HealAbsorb
+	-- include absorbs cast by anyone on the unit — otherwise a priest's
+	-- PW:Shield on the player wouldn't show because it wasn't cast by
+	-- the player. HealingAll/Player/Other still split naturally via
+	-- the calculator's own segmentation.
+	UnitGetDetailedHealPrediction(unit, nil, element.values)
 
 	local max = element.values:GetMaximumHealth()
 	element:SetMinMaxValues(0, max)

--- a/Presets/Defaults.lua
+++ b/Presets/Defaults.lua
@@ -132,6 +132,21 @@ local function baseUnitConfig()
 	}
 end
 
+-- Pinned frames: shared style across up to 9 slots, per-slot name-tracking.
+-- Opt-in by default (enabled = false). Solo preset omits this block entirely.
+local function pinnedConfig()
+	local cfg = baseUnitConfig()
+	cfg.enabled  = false
+	cfg.count    = 3
+	cfg.columns  = 3
+	cfg.width    = 160
+	cfg.height   = 40
+	cfg.spacing  = 2
+	cfg.slots    = {}  -- keys 1..9; nil = unassigned
+	cfg.position = { x = 0, y = 0, anchor = 'CENTER' }
+	return cfg
+end
+
 local function defaultCastbar(frameWidth)
 	return {
 		height         = 16,
@@ -425,7 +440,8 @@ function F.PresetDefaults.GetAll()
 
 	-- Party
 	local partyAuras = soloUnitAuras()
-	partyAuras.party = A.Group(PARTY_AURA_SIZES)
+	partyAuras.party   = A.Group(PARTY_AURA_SIZES)
+	partyAuras.pinned  = A.Group(PARTY_AURA_SIZES)
 
 	presets['Party'] = {
 		isBase    = true,
@@ -441,8 +457,9 @@ function F.PresetDefaults.GetAll()
 				p.height = 18
 				return p
 			end)(),
-			boss  = bossConfig(),
-			party = partyConfig(),
+			boss   = bossConfig(),
+			party  = partyConfig(),
+			pinned = pinnedConfig(),
 		},
 		partyPets = {
 			enabled            = true,
@@ -469,7 +486,8 @@ function F.PresetDefaults.GetAll()
 
 	-- Raid
 	local raidAuras = soloUnitAuras()
-	raidAuras.raid = A.Group(RAID_AURA_SIZES)
+	raidAuras.raid   = A.Group(RAID_AURA_SIZES)
+	raidAuras.pinned = A.Group(RAID_AURA_SIZES)
 
 	presets['Raid'] = {
 		isBase    = true,
@@ -482,6 +500,7 @@ function F.PresetDefaults.GetAll()
 			pet          = petConfig(),
 			boss         = bossConfig(),
 			raid         = raidConfig(),
+			pinned       = pinnedConfig(),
 		},
 		auras = raidAuras,
 	}
@@ -495,7 +514,8 @@ function F.PresetDefaults.GetAll()
 		end
 		return a
 	end)()
-	arenaAuras.arena = A.Arena()
+	arenaAuras.arena   = A.Arena()
+	arenaAuras.pinned  = A.Group(PARTY_AURA_SIZES)
 
 	presets['Arena'] = {
 		isBase    = true,
@@ -517,6 +537,7 @@ function F.PresetDefaults.GetAll()
 			boss         = bossConfig(),
 			party        = partyConfig(),
 			arena        = arenaConfig(),
+			pinned       = pinnedConfig(),
 		},
 		auras = arenaAuras,
 	}

--- a/Presets/Defaults.lua
+++ b/Presets/Defaults.lua
@@ -137,7 +137,7 @@ end
 local function pinnedConfig()
 	local cfg = baseUnitConfig()
 	cfg.enabled  = false
-	cfg.count    = 3
+	cfg.count    = 9
 	cfg.columns  = 3
 	cfg.width    = 160
 	cfg.height   = 40
@@ -413,6 +413,7 @@ local function soloUnitAuras()
 		focus        = A.Solo(14, 6),
 		pet          = A.Minimal(),
 		boss         = A.Boss(),
+		pinned       = A.Minimal(),
 	}
 end
 
@@ -434,6 +435,7 @@ function F.PresetDefaults.GetAll()
 			focus        = focusConfig(),
 			pet          = petConfig(),
 			boss         = bossConfig(),
+			pinned       = pinnedConfig(),
 		},
 		auras = soloUnitAuras(),
 	}
@@ -629,6 +631,13 @@ function F.PresetDefaults.EnsureDefaults()
 					if(savedUC[ut] and savedUC[ut].statusIcons) then
 						savedUC[ut].statusIcons.raidRole = false
 					end
+				end
+
+				-- Migrate pinned.count: old default was 3, new is 9. Bump any
+				-- save that still matches the old default so existing users
+				-- don't get stuck with 3 slots and no UI control to change it.
+				if(savedUC.pinned and savedUC.pinned.count == 3) then
+					savedUC.pinned.count = 9
 				end
 
 				-- General backfill: deep-merge any missing keys from defaults

--- a/Preview/PreviewFrame.lua
+++ b/Preview/PreviewFrame.lua
@@ -530,8 +530,19 @@ local function BuildStatusText(frame, config, fakeUnit)
 	overlay:SetFrameLevel(frame:GetFrameLevel() + config.elementStrata.statusText)
 
 	local text = Widgets.CreateFontString(overlay, stConfig.fontSize, C.Colors.textActive)
-	text:SetPoint(stConfig.anchor, overlay, stConfig.anchor,
-		stConfig.anchorX, stConfig.anchorY)
+
+	-- Anchor by canonical statusText.position. Mirrors the top/center/bottom
+	-- rows used by Elements/Status/StatusText.lua so the preview matches the
+	-- live frame layout instead of guessing absolute anchor coordinates.
+	local anchorTo = frame._healthBar or overlay
+	local position = stConfig.position
+	if(position == 'top') then
+		text:SetPoint('TOP', anchorTo, 'TOP', 0, 0)
+	elseif(position == 'center') then
+		text:SetPoint('CENTER', anchorTo, 'CENTER', 0, 0)
+	else
+		text:SetPoint('BOTTOM', anchorTo, 'BOTTOM', 0, 0)
+	end
 
 	-- Show a fake status for dead units
 	if(fakeUnit and fakeUnit.isDead) then

--- a/Settings/Builders/FramePreview.lua
+++ b/Settings/Builders/FramePreview.lua
@@ -97,14 +97,31 @@ local function getCastbarExtra(config)
 	return config.castbar.height + C.Spacing.base
 end
 
-local function CalculateGroupLayout(config, count)
+local function CalculateGroupLayout(config, count, unitType)
 	local w = config.width
 	local h = config.height + getCastbarExtra(config)
 	local spacing = config.spacing
+
+	local positions = {}
+
+	-- Pinned is a fixed-column, row-major grid (no orientation). Match
+	-- Units/Pinned.lua:Layout so the preview slot order mirrors the real frame.
+	if(unitType == 'pinned') then
+		local cols = math.max(1, math.min(config.columns, count))
+		for i = 0, count - 1 do
+			local col = i % cols
+			local row = math.floor(i / cols)
+			positions[i + 1] = {
+				x = col * (w + spacing),
+				y = -(row * (h + spacing)),
+			}
+		end
+		return positions
+	end
+
 	local upc = config.unitsPerColumn
 	local isVertical = config.orientation == 'vertical'
 
-	local positions = {}
 	for i = 0, count - 1 do
 		local col = math.floor(i / upc)
 		local row = i % upc
@@ -518,7 +535,7 @@ local function RenderGroupPreview(viewport, unitType, count)
 	end
 	sortedFakes = SortFakeUnits(sortedFakes, config)
 
-	local positions = CalculateGroupLayout(config, count)
+	local positions = CalculateGroupLayout(config, count, unitType)
 
 	-- Flush-left with title/toggle (no PREVIEW_INSET). Portrait still shifts
 	-- the frames right so the portrait box sits in the gutter.
@@ -590,19 +607,27 @@ local function RenderGroupPreview(viewport, unitType, count)
 	local config_w = config.width
 	local config_h = config.height
 	local spacing = config.spacing
-	local upc = config.unitsPerColumn
-	local isVertical = config.orientation == 'vertical'
-
-	local cols = math.ceil(count / upc)
-	local rows = math.min(count, upc)
 
 	local totalW, totalH
-	if(isVertical) then
-		totalW = cols * config_w + (cols - 1) * spacing
-		totalH = rows * config_h + (rows - 1) * spacing
+	if(unitType == 'pinned') then
+		local screenCols = math.max(1, math.min(config.columns, count))
+		local screenRows = math.ceil(count / screenCols)
+		totalW = screenCols * config_w + (screenCols - 1) * spacing
+		totalH = screenRows * config_h + (screenRows - 1) * spacing
 	else
-		totalW = rows * config_w + (rows - 1) * spacing
-		totalH = cols * config_h + (cols - 1) * spacing
+		local upc = config.unitsPerColumn
+		local isVertical = config.orientation == 'vertical'
+
+		local cols = math.ceil(count / upc)
+		local rows = math.min(count, upc)
+
+		if(isVertical) then
+			totalW = cols * config_w + (cols - 1) * spacing
+			totalH = rows * config_h + (rows - 1) * spacing
+		else
+			totalW = rows * config_w + (rows - 1) * spacing
+			totalH = cols * config_h + (cols - 1) * spacing
+		end
 	end
 
 	viewport:SetSize(math.max(totalW, 1), math.max(totalH, 1))
@@ -791,15 +816,22 @@ function FP.RebuildPreview()
 		else
 			count = GROUP_COUNTS[activeUnitType]
 		end
-		local upc = config.unitsPerColumn or count
-		local cols = math.ceil(count / upc)
-		local rows = math.min(count, upc)
-		local isVertical = config.orientation == 'vertical'
-		naturalH = rows * (config.height + cbExtra) + (rows - 1) * config.spacing + inset2
-		if(isVertical) then
-			naturalW = cols * config.width + (cols - 1) * config.spacing
+		if(activeUnitType == 'pinned') then
+			local screenCols = math.max(1, math.min(config.columns, count))
+			local screenRows = math.ceil(count / screenCols)
+			naturalH = screenRows * (config.height + cbExtra) + (screenRows - 1) * config.spacing + inset2
+			naturalW = screenCols * config.width + (screenCols - 1) * config.spacing
 		else
-			naturalW = rows * config.width + (rows - 1) * config.spacing
+			local upc = config.unitsPerColumn or count
+			local cols = math.ceil(count / upc)
+			local rows = math.min(count, upc)
+			local isVertical = config.orientation == 'vertical'
+			naturalH = rows * (config.height + cbExtra) + (rows - 1) * config.spacing + inset2
+			if(isVertical) then
+				naturalW = cols * config.width + (cols - 1) * config.spacing
+			else
+				naturalW = rows * config.width + (rows - 1) * config.spacing
+			end
 		end
 	else
 		naturalH = config.height + cbExtra + inset2
@@ -1074,7 +1106,13 @@ function FP.BuildPreviewCard(parent, width, unitType)
 		naturalH = rows * (config.height + cbExtra) + (rows - 1) * config.spacing + inset2
 	elseif(GROUP_COUNTS[unitType]) then
 		local count = GROUP_COUNTS[unitType]
-		local rows = math.min(count, config.unitsPerColumn)
+		local rows
+		if(unitType == 'pinned') then
+			local screenCols = math.max(1, math.min(config.columns, count))
+			rows = math.ceil(count / screenCols)
+		else
+			rows = math.min(count, config.unitsPerColumn)
+		end
 		naturalH = rows * (config.height + cbExtra) + (rows - 1) * config.spacing + inset2
 	else
 		naturalH = config.height + cbExtra + inset2

--- a/Settings/Builders/FramePreview.lua
+++ b/Settings/Builders/FramePreview.lua
@@ -73,9 +73,10 @@ local showPets = false
 local petFrames = {}
 
 local GROUP_COUNTS = {
-	party = 5,
-	arena = 3,
-	boss  = 4,
+	party  = 5,
+	arena  = 3,
+	boss   = 4,
+	pinned = 9,
 }
 
 local function getFakeUnit(index)

--- a/Settings/Builders/FramePreview.lua
+++ b/Settings/Builders/FramePreview.lua
@@ -1027,6 +1027,24 @@ function FP.BuildPreviewCard(parent, width, unitType)
 		petToggle:SetChecked(false)
 	end
 
+	-- Pinned master enable — pinned is the only unit type gated by
+	-- config.enabled (default off), so the toggle has to live somewhere. On
+	-- the preview card it sits adjacent to what it turns on; the Slot
+	-- Assignments card below is then meaningful instead of dead weight. The
+	-- live frame responds automatically via FrameConfigPinned's CONFIG_CHANGED
+	-- handler (keys: 'enabled' → Layout + Resolve).
+	local pinnedEnabledToggle
+	if(unitType == 'pinned') then
+		pinnedEnabledToggle = Widgets.CreateCheckButton(inner, 'Enable Pinned Frames', function(checked)
+			local presetName = F.Settings.GetEditingPreset()
+			if(not presetName) then return end
+			F.Config:Set('presets.' .. presetName .. '.unitConfigs.pinned.enabled', checked)
+			F.PresetManager.MarkCustomized(presetName)
+		end)
+		local config = getUnitConfig('pinned')
+		pinnedEnabledToggle:SetChecked(config and config.enabled == true)
+	end
+
 	-- Preview viewport (horizontal scroll for overflow) — TOPLEFT y is applied
 	-- by the relayout closure below so it shifts when Focus Mode reflows.
 	local viewport = CreateFrame('ScrollFrame', nil, inner)
@@ -1076,6 +1094,12 @@ function FP.BuildPreviewCard(parent, width, unitType)
 		if(petToggle) then
 			petToggle:ClearAllPoints()
 			petToggle:SetPoint('TOPLEFT', inner, 'TOPLEFT', 0, cyNext)
+			cyNext = cyNext - 16
+		end
+
+		if(pinnedEnabledToggle) then
+			pinnedEnabledToggle:ClearAllPoints()
+			pinnedEnabledToggle:SetPoint('TOPLEFT', inner, 'TOPLEFT', 0, cyNext)
 			cyNext = cyNext - 16
 		end
 

--- a/Settings/Builders/FramePreview.lua
+++ b/Settings/Builders/FramePreview.lua
@@ -331,8 +331,16 @@ local function onConfigChanged(path)
 	local config = getUnitConfig(activeUnitType)
 	if(not config) then return end
 
-	if(STRUCTURAL_KEYS[key:match('^[^%.]+')]) then
+	local keyRoot = key:match('^[^%.]+')
+	if(STRUCTURAL_KEYS[keyRoot]) then
 		debouncedRebuild()
+	elseif(keyRoot == 'slots') then
+		-- Pinned 'slots' is an assignment map (which roster member lives in
+		-- which frame), not a visual property. The preview shows generic
+		-- placeholder units, so a slot change doesn't alter the preview —
+		-- skip UpdateFromConfig, which would otherwise destroy+rebuild every
+		-- preview frame's textures and flash them on screen.
+		return
 	else
 		for _, frame in next, previewFrames do
 			F.PreviewFrame.UpdateFromConfig(frame, config, nil, nil)

--- a/Settings/Cards/Pinned.lua
+++ b/Settings/Cards/Pinned.lua
@@ -69,7 +69,13 @@ end
 -- Row decorators (class colors + non-selectable headers)
 -- ============================================================
 
-local function headerDecorator(row, item)
+local HEADER_PREFIX = '__hdr'
+
+local function isHeaderValue(value)
+	return type(value) == 'string' and value:sub(1, #HEADER_PREFIX) == HEADER_PREFIX
+end
+
+local function headerDecorator(row)
 	row._label:SetTextColor(0.6, 0.6, 0.6, 1)
 	row:SetScript('OnEnter', function() end)
 	row:SetScript('OnLeave', function() end)
@@ -208,7 +214,7 @@ function F.Units.Pinned.OpenAssignmentMenu(slotIndex, anchorFrame)
 	detachedDropdown:SetItems(buildItems(slotIndex, slots))
 	detachedDropdown:SetValue(slotToValue(slots[slotIndex]))
 	detachedDropdown:SetOnSelect(function(value)
-		if(type(value) == 'string' and value:sub(1, 5) == '__hdr') then return end
+		if(isHeaderValue(value)) then return end
 		writeSlot(presetName, slotIndex, value)
 	end)
 
@@ -243,7 +249,7 @@ local function renderSlotRow(parent, slotIndex, cardY, width)
 	end
 
 	dd:SetOnSelect(function(value)
-		if(type(value) == 'string' and value:sub(1, 5) == '__hdr') then
+		if(isHeaderValue(value)) then
 			refresh()
 			return
 		end

--- a/Settings/Cards/Pinned.lua
+++ b/Settings/Cards/Pinned.lua
@@ -248,7 +248,6 @@ local function renderSlotRow(parent, slotIndex, cardY, width)
 			return
 		end
 		writeSlot(F.Settings.GetEditingPreset(), slotIndex, value)
-		refresh()
 	end)
 
 	refresh()
@@ -291,13 +290,13 @@ function F.SettingsCards.Pinned(parent, width, unitType, getConfig, setConfig)
 		if(path:match('unitConfigs%.pinned%.count$') or path:match('unitConfigs%.pinned%.slots')) then
 			rebuild()
 		end
-	end, 'PinnedCard.' .. tostring(card) .. '.CC')
+	end, 'PinnedCard.CC')
 
 	F.EventBus:Register('GROUP_ROSTER_UPDATE', function()
 		for _, r in next, rows do
 			if(r._refresh) then r._refresh() end
 		end
-	end, 'PinnedCard.' .. tostring(card) .. '.Roster')
+	end, 'PinnedCard.Roster')
 
 	return card
 end

--- a/Settings/Cards/Pinned.lua
+++ b/Settings/Cards/Pinned.lua
@@ -52,13 +52,20 @@ local function scanRoster()
 	return roster
 end
 
-local function assignedNamesSet(slots, excludeIndex)
+-- Collect the exact dropdown values already assigned to other slots so only
+-- the matching row is hidden — the NAME row and its TARGET sibling are
+-- independent selections and must not block each other.
+local function assignedValuesSet(slots, excludeIndex)
 	local set = {}
 	for i = 1, MAX_SLOTS do
 		if(i ~= excludeIndex) then
 			local s = slots and slots[i]
-			if(s and (s.type == 'name' or s.type == 'nametarget') and s.value) then
-				set[s.value] = true
+			if(s and s.value) then
+				if(s.type == 'name') then
+					set['NAME:' .. s.value] = true
+				elseif(s.type == 'nametarget') then
+					set['TARGET:' .. s.value] = true
+				end
 			end
 		end
 	end
@@ -97,7 +104,7 @@ end
 -- ============================================================
 
 local function buildItems(slotIndex, slots)
-	local blocked = assignedNamesSet(slots, slotIndex)
+	local blocked = assignedValuesSet(slots, slotIndex)
 	local items = {}
 
 	-- Unit references
@@ -122,17 +129,23 @@ local function buildItems(slotIndex, slots)
 				_decorateRow = headerDecorator,
 			}
 			for _, p in next, bucket do
-				if(p.name and not blocked[p.name]) then
-					items[#items + 1] = {
-						text  = p.name,
-						value = 'NAME:' .. p.name,
-						_decorateRow = classColorDecorator(p.class, false),
-					}
-					items[#items + 1] = {
-						text  = p.name .. "'s Target",
-						value = 'TARGET:' .. p.name,
-						_decorateRow = classColorDecorator(p.class, true),
-					}
+				if(p.name) then
+					local nameValue   = 'NAME:' .. p.name
+					local targetValue = 'TARGET:' .. p.name
+					if(not blocked[nameValue]) then
+						items[#items + 1] = {
+							text  = p.name,
+							value = nameValue,
+							_decorateRow = classColorDecorator(p.class, false),
+						}
+					end
+					if(not blocked[targetValue]) then
+						items[#items + 1] = {
+							text  = p.name .. "'s Target",
+							value = targetValue,
+							_decorateRow = classColorDecorator(p.class, true),
+						}
+					end
 				end
 			end
 		end
@@ -149,13 +162,17 @@ end
 -- Value <-> slot conversion
 -- ============================================================
 
+-- Return nil for an empty slot so the dropdown treats it as "no value selected"
+-- instead of matching the '(Unassign)' row at the bottom of the list — that
+-- match would trigger the scroll-to-selected logic and open the list already
+-- scrolled past the Unit References / Focus rows at the top.
 local function slotToValue(slot)
-	if(not slot) then return 'UNASSIGN' end
+	if(not slot) then return nil end
 	if(slot.type == 'unit' and slot.value == 'focus')       then return 'FOCUS' end
 	if(slot.type == 'unit' and slot.value == 'focustarget') then return 'FOCUSTARGET' end
 	if(slot.type == 'name')                                 then return 'NAME:' .. slot.value end
 	if(slot.type == 'nametarget')                           then return 'TARGET:' .. slot.value end
-	return 'UNASSIGN'
+	return nil
 end
 
 local function valueToSlot(value)
@@ -173,15 +190,49 @@ end
 -- Preset-scoped read/write
 -- ============================================================
 
+-- Normalize any legacy string-keyed entries ('1' → 1). Config:Set paths are
+-- dot-split into string keys, so earlier builds that wrote slots.<i> through
+-- Config:Set left the entries under string keys; readers use numeric keys
+-- throughout so those writes were invisible until normalized.
+local function normalizeSlotKeys(slots)
+	if(type(slots) ~= 'table') then return slots end
+	for k, v in next, slots do
+		if(type(k) == 'string') then
+			local n = tonumber(k)
+			if(n and slots[n] == nil) then
+				slots[n] = v
+			end
+			slots[k] = nil
+		end
+	end
+	return slots
+end
+
 local function readSlotsFor(presetName)
 	if(not presetName) then return nil end
 	local cfg = F.Config:Get('presets.' .. presetName .. '.unitConfigs.pinned')
-	return cfg and cfg.slots
+	return cfg and normalizeSlotKeys(cfg.slots)
 end
 
 local function writeSlot(presetName, slotIndex, value)
 	if(not presetName) then return end
-	F.Config:Set('presets.' .. presetName .. '.unitConfigs.pinned.slots.' .. slotIndex, valueToSlot(value))
+	local basePath = 'presets.' .. presetName .. '.unitConfigs.pinned.slots'
+	local slots    = F.Config:Get(basePath)
+	if(type(slots) ~= 'table') then
+		F.Config:Set(basePath, {})
+		slots = F.Config:Get(basePath)
+	end
+	normalizeSlotKeys(slots)
+
+	local newSlot = valueToSlot(value)
+	local oldSlot = slots[slotIndex]
+	slots[slotIndex] = newSlot
+
+	-- Mutating the table directly bypasses Config:Set's dot-path expansion,
+	-- which would otherwise coerce the slot index to a string key.
+	local path = basePath .. '.' .. slotIndex
+	F.EventBus:Fire('CONFIG_CHANGED', path, newSlot, oldSlot)
+	F.EventBus:Fire('CONFIG_CHANGED:presets', path, newSlot, oldSlot)
 	F.PresetManager.MarkCustomized(presetName)
 end
 
@@ -190,8 +241,6 @@ end
 -- Called from the gear icon on assigned slots and the placeholder
 -- on empty slots. Binds to the currently-active preset.
 -- ============================================================
-
-local detachedDropdown
 
 function F.Units.Pinned.OpenAssignmentMenu(slotIndex, anchorFrame)
 	if(InCombatLockdown()) then
@@ -202,24 +251,11 @@ function F.Units.Pinned.OpenAssignmentMenu(slotIndex, anchorFrame)
 	local presetName = F.AutoSwitch.GetCurrentPreset()
 	if(not presetName) then return end
 
-	if(not detachedDropdown) then
-		detachedDropdown = Widgets.CreateDropdown(UIParent, 200)
-		detachedDropdown:SetFrameStrata('DIALOG')
-	end
-
-	detachedDropdown:ClearAllPoints()
-	detachedDropdown:SetPoint('TOP', anchorFrame, 'BOTTOM', 0, -2)
-
 	local slots = readSlotsFor(presetName) or {}
-	detachedDropdown:SetItems(buildItems(slotIndex, slots))
-	detachedDropdown:SetValue(slotToValue(slots[slotIndex]))
-	detachedDropdown:SetOnSelect(function(value)
+	Widgets.OpenPopupMenu(anchorFrame, buildItems(slotIndex, slots), slotToValue(slots[slotIndex]), function(value)
 		if(isHeaderValue(value)) then return end
 		writeSlot(presetName, slotIndex, value)
 	end)
-
-	detachedDropdown:Show()
-	if(detachedDropdown.Open) then detachedDropdown:Open() end
 end
 
 -- ============================================================
@@ -245,7 +281,15 @@ local function renderSlotRow(parent, slotIndex, cardY, width)
 		local presetName = F.Settings.GetEditingPreset()
 		local slots = readSlotsFor(presetName) or {}
 		dd:SetItems(buildItems(slotIndex, slots))
-		dd:SetValue(slotToValue(slots[slotIndex]))
+		local value = slotToValue(slots[slotIndex])
+		dd:SetValue(value)
+		-- Empty slots send nil (to avoid auto-scrolling to the '(Unassign)' row);
+		-- paint a muted placeholder on the button so the user still sees state.
+		if(value == nil) then
+			dd._label:SetText('(Unassign)')
+			local ts = C.Colors.textSecondary
+			dd._label:SetTextColor(ts[1], ts[2], ts[3], ts[4] or 1)
+		end
 	end
 
 	dd:SetOnSelect(function(value)
@@ -293,8 +337,16 @@ function F.SettingsCards.Pinned(parent, width, unitType, getConfig, setConfig)
 
 	F.EventBus:Register('CONFIG_CHANGED', function(path)
 		if(not path) then return end
-		if(path:match('unitConfigs%.pinned%.count$') or path:match('unitConfigs%.pinned%.slots')) then
+		-- count changes the number of rows, so a full rebuild is required.
+		if(path:match('unitConfigs%.pinned%.count$')) then
 			rebuild()
+		-- slot changes keep the same 9 rows — just refresh their dropdowns.
+		-- Destroying and recreating every row on each assign/unassign caused
+		-- a visible texture flash across all 9 settings widgets.
+		elseif(path:match('unitConfigs%.pinned%.slots')) then
+			for _, r in next, rows do
+				if(r._refresh) then r._refresh() end
+			end
 		end
 	end, 'PinnedCard.CC')
 

--- a/Settings/Cards/Pinned.lua
+++ b/Settings/Cards/Pinned.lua
@@ -1,0 +1,303 @@
+local addonName, Framed = ...
+local F = Framed
+local Widgets = F.Widgets
+local C = F.Constants
+local B = F.FrameSettingsBuilder
+
+F.SettingsCards = F.SettingsCards or {}
+
+local MAX_SLOTS   = 9
+local ROLES       = { 'TANK', 'HEALER', 'DAMAGER' }
+local ROLE_LABELS = { TANK = 'Tanks', HEALER = 'Healers', DAMAGER = 'DPS' }
+
+-- ============================================================
+-- Helpers
+-- ============================================================
+
+local function getClassColor(class)
+	local oUF = F.oUF
+	if(oUF and oUF.colors and oUF.colors.class and oUF.colors.class[class]) then
+		return oUF.colors.class[class]:GetRGB()
+	end
+	return 0.5, 0.5, 0.5
+end
+
+local function fullUnitName(token)
+	if(not UnitExists(token)) then return nil end
+	local name, realm = UnitName(token)
+	if(not name) then return nil end
+	if(realm and realm ~= '') then return name .. '-' .. realm end
+	return name
+end
+
+local function scanRoster()
+	local roster = {}
+	local function add(token)
+		if(not UnitExists(token)) then return end
+		roster[#roster + 1] = {
+			name  = fullUnitName(token),
+			token = token,
+			class = select(2, UnitClass(token)),
+			role  = UnitGroupRolesAssigned(token) or 'DAMAGER',
+		}
+	end
+	if(IsInRaid()) then
+		for i = 1, GetNumGroupMembers() do add('raid' .. i) end
+	elseif(IsInGroup()) then
+		for i = 1, GetNumGroupMembers() - 1 do add('party' .. i) end
+		add('player')
+	else
+		add('player')
+	end
+	return roster
+end
+
+local function assignedNamesSet(slots, excludeIndex)
+	local set = {}
+	for i = 1, MAX_SLOTS do
+		if(i ~= excludeIndex) then
+			local s = slots and slots[i]
+			if(s and (s.type == 'name' or s.type == 'nametarget') and s.value) then
+				set[s.value] = true
+			end
+		end
+	end
+	return set
+end
+
+-- ============================================================
+-- Row decorators (class colors + non-selectable headers)
+-- ============================================================
+
+local function headerDecorator(row, item)
+	row._label:SetTextColor(0.6, 0.6, 0.6, 1)
+	row:SetScript('OnEnter', function() end)
+	row:SetScript('OnLeave', function() end)
+	row:SetScript('OnMouseDown', function() end)
+end
+
+local function classColorDecorator(classToken, indent)
+	return function(row, item)
+		if(indent) then
+			row._label:SetText('    ' .. (item.text or ''))
+		end
+		local r, g, b = getClassColor(classToken)
+		row._label:SetTextColor(r, g, b, 1)
+	end
+end
+
+-- ============================================================
+-- Build dropdown items from a slots table
+-- ============================================================
+
+local function buildItems(slotIndex, slots)
+	local blocked = assignedNamesSet(slots, slotIndex)
+	local items = {}
+
+	-- Unit references
+	items[#items + 1] = { text = '— Unit References —', value = '__hdr_unit', _decorateRow = headerDecorator }
+	items[#items + 1] = { text = 'Focus',        value = 'FOCUS' }
+	items[#items + 1] = { text = 'Focus Target', value = 'FOCUSTARGET' }
+
+	-- Role-grouped roster
+	local roster = scanRoster()
+	local byRole = { TANK = {}, HEALER = {}, DAMAGER = {} }
+	for _, p in next, roster do
+		local bucket = byRole[p.role] or byRole.DAMAGER
+		bucket[#bucket + 1] = p
+	end
+
+	for _, roleToken in next, ROLES do
+		local bucket = byRole[roleToken]
+		if(bucket and #bucket > 0) then
+			items[#items + 1] = {
+				text  = '— ' .. ROLE_LABELS[roleToken] .. ' —',
+				value = '__hdr_' .. roleToken,
+				_decorateRow = headerDecorator,
+			}
+			for _, p in next, bucket do
+				if(p.name and not blocked[p.name]) then
+					items[#items + 1] = {
+						text  = p.name,
+						value = 'NAME:' .. p.name,
+						_decorateRow = classColorDecorator(p.class, false),
+					}
+					items[#items + 1] = {
+						text  = p.name .. "'s Target",
+						value = 'TARGET:' .. p.name,
+						_decorateRow = classColorDecorator(p.class, true),
+					}
+				end
+			end
+		end
+	end
+
+	-- Unassign
+	items[#items + 1] = { text = '— None —',  value = '__hdr_none', _decorateRow = headerDecorator }
+	items[#items + 1] = { text = '(Unassign)', value = 'UNASSIGN' }
+
+	return items
+end
+
+-- ============================================================
+-- Value <-> slot conversion
+-- ============================================================
+
+local function slotToValue(slot)
+	if(not slot) then return 'UNASSIGN' end
+	if(slot.type == 'unit' and slot.value == 'focus')       then return 'FOCUS' end
+	if(slot.type == 'unit' and slot.value == 'focustarget') then return 'FOCUSTARGET' end
+	if(slot.type == 'name')                                 then return 'NAME:' .. slot.value end
+	if(slot.type == 'nametarget')                           then return 'TARGET:' .. slot.value end
+	return 'UNASSIGN'
+end
+
+local function valueToSlot(value)
+	if(value == 'UNASSIGN')    then return nil end
+	if(value == 'FOCUS')       then return { type = 'unit', value = 'focus' } end
+	if(value == 'FOCUSTARGET') then return { type = 'unit', value = 'focustarget' } end
+	local name = value:match('^NAME:(.+)$')
+	if(name) then return { type = 'name', value = name } end
+	local tgtName = value:match('^TARGET:(.+)$')
+	if(tgtName) then return { type = 'nametarget', value = tgtName } end
+	return nil
+end
+
+-- ============================================================
+-- Preset-scoped read/write
+-- ============================================================
+
+local function readSlotsFor(presetName)
+	if(not presetName) then return nil end
+	local cfg = F.Config:Get('presets.' .. presetName .. '.unitConfigs.pinned')
+	return cfg and cfg.slots
+end
+
+local function writeSlot(presetName, slotIndex, value)
+	if(not presetName) then return end
+	F.Config:Set('presets.' .. presetName .. '.unitConfigs.pinned.slots.' .. slotIndex, valueToSlot(value))
+	F.PresetManager.MarkCustomized(presetName)
+end
+
+-- ============================================================
+-- In-world assignment dropdown (overrides Units/Pinned.lua stub)
+-- Called from the gear icon on assigned slots and the placeholder
+-- on empty slots. Binds to the currently-active preset.
+-- ============================================================
+
+local detachedDropdown
+
+function F.Units.Pinned.OpenAssignmentMenu(slotIndex, anchorFrame)
+	if(InCombatLockdown()) then
+		print('|cff00ccffFramed|r Pinned: cannot reassign during combat')
+		return
+	end
+
+	local presetName = F.AutoSwitch.GetCurrentPreset()
+	if(not presetName) then return end
+
+	if(not detachedDropdown) then
+		detachedDropdown = Widgets.CreateDropdown(UIParent, 200)
+		detachedDropdown:SetFrameStrata('DIALOG')
+	end
+
+	detachedDropdown:ClearAllPoints()
+	detachedDropdown:SetPoint('TOP', anchorFrame, 'BOTTOM', 0, -2)
+
+	local slots = readSlotsFor(presetName) or {}
+	detachedDropdown:SetItems(buildItems(slotIndex, slots))
+	detachedDropdown:SetValue(slotToValue(slots[slotIndex]))
+	detachedDropdown:SetOnSelect(function(value)
+		if(type(value) == 'string' and value:sub(1, 5) == '__hdr') then return end
+		writeSlot(presetName, slotIndex, value)
+	end)
+
+	detachedDropdown:Show()
+	if(detachedDropdown.Open) then detachedDropdown:Open() end
+end
+
+-- ============================================================
+-- Settings card — per-slot list bound to the editing preset
+-- ============================================================
+
+local ROW_H = 28
+
+local function renderSlotRow(parent, slotIndex, cardY, width)
+	local row = CreateFrame('Frame', nil, parent)
+	row:SetSize(width, ROW_H)
+
+	local label = Widgets.CreateFontString(row, C.Font.sizeNormal, C.Colors.textPrimary)
+	label:SetPoint('LEFT', row, 'LEFT', 0, 0)
+	label:SetText('Slot ' .. slotIndex)
+	label:SetWidth(60)
+
+	local dd = Widgets.CreateDropdown(row, width - 72)
+	dd:ClearAllPoints()
+	dd:SetPoint('LEFT', label, 'RIGHT', 12, 0)
+
+	local function refresh()
+		local presetName = F.Settings.GetEditingPreset()
+		local slots = readSlotsFor(presetName) or {}
+		dd:SetItems(buildItems(slotIndex, slots))
+		dd:SetValue(slotToValue(slots[slotIndex]))
+	end
+
+	dd:SetOnSelect(function(value)
+		if(type(value) == 'string' and value:sub(1, 5) == '__hdr') then
+			refresh()
+			return
+		end
+		writeSlot(F.Settings.GetEditingPreset(), slotIndex, value)
+		refresh()
+	end)
+
+	refresh()
+	row._refresh = refresh
+	return row
+end
+
+function F.SettingsCards.Pinned(parent, width, unitType, getConfig, setConfig)
+	local card, inner, cardY = Widgets.StartCard(parent, width, 0)
+	local innerW = width - Widgets.CARD_PADDING * 2
+
+	local rows = {}
+
+	local function rebuild()
+		for _, r in next, rows do r:Hide(); r:SetParent(nil) end
+		rows = {}
+
+		local presetName = F.Settings.GetEditingPreset()
+		local cfg = presetName and F.Config:Get('presets.' .. presetName .. '.unitConfigs.pinned')
+		if(not cfg) then
+			Widgets.EndCard(card, parent, cardY)
+			return
+		end
+		local count = math.max(1, math.min(cfg.count or 3, MAX_SLOTS))
+
+		local y = cardY
+		for i = 1, count do
+			local row = renderSlotRow(inner, i, y, innerW)
+			rows[i] = row
+			y = B.PlaceWidget(row, inner, y, ROW_H)
+		end
+
+		Widgets.EndCard(card, parent, y)
+	end
+
+	rebuild()
+
+	F.EventBus:Register('CONFIG_CHANGED', function(path)
+		if(not path) then return end
+		if(path:match('unitConfigs%.pinned%.count$') or path:match('unitConfigs%.pinned%.slots')) then
+			rebuild()
+		end
+	end, 'PinnedCard.' .. tostring(card) .. '.CC')
+
+	F.EventBus:Register('GROUP_ROSTER_UPDATE', function()
+		for _, r in next, rows do
+			if(r._refresh) then r._refresh() end
+		end
+	end, 'PinnedCard.' .. tostring(card) .. '.Roster')
+
+	return card
+end

--- a/Settings/Cards/PositionAndLayout.lua
+++ b/Settings/Cards/PositionAndLayout.lua
@@ -193,6 +193,18 @@ function F.SettingsCards.PositionAndLayout(parent, width, unitType, getConfig, s
 		posYSlider:SetValue(y)
 	end, evtTag .. '.dragging')
 
+	-- EditMode hides Settings on entry (killing our listeners via OnHide)
+	-- and reshows it on exit — so edit-mode commits land in config while
+	-- our sliders are inert. Re-sync on show or the user's next nudge
+	-- writes (stale + delta) and snaps the frame back near pre-edit.
+	card:HookScript('OnShow', function()
+		widthSlider:SetValue(getConfig('width'))
+		heightSlider:SetValue(getConfig('height'))
+		anchorPicker:SetAnchor(getConfig('position.anchor'), 0, 0)
+		posXSlider:SetValue(getConfig('position.x'))
+		posYSlider:SetValue(getConfig('position.y'))
+	end)
+
 	-- Unregister when card is destroyed
 	card:HookScript('OnHide', function()
 		F.EventBus:Unregister('EDIT_MODE_FRAME_RESIZED', evtTag .. '.resize')

--- a/Settings/FrameSettingsBuilder.lua
+++ b/Settings/FrameSettingsBuilder.lua
@@ -874,7 +874,7 @@ function F.FrameSettingsBuilder.Create(parent, unitType)
 	if(unitType == 'party') then
 		grid:AddCard('partyPets', 'Party Pets', F.SettingsCards.PartyPets, {})
 	end
-	if(unitType == 'pinned' and F.SettingsCards.Pinned) then
+	if(unitType == 'pinned') then
 		grid:AddCard('slotAssignments', 'Slot Assignments', F.SettingsCards.Pinned, {})
 	end
 

--- a/Settings/FrameSettingsBuilder.lua
+++ b/Settings/FrameSettingsBuilder.lua
@@ -23,6 +23,7 @@ local GROUP_TYPES = {
 	raid         = true,
 	battleground = true,
 	worldraid    = true,
+	pinned       = true,
 }
 
 -- Unit types whose health bar uses oUF's full UpdateColor chain.
@@ -95,7 +96,7 @@ end
 -- ============================================================
 
 local SOLO_TYPES = { player = true, target = true, targettarget = true, focus = true, pet = true }
-local GROUP_COUNTS = { party = 5, arena = 3, boss = 4 }
+local GROUP_COUNTS = { party = 5, arena = 3, boss = 4, pinned = 9 }
 
 function F.FrameSettingsBuilder.ComputePinnedSplit(totalW, gap, unitType, previewPad)
 	local config = F.Config:Get('presets.' .. (F.Settings.GetEditingPreset() or 'Solo') .. '.unitConfigs.' .. unitType)
@@ -184,7 +185,7 @@ end
 local SUMMARY_ROW_H = 16
 local ICON_SIZE = 12
 
-local GROUP_ICON_TYPES = { party = true, raid = true, arena = true }
+local GROUP_ICON_TYPES = { party = true, raid = true, arena = true, pinned = true }
 
 -- Icon-row definitions mirror Settings/Cards/StatusIcons.lua so the summary
 -- surfaces the same individual toggles (filtered per unit via IconRelevance).
@@ -872,6 +873,9 @@ function F.FrameSettingsBuilder.Create(parent, unitType)
 	grid:AddCard('markers', 'Markers', F.SettingsCards.Markers, { unitType, getConfig, makeCardSetConfig('markers'), relayout })
 	if(unitType == 'party') then
 		grid:AddCard('partyPets', 'Party Pets', F.SettingsCards.PartyPets, {})
+	end
+	if(unitType == 'pinned' and F.SettingsCards.Pinned) then
+		grid:AddCard('slotAssignments', 'Slot Assignments', F.SettingsCards.Pinned, {})
 	end
 
 	-- ── Persist pin state ─────────────────────────────────────

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -115,6 +115,11 @@ function Settings._getUnitTypeItems()
 	if(info and info.groupKey) then
 		items[#items + 1] = { text = info.groupLabel, value = info.groupKey }
 	end
+	-- Pinned appears as an additional group-tier unit type whenever the
+	-- active preset has an auras.pinned block (which Solo lacks).
+	if(presetName and F.Config and F.Config:Get('presets.' .. presetName .. '.auras.pinned')) then
+		items[#items + 1] = { text = 'Pinned Frames', value = 'pinned' }
+	end
 	return items
 end
 

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -601,6 +601,15 @@ F.EventBus:Register('EDITING_PRESET_CHANGED', function()
 	if(not Settings._mainFrame or not Settings._mainFrame:IsShown()) then return end
 	local activeId = Settings._activePanelId
 	if(not activeId) then return end
+	-- Redirect away from preset-specific panels that don't exist under the
+	-- new preset (pinned is absent in Solo). Rebuilding them would crash on
+	-- the first unitConfigs read.
+	if(activeId == 'pinned') then
+		local preset = Settings.GetEditingPreset()
+		if(not preset or not F.Config:Get('presets.' .. preset .. '.unitConfigs.pinned')) then
+			activeId = 'player'
+		end
+	end
 	if(Settings._panelRefresh[activeId]) then
 		Settings._panelRefresh[activeId]()
 	else

--- a/Settings/Panels/Pinned.lua
+++ b/Settings/Panels/Pinned.lua
@@ -1,0 +1,13 @@
+local addonName, Framed = ...
+local F = Framed
+
+F.Settings.RegisterPanel({
+	id       = 'pinned',
+	label    = 'Pinned',
+	section  = 'PRESET_SCOPED',
+	unitType = 'pinned',
+	order    = 65,
+	create   = function(parent)
+		return F.FrameSettingsBuilder.Create(parent, 'pinned')
+	end,
+})

--- a/Settings/Sidebar.lua
+++ b/Settings/Sidebar.lua
@@ -234,6 +234,14 @@ local function getGroupFrameLabel()
 	return info and info.groupLabel or nil
 end
 
+--- Pinned frames are per-preset. Solo omits `unitConfigs.pinned` entirely,
+--- so navigating to the Pinned panel under Solo would crash the HealthColor
+--- card on the first non-fallback read. Hide the button when absent.
+local function hasPinnedConfig()
+	local preset = Settings.GetEditingPreset()
+	return preset and F.Config and F.Config:Get('presets.' .. preset .. '.unitConfigs.pinned') ~= nil
+end
+
 -- ============================================================
 -- Sidebar Builder
 -- ============================================================
@@ -270,6 +278,7 @@ local function buildSidebarContent(sidebar, contentParent)
 
 	-- References for dynamic elements updated by EDITING_PRESET_CHANGED
 	local groupFrameBtn
+	local pinnedFrameBtn
 
 	-- Aura buttons that may be hidden when the Pet page is active
 	local hiddenAuraBtns = {}
@@ -402,6 +411,12 @@ local function buildSidebarContent(sidebar, contentParent)
 						else
 							btn:Hide()
 						end
+					end
+
+					-- Pinned frames button — per-preset (absent in Solo)
+					if(panel.id == 'pinned') then
+						pinnedFrameBtn = btn
+						if(hasPinnedConfig()) then btn:Show() else btn:Hide() end
 					end
 
 					-- Track aura panels that may be hidden per unit type
@@ -569,6 +584,7 @@ local function buildSidebarContent(sidebar, contentParent)
 
 	-- ── EDITING_PRESET_CHANGED listener ──────────────────────
 	F.EventBus:Register('EDITING_PRESET_CHANGED', function(presetName)
+		local changed = false
 		if(groupFrameBtn) then
 			local groupLabel = getGroupFrameLabel()
 			if(groupLabel) then
@@ -577,10 +593,21 @@ local function buildSidebarContent(sidebar, contentParent)
 			else
 				groupFrameBtn:Hide()
 			end
-			-- Recalc FRAMES container height since groupFrameBtn visibility changed
-			if(sidebar._framesContainer and sidebar._framesContainer._recalc) then
-				sidebar._framesContainer._recalc(true)
+			changed = true
+		end
+		if(pinnedFrameBtn) then
+			local shouldShow = hasPinnedConfig()
+			if(shouldShow and not pinnedFrameBtn:IsShown()) then
+				pinnedFrameBtn:Show()
+				changed = true
+			elseif(not shouldShow and pinnedFrameBtn:IsShown()) then
+				pinnedFrameBtn:Hide()
+				changed = true
 			end
+		end
+		-- Recalc FRAMES container height since button visibility changed
+		if(changed and sidebar._framesContainer and sidebar._framesContainer._recalc) then
+			sidebar._framesContainer._recalc(true)
 		end
 	end, 'Sidebar')
 

--- a/Units/LiveUpdate/FrameConfigHealth.lua
+++ b/Units/LiveUpdate/FrameConfigHealth.lua
@@ -209,20 +209,19 @@ F.EventBus:Register('CONFIG_CHANGED', function(path)
 	end
 
 	-- Damage absorb (shields) toggle
+	-- Don't nil h.DamageAbsorb — oUF only registers UNIT_ABSORB_AMOUNT_CHANGED
+	-- during Enable if DamageAbsorb is set, so nilling post-Enable breaks the
+	-- event wiring permanently. Setup always assigns it; toggle only shows/hides.
 	if(key == 'health.damageAbsorb') then
 		local config = F.StyleBuilder.GetConfig(unitType)
 		local enabled = config.health and config.health.damageAbsorb
 		ForEachFrame(unitType, function(frame)
 			local h = frame.Health
-			if(not h) then return end
+			if(not h or not h._damageAbsorbBar) then return end
 			if(enabled) then
-				if(h._damageAbsorbBar) then
-					h.DamageAbsorb = h._damageAbsorbBar
-					h._damageAbsorbBar:Show()
-				end
+				h._damageAbsorbBar:Show()
 			else
-				h.DamageAbsorb = nil
-				if(h._damageAbsorbBar) then h._damageAbsorbBar:Hide() end
+				h._damageAbsorbBar:Hide()
 			end
 			h:ForceUpdate()
 		end)

--- a/Units/LiveUpdate/FrameConfigLayout.lua
+++ b/Units/LiveUpdate/FrameConfigLayout.lua
@@ -249,6 +249,7 @@ F.EventBus:Register('CONFIG_CHANGED', function(path)
 
 	-- Frame position (x, y)
 	if(key == 'position.x' or key == 'position.y') then
+		if(unitType == 'pinned') then return end
 		if(suppressPositionUpdate) then return end
 		local config = F.StyleBuilder.GetConfig(unitType)
 		if(GROUP_TYPES[unitType]) then
@@ -270,6 +271,7 @@ F.EventBus:Register('CONFIG_CHANGED', function(path)
 
 	-- Dimensions — resize frame, health wrapper, power wrapper
 	if(key == 'width' or key == 'height') then
+		if(unitType == 'pinned') then return end
 		local config = F.StyleBuilder.GetConfig(unitType)
 		debouncedApply('dimensions.' .. unitType, function()
 			local powerHeight = config.power.height

--- a/Units/LiveUpdate/FrameConfigPinned.lua
+++ b/Units/LiveUpdate/FrameConfigPinned.lua
@@ -18,19 +18,25 @@ local function onConfigChanged(path)
 		end)
 	elseif(key == 'enabled' or key == 'count' or key == 'columns'
 	    or key == 'width' or key == 'height' or key == 'spacing') then
-		debouncedApply('pinned.layout', function()
-			F.Units.Pinned.Layout()
-			F.Units.Pinned.Resolve()
-		end)
+		-- Refresh = Hide → Layout → Resolve → Show atomic. Keeps the 9
+		-- frames invisible through the whole transition so the user
+		-- never sees them briefly render with their stale 'player' seed
+		-- state before Resolve clears the unit on unassigned slots.
+		debouncedApply('pinned.layout', F.Units.Pinned.Refresh)
 	elseif(key and key:match('^slots')) then
-		F.Units.Pinned.Resolve()
-		F.Units.Pinned.Layout()
+		-- Single-slot path: `slots.N` or `slots.N.<field>`. Only touch frame N
+		-- so the other eight don't re-anchor (which flashed their backdrops).
+		local slotIndex = tonumber(key:match('^slots%.(%d+)'))
+		if(slotIndex) then
+			F.Units.Pinned.ApplySlot(slotIndex)
+		else
+			F.Units.Pinned.Refresh()
+		end
 	end
 end
 F.EventBus:Register('CONFIG_CHANGED', onConfigChanged, 'FrameConfigPinned.CC')
 
 F.EventBus:Register('PRESET_CHANGED', function()
 	F.Units.Pinned.ApplyPosition()
-	F.Units.Pinned.Layout()
-	F.Units.Pinned.Resolve()
+	F.Units.Pinned.Refresh()
 end, 'FrameConfigPinned.PresetChanged')

--- a/Units/LiveUpdate/FrameConfigPinned.lua
+++ b/Units/LiveUpdate/FrameConfigPinned.lua
@@ -1,0 +1,51 @@
+local _, Framed = ...
+local F = Framed
+
+local Shared = F.LiveUpdate and F.LiveUpdate.FrameConfigShared
+if(not Shared) then return end
+
+local guardConfigChanged = Shared.guardConfigChanged
+local debouncedApply     = Shared.debouncedApply
+
+local MAX_SLOTS = 9
+
+local function onConfigChanged(path)
+	local unitType, key = guardConfigChanged(path)
+	if(unitType ~= 'pinned') then return end
+
+	if(key == 'position.x' or key == 'position.y' or key == 'position.anchor') then
+		debouncedApply('pinned.position', function()
+			F.Units.Pinned.ApplyPosition()
+			F.Units.Pinned.Layout()
+		end)
+	elseif(key == 'enabled' or key == 'count' or key == 'columns'
+	    or key == 'width' or key == 'height' or key == 'spacing') then
+		debouncedApply('pinned.layout', function()
+			F.Units.Pinned.Layout()
+			F.Units.Pinned.Resolve()
+		end)
+	elseif(key and key:match('^slots')) then
+		F.Units.Pinned.Resolve()
+		F.Units.Pinned.Layout()
+	else
+		debouncedApply('pinned.style', function()
+			local config = F.StyleBuilder.GetConfig('pinned')
+			local frames = F.Units.Pinned.frames
+			if(not config or not frames) then return end
+			for i = 1, MAX_SLOTS do
+				local f = frames[i]
+				if(f) then
+					F.StyleBuilder.Apply(f, f.unit, config, 'pinned')
+					if(f.UpdateAllElements) then f:UpdateAllElements('RefreshStyle') end
+				end
+			end
+		end)
+	end
+end
+F.EventBus:Register('CONFIG_CHANGED', onConfigChanged, 'FrameConfigPinned.CC')
+
+F.EventBus:Register('PRESET_CHANGED', function()
+	F.Units.Pinned.ApplyPosition()
+	F.Units.Pinned.Layout()
+	F.Units.Pinned.Resolve()
+end, 'FrameConfigPinned.PresetChanged')

--- a/Units/LiveUpdate/FrameConfigPinned.lua
+++ b/Units/LiveUpdate/FrameConfigPinned.lua
@@ -7,8 +7,6 @@ if(not Shared) then return end
 local guardConfigChanged = Shared.guardConfigChanged
 local debouncedApply     = Shared.debouncedApply
 
-local MAX_SLOTS = 9
-
 local function onConfigChanged(path)
 	local unitType, key = guardConfigChanged(path)
 	if(unitType ~= 'pinned') then return end
@@ -27,19 +25,6 @@ local function onConfigChanged(path)
 	elseif(key and key:match('^slots')) then
 		F.Units.Pinned.Resolve()
 		F.Units.Pinned.Layout()
-	else
-		debouncedApply('pinned.style', function()
-			local config = F.StyleBuilder.GetConfig('pinned')
-			local frames = F.Units.Pinned.frames
-			if(not config or not frames) then return end
-			for i = 1, MAX_SLOTS do
-				local f = frames[i]
-				if(f) then
-					F.StyleBuilder.Apply(f, f.unit, config, 'pinned')
-					if(f.UpdateAllElements) then f:UpdateAllElements('RefreshStyle') end
-				end
-			end
-		end)
 	end
 end
 F.EventBus:Register('CONFIG_CHANGED', onConfigChanged, 'FrameConfigPinned.CC')

--- a/Units/LiveUpdate/FrameConfigPreset.lua
+++ b/Units/LiveUpdate/FrameConfigPreset.lua
@@ -236,7 +236,9 @@ local function applyFullConfig(frame, config)
 			if(h._overDamageAbsorbIndicator) then h._overDamageAbsorbIndicator:Hide() end
 		end
 
-		h:ForceUpdate()
+		-- Pinned slots without an assigned unit have frame.unit = nil; the
+		-- element updaters read UnitHealth/UnitPower which error on nil.
+		if(frame.unit) then h:ForceUpdate() end
 	end
 
 	-- ── Power element ────────────────────────────────────────
@@ -274,7 +276,7 @@ local function applyFullConfig(frame, config)
 			p.text._anchorY = pc.textAnchorY
 		end
 
-		p:ForceUpdate()
+		if(frame.unit) then p:ForceUpdate() end
 	end
 
 	-- ── Name element ────────────────────────────────────────
@@ -343,7 +345,7 @@ local function applyFullConfig(frame, config)
 	-- and re-trigger Health so the centering code repositions Name.
 	if(frame.Health and frame.Health._attachedToName and frame.Name) then
 		frame.Health._lastAttachShift = nil
-		if(frame.Health.ForceUpdate) then
+		if(frame.unit and frame.Health.ForceUpdate) then
 			frame.Health:ForceUpdate()
 		end
 	end
@@ -394,7 +396,7 @@ local function applyFullConfig(frame, config)
 			frame:EnableElement('Portrait')
 		end
 		frame.Portrait:Show()
-		if(frame.Portrait.ForceUpdate) then frame.Portrait:ForceUpdate() end
+		if(frame.unit and frame.Portrait.ForceUpdate) then frame.Portrait:ForceUpdate() end
 	else
 		if(frame.Portrait) then
 			frame:DisableElement('Portrait')

--- a/Units/LiveUpdate/FrameConfigPreset.lua
+++ b/Units/LiveUpdate/FrameConfigPreset.lua
@@ -30,7 +30,8 @@ local function applyFullConfig(frame, config)
 
 	local unitType = frame._framedUnitType
 	-- ── Position (solo frames only) ──────────────────────────
-	if(not GROUP_TYPES[unitType]) then
+	-- Pinned frames position via Layout() grid, not per-frame SetPoint.
+	if(not GROUP_TYPES[unitType] and unitType ~= 'pinned') then
 		repositionFrame(frame, config)
 	end
 

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -189,6 +189,48 @@ function F.Units.Pinned.ApplyPosition()
 end
 
 -- ============================================================
+-- Empty-slot placeholders
+-- Non-secure overlay frames shown when a slot is unassigned.
+-- Safe in combat (non-secure, no SetAttribute).
+-- ============================================================
+
+local function createPlaceholder(parent, slotIndex)
+	local ph = CreateFrame('Button', nil, parent, 'BackdropTemplate')
+	ph:SetFrameStrata('MEDIUM')
+	ph:SetBackdrop({
+		bgFile   = [[Interface\BUTTONS\WHITE8x8]],
+		edgeFile = [[Interface\BUTTONS\WHITE8x8]],
+		edgeSize = 1,
+	})
+	ph:SetBackdropColor(0.08, 0.08, 0.08, 0.6)
+	ph:SetBackdropBorderColor(0.4, 0.4, 0.4, 0.7)
+
+	local plus = F.Widgets.CreateFontString(ph, 20, F.Constants.Colors.textSecondary)
+	plus:SetPoint('CENTER', ph, 'CENTER', 0, 4)
+	plus:SetText('+')
+
+	local hint = F.Widgets.CreateFontString(ph, F.Constants.Font.sizeSmall, F.Constants.Colors.textSecondary)
+	hint:SetPoint('BOTTOM', ph, 'BOTTOM', 0, 4)
+	hint:SetAlpha(0.7)
+	hint:SetText('Click to assign')
+
+	ph._slotIndex = slotIndex
+	ph:SetAlpha(0)  -- hidden until hover
+	ph:RegisterForClicks('LeftButtonUp')
+
+	ph:SetScript('OnEnter', function(self) self:SetAlpha(1) end)
+	ph:SetScript('OnLeave', function(self) self:SetAlpha(0) end)
+
+	ph:SetScript('OnClick', function(self)
+		if(F.Units.Pinned.OpenAssignmentMenu) then
+			F.Units.Pinned.OpenAssignmentMenu(self._slotIndex, self)
+		end
+	end)
+
+	return ph
+end
+
+-- ============================================================
 -- Layout (grid)
 -- ============================================================
 function F.Units.Pinned.Layout()
@@ -231,6 +273,25 @@ function F.Units.Pinned.Layout()
 	F.Widgets.SetSize(anchor,
 		columns * width + (columns - 1) * spacing,
 		rows    * height + (rows    - 1) * spacing)
+
+	-- Manage placeholders for active but unassigned slots
+	F.Units.Pinned.placeholders = F.Units.Pinned.placeholders or {}
+	local phs = F.Units.Pinned.placeholders
+	local slots = config.slots or {}
+
+	for i = 1, MAX_SLOTS do
+		if(i <= count and not slots[i]) then
+			phs[i] = phs[i] or createPlaceholder(anchor, i)
+			local f = frames[i]
+			phs[i]:ClearAllPoints()
+			phs[i]:SetAllPoints(f)
+			F.Widgets.SetSize(phs[i], width, height)
+			phs[i]:Show()
+		elseif(phs[i]) then
+			phs[i]:Hide()
+		end
+	end
+
 	updatePolling()
 end
 
@@ -303,6 +364,13 @@ function F.Units.Pinned.Spawn()
 
 	F.Units.Pinned.Layout()
 	F.Units.Pinned.Resolve()
+end
+
+--- Placeholder: real implementation lives in Settings/Cards/Pinned.lua
+--- and attaches via F.Units.Pinned.OpenAssignmentMenu = ... on card load.
+--- When invoked before the card is loaded, print a hint.
+function F.Units.Pinned.OpenAssignmentMenu(slotIndex, anchorFrame)
+	print('|cff00ccffFramed|r Pinned: open /framed → Pinned to assign slot ' .. slotIndex)
 end
 
 -- ============================================================

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -145,9 +145,7 @@ F.Units.Pinned.UpdatePolling = updatePolling
 -- Config accessor
 -- ============================================================
 function F.Units.Pinned.GetConfig()
-	local presetName = F.PresetManager and F.PresetManager.GetActive()
-	if(not presetName) then return nil end
-	return F.Config:Get('presets.' .. presetName .. '.unitConfigs.pinned')
+	return F.StyleBuilder.GetConfig('pinned')
 end
 
 -- ============================================================

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -173,6 +173,45 @@ local function Style(self, unit)
 		self.SlotIdentity = fs
 	end
 
+	if(not self.ReassignGear) then
+		local gear = CreateFrame('Button', nil, self)
+		gear:SetSize(14, 14)
+		gear:SetPoint('TOPRIGHT', self, 'TOPRIGHT', -2, -2)
+		gear:SetFrameLevel(self:GetFrameLevel() + 5)
+
+		local icon = gear:CreateTexture(nil, 'OVERLAY')
+		icon:SetAllPoints(gear)
+		icon:SetTexture(F.Media.GetIcon('Settings'))
+		gear._icon = icon
+
+		gear:SetAlpha(0)
+		gear:RegisterForClicks('LeftButtonUp')
+
+		-- Hide gear during combat
+		self:HookScript('OnEnter', function(frame)
+			if(InCombatLockdown()) then return end
+			if(frame._pinnedSlotIndex) then
+				gear:SetAlpha(0.8)
+			end
+		end)
+		self:HookScript('OnLeave', function()
+			gear:SetAlpha(0)
+		end)
+		gear:SetScript('OnEnter', function(self) self:SetAlpha(1) end)
+		gear:SetScript('OnLeave', function(self)
+			if(self:GetParent():IsMouseOver()) then self:SetAlpha(0.8) else self:SetAlpha(0) end
+		end)
+
+		gear:SetScript('OnClick', function(g)
+			local parent = g:GetParent()
+			if(parent._pinnedSlotIndex and F.Units.Pinned.OpenAssignmentMenu) then
+				F.Units.Pinned.OpenAssignmentMenu(parent._pinnedSlotIndex, parent)
+			end
+		end)
+
+		self.ReassignGear = gear
+	end
+
 	F.Widgets.RegisterForUIScale(self)
 end
 
@@ -337,6 +376,13 @@ function F.Units.Pinned.Resolve()
 					frame.SlotIdentity:Hide()
 				end
 			end
+			if(frame.ReassignGear) then
+				if(slot) then
+					-- Gear visible-on-hover; don't force show here
+				else
+					frame.ReassignGear:SetAlpha(0)
+				end
+			end
 		end
 	end
 	updatePolling()
@@ -359,6 +405,7 @@ function F.Units.Pinned.Spawn()
 		local frame = oUF:Spawn('player', 'FramedPinnedFrame' .. i)
 		frame:SetParent(anchor)
 		frames[i] = frame
+		frame._pinnedSlotIndex = i
 	end
 	F.Units.Pinned.frames = frames
 

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -212,8 +212,15 @@ local function normalizeSlotKeys(slots)
 	end
 end
 
+-- Read pinned config directly from the current preset (no cross-preset
+-- fallback). StyleBuilder.GetConfig('pinned') falls back to any base group
+-- preset so Style() can wire Health/Name elements at cold start under Solo —
+-- but that fallback would leak another preset's enabled/slots into Refresh
+-- and show pinned anchors on presets that don't have pinned configured.
 function F.Units.Pinned.GetConfig()
-	local config = F.StyleBuilder.GetConfig('pinned')
+	local presetName = F.AutoSwitch.GetCurrentPreset()
+	local _, presetData = F.AutoSwitch.ResolvePreset(presetName)
+	local config = presetData and presetData.unitConfigs and presetData.unitConfigs.pinned
 	if(config and config.slots) then
 		normalizeSlotKeys(config.slots)
 	end

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -1,0 +1,116 @@
+local _, Framed = ...
+local F = Framed
+local oUF = F.oUF
+
+F.Units        = F.Units        or {}
+F.Units.Pinned = F.Units.Pinned or {}
+
+local MAX_SLOTS = 9
+
+-- ============================================================
+-- Config accessor
+-- ============================================================
+function F.Units.Pinned.GetConfig()
+	local presetName = F.PresetManager and F.PresetManager.GetActive()
+	if(not presetName) then return nil end
+	return F.Config:Get('presets.' .. presetName .. '.unitConfigs.pinned')
+end
+
+-- ============================================================
+-- Style
+-- ============================================================
+local function Style(self, unit)
+	self:SetFrameStrata('LOW')
+	self:RegisterForClicks('AnyUp')
+	self._framedUnitType = 'pinned'
+
+	local config = F.Units.Pinned.GetConfig()
+	if(config) then
+		F.Widgets.SetSize(self, config.width or 160, config.height or 40)
+		F.StyleBuilder.Apply(self, config, 'pinned')
+	else
+		F.Widgets.SetSize(self, 160, 40)
+	end
+
+	F.Widgets.RegisterForUIScale(self)
+end
+
+-- ============================================================
+-- Position
+-- ============================================================
+function F.Units.Pinned.ApplyPosition()
+	local anchor = F.Units.Pinned.anchor
+	if(not anchor) then return end
+	local config = F.Units.Pinned.GetConfig()
+	local pos = (config and config.position) or { x = 0, y = 0, anchor = 'CENTER' }
+	anchor:ClearAllPoints()
+	anchor:SetPoint(pos.anchor or 'CENTER', UIParent, pos.anchor or 'CENTER', pos.x or 0, pos.y or 0)
+end
+
+-- ============================================================
+-- Layout (grid)
+-- ============================================================
+function F.Units.Pinned.Layout()
+	local anchor = F.Units.Pinned.anchor
+	local frames = F.Units.Pinned.frames
+	if(not anchor or not frames) then return end
+
+	local config = F.Units.Pinned.GetConfig()
+	if(not config or not config.enabled) then
+		anchor:Hide()
+		return
+	end
+	anchor:Show()
+
+	local count   = math.max(1, math.min(config.count   or 3, MAX_SLOTS))
+	local columns = math.max(1, math.min(config.columns or 3, count))
+	local width   = config.width   or 160
+	local height  = config.height  or 40
+	local spacing = config.spacing or 2
+
+	for i = 1, MAX_SLOTS do
+		local f = frames[i]
+		if(f) then
+			if(i <= count) then
+				local row = math.ceil(i / columns) - 1
+				local col = ((i - 1) % columns)
+				f:ClearAllPoints()
+				f:SetPoint('TOPLEFT', anchor, 'TOPLEFT',
+					col * (width + spacing),
+					-(row * (height + spacing)))
+				F.Widgets.SetSize(f, width, height)
+				f:Show()
+			else
+				f:Hide()
+			end
+		end
+	end
+
+	local rows = math.ceil(count / columns)
+	F.Widgets.SetSize(anchor,
+		columns * width + (columns - 1) * spacing,
+		rows    * height + (rows    - 1) * spacing)
+end
+
+-- ============================================================
+-- Spawn
+-- ============================================================
+function F.Units.Pinned.Spawn()
+	oUF:RegisterStyle('FramedPinned', Style)
+	oUF:SetActiveStyle('FramedPinned')
+
+	local anchor = CreateFrame('Frame', 'FramedPinnedAnchor', UIParent)
+	F.Widgets.SetSize(anchor, 1, 1)
+	F.Units.Pinned.anchor = anchor
+	F.Units.Pinned.ApplyPosition()
+
+	local frames = {}
+	for i = 1, MAX_SLOTS do
+		local frame = oUF:Spawn('player', 'FramedPinnedFrame' .. i)
+		frame:SetParent(anchor)
+		frames[i] = frame
+	end
+	F.Units.Pinned.frames = frames
+
+	F.Units.Pinned.Layout()
+end

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -152,8 +152,11 @@ end
 -- Style
 -- ============================================================
 local function Style(self, unit)
+	-- LOW so empty-slot placeholders (MEDIUM) render above and catch hover.
 	self:SetFrameStrata('LOW')
 	self:RegisterForClicks('AnyUp')
+	-- Also set by StyleBuilder.Apply, but Apply is gated on config being
+	-- non-nil — cold start under a preset without pinned leaves the tag unset.
 	self._framedUnitType = 'pinned'
 
 	local config = F.StyleBuilder.GetConfig('pinned')
@@ -416,11 +419,12 @@ function F.Units.Pinned.Spawn()
 	F.Units.Pinned.Resolve()
 end
 
---- Placeholder: real implementation lives in Settings/Cards/Pinned.lua
---- and attaches via F.Units.Pinned.OpenAssignmentMenu = ... on card load.
---- When invoked before the card is loaded, print a hint.
-function F.Units.Pinned.OpenAssignmentMenu(slotIndex, anchorFrame)
-	print('|cff00ccffFramed|r Pinned: open /framed → Pinned to assign slot ' .. slotIndex)
+--- Fallback: the real implementation lives in Settings/Cards/Pinned.lua and
+--- overwrites this at load time. This body only runs if that file failed to
+--- load — in which case the Settings UI is also unreachable, so don't direct
+--- the user there.
+function F.Units.Pinned.OpenAssignmentMenu(slotIndex)
+	print('|cff00ccffFramed|r Pinned panel is unavailable (slot ' .. slotIndex .. ').')
 end
 
 -- ============================================================

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -24,10 +24,10 @@ local function Style(self, unit)
 	self:RegisterForClicks('AnyUp')
 	self._framedUnitType = 'pinned'
 
-	local config = F.Units.Pinned.GetConfig()
+	local config = F.StyleBuilder.GetConfig('pinned')
 	if(config) then
 		F.Widgets.SetSize(self, config.width or 160, config.height or 40)
-		F.StyleBuilder.Apply(self, config, 'pinned')
+		F.StyleBuilder.Apply(self, unit, config, 'pinned')
 	else
 		F.Widgets.SetSize(self, 160, 40)
 	end

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -861,11 +861,165 @@ function F.Units.Pinned.OpenAssignmentMenu(slotIndex)
 end
 
 -- ============================================================
+-- Group fingerprint & clear-on-leave
+--
+-- Pinned slots scope to "this group, right now" — wipe them across
+-- all presets when the user leaves/disbands. Persist across pulls
+-- (nothing clears while in-group) and across DC/relog if the current
+-- group shares at least one member with the stored fingerprint.
+-- ============================================================
+
+-- Fingerprint by character name, not GUID. When a party member is in a
+-- vehicle (mount, skyriding dragon, combat vehicle), UnitGUID(token)
+-- returns the vehicle GUID — which has a spawn-instance suffix that
+-- changes every session. UnitName(token) resolves through the vehicle
+-- to the player's actual name, matching how Pinned stores slot identity
+-- (findUnitForName / fullUnitName) and staying stable across relog.
+local function collectGroupNames()
+	local names = {}
+	local inGroup = false
+	-- rosterReady = "unit tokens actually resolve right now." At login and
+	-- on some zone transitions, IsInRaid()/IsInGroup() return true before
+	-- the client has populated raidN/partyN data. Reconciling against
+	-- that empty roster looks like "totally different group" and nukes
+	-- the pins. Caller must bail when inGroup && !rosterReady.
+	local rosterReady = true
+	if(IsInRaid()) then
+		inGroup = true
+		local count = GetNumGroupMembers()
+		if(count <= 0) then rosterReady = false end
+		for i = 1, count do
+			local name = fullUnitName('raid' .. i)
+			if(name) then
+				names[name] = true
+			else
+				rosterReady = false
+			end
+		end
+	elseif(IsInGroup()) then
+		inGroup = true
+		local count = GetNumGroupMembers() - 1
+		if(count < 0) then count = 0 end
+		-- party1..partyN are the *other* members; the player themselves
+		-- is 'player' in party groups. We deliberately don't include the
+		-- player's own name in the fingerprint because it never changes
+		-- and would force overlap=true on every comparison, defeating
+		-- the "different group entirely" detection path.
+		for i = 1, count do
+			local name = fullUnitName('party' .. i)
+			if(name) then
+				names[name] = true
+			else
+				rosterReady = false
+			end
+		end
+		if(count == 0) then
+			-- Solo-invite one-player "party" — IsInGroup is momentarily true
+			-- while WoW processes the invite. Treat as not-yet-ready so we
+			-- don't overwrite the stored fingerprint with nothing.
+			rosterReady = false
+		end
+	end
+	return names, inGroup, rosterReady
+end
+
+local function nameOverlap(a, b)
+	if(not a or not b) then return false end
+	for name in next, a do
+		if(b[name]) then return true end
+	end
+	return false
+end
+
+local function clearAllPinnedSlots()
+	local presets = F.Config and F.Config:Get('presets')
+	if(not presets) then return end
+	local didClear = false
+	for presetName, preset in next, presets do
+		local pinned = preset.unitConfigs and preset.unitConfigs.pinned
+		if(pinned and pinned.slots and next(pinned.slots)) then
+			pinned.slots = {}
+			didClear = true
+			if(F.PresetManager and F.PresetManager.MarkCustomized) then
+				F.PresetManager.MarkCustomized(presetName)
+			end
+		end
+	end
+	if(didClear and F.Units.Pinned.Refresh) then
+		F.Units.Pinned.Refresh()
+	end
+end
+
+local function reconcileGroupMembership()
+	if(not FramedCharDB) then return end
+	FramedCharDB.pinnedGroup = FramedCharDB.pinnedGroup or { names = {}, inGroup = false }
+	local stored = FramedCharDB.pinnedGroup
+	-- Migrate legacy GUID-based fingerprints. Vehicle/NPC GUIDs include
+	-- session-scoped spawn suffixes, so the old fingerprint could never
+	-- overlap across relog — drop it AND the inGroup flag, so the next
+	-- reconcile seeds a fresh names fingerprint instead of comparing
+	-- zero stored names against a full current roster and falsely
+	-- clearing under "no name overlap".
+	if(stored.guids) then
+		stored.guids   = nil
+		stored.names   = {}
+		stored.inGroup = false
+	end
+	stored.names = stored.names or {}
+
+	local currentNames, currentInGroup, rosterReady = collectGroupNames()
+
+	-- Roster data hasn't arrived from the server yet (common on the first
+	-- GROUP_ROSTER_UPDATE after login). Bail — another GRU will fire once
+	-- member names resolve, and we'll reconcile then. Importantly don't
+	-- update stored.names here: a partial roster would masquerade as "a
+	-- different group" on the next tick and trigger a false clear.
+	if(currentInGroup and not rosterReady) then
+		return
+	end
+
+	local shouldClear = false
+
+	-- In-group → not-in-group: user left, got kicked, or group disbanded.
+	-- Covers both live transitions and the "logged out in group, logged
+	-- back in solo" case (fingerprint says was-grouped, current says not).
+	if(stored.inGroup and not currentInGroup) then
+		shouldClear = true
+	-- Both sides grouped but zero member overlap: a different group
+	-- entirely. Rare mid-session; on relog means the old group disbanded
+	-- and the user joined a brand-new one before the addon ran.
+	elseif(stored.inGroup and currentInGroup and not nameOverlap(stored.names, currentNames)) then
+		shouldClear = true
+	end
+
+	if(shouldClear) then
+		clearAllPinnedSlots()
+	end
+
+	stored.names   = currentNames
+	stored.inGroup = currentInGroup
+end
+
+-- ============================================================
 -- Event registration
 -- ============================================================
 F.EventBus:Register('GROUP_ROSTER_UPDATE', function()
+	reconcileGroupMembership()
 	F.Units.Pinned.Resolve()
 end, 'Pinned.Resolve')
+
+-- We deliberately do NOT hook PLAYER_ENTERING_WORLD. At login, IsInGroup()
+-- can briefly return false before the client has finished syncing group
+-- state with the server — reconciling against that lie would see
+-- "stored.inGroup=true but currentInGroup=false" and wrongly clear pins
+-- seconds before GROUP_ROSTER_UPDATE arrives with the truth. GRU is the
+-- only event that fires when the client actually knows group state.
+--
+-- Edge case: user logs out in a group, the group disbands during logout,
+-- user logs back in solo. GRU may not fire (nothing to report). Stored
+-- state stays stale but pins aren't visible on solo presets anyway; the
+-- next time they join any group, GRU fires and the overlap check clears
+-- correctly. Eventual consistency beats aggressive clearing at login.
 
 local function refreshAllPlaceholders()
 	for i = 1, MAX_SLOTS do

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -283,6 +283,16 @@ local function Style(self, unit)
 	end
 
 	F.Widgets.RegisterForUIScale(self)
+
+	-- RegisterForUIScale just applied SetScale(desiredScale / uiParentScale)
+	-- to self. The gear is parented to self and inherits that scale-up, which
+	-- makes it render noticeably larger than placeholder gears (parented to
+	-- the unscaled anchor). Counter-scale the gear to cancel out self's scale
+	-- so both live and placeholder gears render at the same physical size.
+	local selfScale = self:GetScale() or 1
+	if(self.ReassignGear and selfScale > 0) then
+		self.ReassignGear:SetScale(1 / selfScale)
+	end
 end
 
 -- ============================================================

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -50,19 +50,56 @@ local function findUnitForName(storedName)
 end
 F.Units.Pinned.FindUnitForName = findUnitForName
 
+-- Indicators that resolve self.unit directly inside event paths that don't
+-- filter by arg-unit (GROUP_ROSTER_UPDATE / PLAYER_ROLES_ASSIGNED). On an
+-- unassigned pinned frame self.unit is nil and UnitIsGroupLeader(nil) etc.
+-- raise argument errors, aborting the event mid-flight and starving
+-- downstream listeners (Pinned.Resolve, role/color updates) of their run.
+-- We toggle them off on unassign and back on when a unit returns.
+local NIL_UNSAFE_INDICATORS = {
+	'LeaderIndicator',
+	'AssistantIndicator',
+	'GroupRoleIndicator',
+	'RaidRoleIndicator',
+}
+
+local function disableNilUnsafeIndicators(frame)
+	for _, name in next, NIL_UNSAFE_INDICATORS do
+		if(frame[name] and frame.IsElementEnabled and frame:IsElementEnabled(name)) then
+			frame:DisableElement(name)
+			frame[name]:Hide()
+		end
+	end
+end
+
+local function enableNilUnsafeIndicators(frame)
+	for _, name in next, NIL_UNSAFE_INDICATORS do
+		if(frame[name] and frame.IsElementEnabled and not frame:IsElementEnabled(name)) then
+			frame:EnableElement(name)
+		end
+	end
+end
+
 --- Swap a frame's unit. Updates secure attribute + frame.unit mirror.
 --- Combat-safe: returns false if InCombatLockdown prevents SetAttribute.
 local function setFrameUnit(frame, token)
 	if(InCombatLockdown()) then return false end
+	if(frame.unit == token) then return true end
 	if(token) then
 		frame:SetAttribute('unit', token)
 		frame.unit = token
+		enableNilUnsafeIndicators(frame)
+		if(frame.UpdateAllElements) then
+			frame:UpdateAllElements('RefreshUnit')
+		end
 	else
+		disableNilUnsafeIndicators(frame)
 		frame:SetAttribute('unit', nil)
 		frame.unit = nil
-	end
-	if(frame.UpdateAllElements) then
-		frame:UpdateAllElements('RefreshUnit')
+		-- Skip UpdateAllElements on unassign: oUF elements read UnitPower /
+		-- UnitHealth / etc., which error on a nil unit. The placeholder covers
+		-- the frame visually, so leaving elements with their previous state is
+		-- invisible to the user.
 	end
 	return true
 end
@@ -111,10 +148,25 @@ local function onPollUpdate(_, elapsed)
 		local frame = frames[i]
 		if(slotNeedsPolling(slot) and frame and frame.unit) then
 			local newGUID = UnitGUID(frame.unit)
-			if(newGUID ~= lastGUIDs[i]) then
-				lastGUIDs[i] = newGUID
+			-- UnitGUID on a compound unit (e.g. 'party2target') can return
+			-- a secret-tainted string in combat. Comparing would taint Lua.
+			-- When we can't safely diff, refresh unconditionally — the poll
+			-- is already rate-limited to 200ms so this is cheap.
+			local changed
+			if(F.IsValueNonSecret(newGUID)) then
+				changed = newGUID ~= lastGUIDs[i]
+				if(changed) then lastGUIDs[i] = newGUID end
+			else
+				changed = true
+				lastGUIDs[i] = nil
+			end
+			if(changed) then
 				if(frame.UpdateAllElements) then
 					frame:UpdateAllElements('RefreshUnit')
+				end
+				-- Target went to/from existence — placeholder needs to flip.
+				if(F.Units.Pinned.RefreshPlaceholder) then
+					F.Units.Pinned.RefreshPlaceholder(i)
 				end
 			end
 		else
@@ -144,8 +196,28 @@ F.Units.Pinned.UpdatePolling = updatePolling
 -- ============================================================
 -- Config accessor
 -- ============================================================
+
+-- Legacy Config:Set writes stored slot entries under string keys (slots['1']);
+-- every reader here uses numeric indices, so normalize once per read.
+local function normalizeSlotKeys(slots)
+	if(type(slots) ~= 'table') then return end
+	for k, v in next, slots do
+		if(type(k) == 'string') then
+			local n = tonumber(k)
+			if(n and slots[n] == nil) then
+				slots[n] = v
+			end
+			slots[k] = nil
+		end
+	end
+end
+
 function F.Units.Pinned.GetConfig()
-	return F.StyleBuilder.GetConfig('pinned')
+	local config = F.StyleBuilder.GetConfig('pinned')
+	if(config and config.slots) then
+		normalizeSlotKeys(config.slots)
+	end
+	return config
 end
 
 -- ============================================================
@@ -169,7 +241,13 @@ local function Style(self, unit)
 
 	if(not self.SlotIdentity) then
 		local fs = F.Widgets.CreateFontString(self, F.Constants.Font.sizeSmall, F.Constants.Colors.textSecondary)
-		fs:SetPoint('BOTTOM', self, 'TOP', 0, 2)
+		-- Two horizontal anchors bound width to the frame so long labels
+		-- (e.g. "Some Long Name's Target") truncate with an ellipsis instead
+		-- of overflowing past the frame edges.
+		fs:SetPoint('BOTTOMLEFT',  self, 'TOPLEFT',  0, 2)
+		fs:SetPoint('BOTTOMRIGHT', self, 'TOPRIGHT', 0, 2)
+		fs:SetWordWrap(false)
+		fs:SetJustifyH('CENTER')
 		fs:SetAlpha(0.7)
 		self.SlotIdentity = fs
 	end
@@ -185,34 +263,17 @@ local function Style(self, unit)
 		icon:SetTexture(F.Media.GetIcon('Settings'))
 		gear._icon = icon
 
-		gear:SetAlpha(0)
-		gear:EnableMouse(false)
+		-- Hover visibility is driven by a centralized IsMouseOver() poll
+		-- (see anchor OnUpdate in Spawn). HookScript('OnEnter'/'OnLeave')
+		-- fires unreliably on pinned frames because aura/overlay children
+		-- swallow mouse motion, so we don't register for those here.
+		gear:Hide()
+		gear:EnableMouse(true)
 		gear:RegisterForClicks('LeftButtonUp')
-
-		-- Hide gear during combat
-		self:HookScript('OnEnter', function(frame)
-			if(InCombatLockdown()) then return end
-			if(frame._pinnedSlotIndex) then
-				gear:EnableMouse(true)
-				gear:SetAlpha(0.8)
-			end
-		end)
-		self:HookScript('OnLeave', function()
-			gear:SetAlpha(0)
-			gear:EnableMouse(false)
-		end)
-		gear:SetScript('OnEnter', function(self) self:SetAlpha(1) end)
-		gear:SetScript('OnLeave', function(self)
-			if(self:GetParent():IsMouseOver()) then
-				self:SetAlpha(0.8)
-			else
-				self:SetAlpha(0)
-				self:EnableMouse(false)
-			end
-		end)
 
 		gear:SetScript('OnClick', function(g)
 			local parent = g:GetParent()
+			if(InCombatLockdown()) then return end
 			if(parent._pinnedSlotIndex and F.Units.Pinned.OpenAssignmentMenu) then
 				F.Units.Pinned.OpenAssignmentMenu(parent._pinnedSlotIndex, parent)
 			end
@@ -243,33 +304,112 @@ end
 -- ============================================================
 
 local function createPlaceholder(parent, slotIndex)
-	local ph = CreateFrame('Button', nil, parent, 'BackdropTemplate')
+	-- Manual textures via SetColorTexture instead of SetBackdrop + WHITE8x8.
+	-- SetBackdrop's bgFile triggers a texture load whose first-paint can
+	-- land before SetBackdropColor's tint applies, producing a white flash
+	-- on all 9 slots when pinned is first enabled. SetColorTexture creates
+	-- a GPU-synthesized solid color with no texture load — correct from
+	-- frame 1.
+	local ph = CreateFrame('Button', nil, parent)
+	ph:Hide()
 	ph:SetFrameStrata('MEDIUM')
-	ph:SetBackdrop({
-		bgFile   = [[Interface\BUTTONS\WHITE8x8]],
-		edgeFile = [[Interface\BUTTONS\WHITE8x8]],
-		edgeSize = 1,
-	})
-	ph:SetBackdropColor(0.08, 0.08, 0.08, 0.6)
-	ph:SetBackdropBorderColor(0.4, 0.4, 0.4, 0.7)
+
+	local bg = ph:CreateTexture(nil, 'BACKGROUND')
+	bg:SetAllPoints(ph)
+	bg:SetColorTexture(0.08, 0.08, 0.08, 0.6)
+
+	-- 1px border via four solid-color textures
+	local br, bgCol, bb, ba = 0.4, 0.4, 0.4, 0.7
+	local top = ph:CreateTexture(nil, 'BORDER')
+	top:SetColorTexture(br, bgCol, bb, ba)
+	top:SetPoint('TOPLEFT',  ph, 'TOPLEFT',  0, 0)
+	top:SetPoint('TOPRIGHT', ph, 'TOPRIGHT', 0, 0)
+	top:SetHeight(1)
+	local bottom = ph:CreateTexture(nil, 'BORDER')
+	bottom:SetColorTexture(br, bgCol, bb, ba)
+	bottom:SetPoint('BOTTOMLEFT',  ph, 'BOTTOMLEFT',  0, 0)
+	bottom:SetPoint('BOTTOMRIGHT', ph, 'BOTTOMRIGHT', 0, 0)
+	bottom:SetHeight(1)
+	local left = ph:CreateTexture(nil, 'BORDER')
+	left:SetColorTexture(br, bgCol, bb, ba)
+	left:SetPoint('TOPLEFT',    ph, 'TOPLEFT',    0, 0)
+	left:SetPoint('BOTTOMLEFT', ph, 'BOTTOMLEFT', 0, 0)
+	left:SetWidth(1)
+	local right = ph:CreateTexture(nil, 'BORDER')
+	right:SetColorTexture(br, bgCol, bb, ba)
+	right:SetPoint('TOPRIGHT',    ph, 'TOPRIGHT',    0, 0)
+	right:SetPoint('BOTTOMRIGHT', ph, 'BOTTOMRIGHT', 0, 0)
+	right:SetWidth(1)
 
 	local plus = F.Widgets.CreateFontString(ph, 20, F.Constants.Colors.textSecondary)
 	plus:SetPoint('CENTER', ph, 'CENTER', 0, 4)
 	plus:SetText('+')
+
+	local identity = F.Widgets.CreateFontString(ph, F.Constants.Font.sizeNormal, F.Constants.Colors.textPrimary)
+	-- Bound to placeholder width so long identity strings ("Some Long
+	-- Name's Target") truncate with an ellipsis instead of spilling past
+	-- the placeholder edges.
+	identity:SetPoint('LEFT',  ph, 'LEFT',   2, 4)
+	identity:SetPoint('RIGHT', ph, 'RIGHT', -2, 4)
+	identity:SetWordWrap(false)
+	identity:SetJustifyH('CENTER')
+	identity:Hide()
 
 	local hint = F.Widgets.CreateFontString(ph, F.Constants.Font.sizeSmall, F.Constants.Colors.textSecondary)
 	hint:SetPoint('BOTTOM', ph, 'BOTTOM', 0, 4)
 	hint:SetAlpha(0.7)
 	hint:SetText('Click to assign')
 
+	-- Gear icon for 'empty' mode: mirrors ReassignGear on live frames so
+	-- assigned-but-unresolved target-type slots expose the same gear-on-hover
+	-- config entry point as character slots, rather than a different
+	-- click-anywhere affordance.
+	local gear = CreateFrame('Button', nil, ph)
+	gear:SetSize(14, 14)
+	gear:SetPoint('TOPRIGHT', ph, 'TOPRIGHT', -2, -2)
+	gear:SetFrameLevel(ph:GetFrameLevel() + 5)
+
+	local gearIcon = gear:CreateTexture(nil, 'OVERLAY')
+	gearIcon:SetAllPoints(gear)
+	gearIcon:SetTexture(F.Media.GetIcon('Settings'))
+
+	-- Hover/alpha is driven by updatePlaceholderGearHover (anchor OnUpdate poll).
+	-- No SetScript for OnEnter/OnLeave — let the poll own state.
+	gear:Hide()
+	gear:EnableMouse(true)
+	gear:RegisterForClicks('LeftButtonUp')
+	gear:SetScript('OnClick', function(g)
+		if(InCombatLockdown()) then return end
+		if(F.Units.Pinned.OpenAssignmentMenu) then
+			F.Units.Pinned.OpenAssignmentMenu(g:GetParent()._slotIndex, g:GetParent())
+		end
+	end)
+
+	ph._plusText     = plus
+	ph._identityText = identity
+	ph._hintText     = hint
+	ph._gear         = gear
 	ph._slotIndex = slotIndex
-	ph:SetAlpha(0)  -- hidden until hover
+	-- Slot 1 is the user's "you are here" anchor — always visible at a dim
+	-- alpha so the pinned region is findable even when nothing is assigned.
+	-- Remaining slots stay hover-only to avoid visual clutter.
+	local restingAlpha = (slotIndex == 1) and 0.5 or 0
+	ph._restingAlpha = restingAlpha
+	ph:SetAlpha(restingAlpha)
 	ph:RegisterForClicks('LeftButtonUp')
 
-	ph:SetScript('OnEnter', function(self) self:SetAlpha(1) end)
-	ph:SetScript('OnLeave', function(self) self:SetAlpha(0) end)
+	-- Alpha + gear visibility are owned by updatePlaceholderGearHover; see
+	-- the anchor OnUpdate poll in F.Units.Pinned.Spawn. OnEnter/OnLeave were
+	-- removed because child mouse events (aura overlays on the sibling live
+	-- frame) would sometimes leave OnLeave unfired.
 
+	-- 'unassigned' mode uses whole-frame click (no other affordance exists for
+	-- an unselected slot). 'empty' mode defers to the gear icon so it matches
+	-- the live-frame gear-on-hover pattern. The branch lives in OnClick rather
+	-- than swap-in/out scripts because setPlaceholderMode runs frequently and
+	-- re-binding scripts would add churn.
 	ph:SetScript('OnClick', function(self)
+		if(self._mode == 'empty') then return end
 		if(F.Units.Pinned.OpenAssignmentMenu) then
 			F.Units.Pinned.OpenAssignmentMenu(self._slotIndex, self)
 		end
@@ -278,10 +418,53 @@ local function createPlaceholder(parent, slotIndex)
 	return ph
 end
 
+-- Placeholder modes:
+--   'unassigned' — slot has no selection. Shows "+" + "Click to assign".
+--   'empty'      — slot is assigned (e.g. "X's Target") but the underlying
+--                  unit doesn't exist right now, so the secure oUF frame is
+--                  hidden. The placeholder steps in so the user always has a
+--                  hoverable, clickable target for reassigning or unassigning.
+local function setPlaceholderMode(ph, mode, identityText)
+	local sameMode = (ph._mode == mode)
+	-- Idempotency: if mode+text are unchanged, don't touch anything.
+	-- RefreshPlaceholder is called from the 0.2s target-GUID poll and
+	-- re-setting alpha/visibility here would fight the hover poll,
+	-- causing a flash every 200ms.
+	if(sameMode and (mode ~= 'empty' or ph._identityText:GetText() == (identityText or ''))) then
+		return
+	end
+
+	ph._mode = mode
+	if(mode == 'empty') then
+		ph._plusText:Hide()
+		ph._identityText:SetText(identityText or '')
+		ph._identityText:Show()
+		ph._hintText:Hide()
+		ph._restingAlpha = 0.5
+	else
+		ph._plusText:Show()
+		ph._identityText:Hide()
+		ph._hintText:SetText('Click to assign')
+		ph._hintText:Show()
+		ph._restingAlpha = (ph._slotIndex == 1) and 0.5 or 0
+	end
+	-- Gear visibility + alpha are owned by updatePlaceholderGearHover;
+	-- this function only handles mode+text. Hide gear eagerly on mode
+	-- change so a stale gear doesn't stick around for 100ms until the
+	-- poll catches up.
+	if(ph._gear) then ph._gear:Hide() end
+end
+
 -- ============================================================
 -- Layout (grid)
 -- ============================================================
-function F.Units.Pinned.Layout()
+-- @param deferShow  boolean  When true, skip the final anchor:Show() —
+-- used by callers that follow Layout with Resolve so the anchor stays
+-- hidden through the entire Layout+Resolve transition. Without this,
+-- oUF frames briefly render with their stale unit state (spawned as
+-- 'player', so all 9 slots flash the player's bars/name) before Resolve
+-- clears unit = nil for unassigned slots.
+function F.Units.Pinned.Layout(deferShow)
 	local anchor = F.Units.Pinned.anchor
 	local frames = F.Units.Pinned.frames
 	if(not anchor or not frames) then return end
@@ -291,7 +474,8 @@ function F.Units.Pinned.Layout()
 		anchor:Hide()
 		return
 	end
-	anchor:Show()
+	-- anchor:Show() deferred to the end of the function so positioning
+	-- and placeholder creation happen while the anchor is still hidden.
 
 	local count   = math.max(1, math.min(config.count   or 3, MAX_SLOTS))
 	local columns = math.max(1, math.min(config.columns or 3, count))
@@ -310,6 +494,13 @@ function F.Units.Pinned.Layout()
 					col * (width + spacing),
 					-(row * (height + spacing)))
 				F.Widgets.SetSize(f, width, height)
+				-- The outer frame was originally pixel-snapped at the pre-scale
+				-- effective scale. Inner wrappers (health/power) captured that
+				-- snap too and were never re-run, so on non-1.0 UI scales they
+				-- render ~1px wider than the frame and spill past the dark bg.
+				-- Re-snap them at the current (post-SetScale) effective scale.
+				if(f.Health and f.Health._wrapper) then F.Widgets.ReSize(f.Health._wrapper) end
+				if(f.Power  and f.Power._wrapper)  then F.Widgets.ReSize(f.Power._wrapper)  end
 				f:Show()
 			else
 				f:Hide()
@@ -322,25 +513,59 @@ function F.Units.Pinned.Layout()
 		columns * width + (columns - 1) * spacing,
 		rows    * height + (rows    - 1) * spacing)
 
-	-- Manage placeholders for active but unassigned slots
+	-- Manage placeholders. Shown for unassigned slots AND for slots whose
+	-- unit token doesn't currently resolve to an existing unit — otherwise
+	-- the user has no hoverable surface to reopen the assignment menu.
 	F.Units.Pinned.placeholders = F.Units.Pinned.placeholders or {}
 	local phs = F.Units.Pinned.placeholders
 	local slots = config.slots or {}
 
 	for i = 1, MAX_SLOTS do
-		if(i <= count and not slots[i]) then
-			phs[i] = phs[i] or createPlaceholder(anchor, i)
-			local f = frames[i]
-			phs[i]:ClearAllPoints()
-			phs[i]:SetAllPoints(f)
-			F.Widgets.SetSize(phs[i], width, height)
-			phs[i]:Show()
+		local slot = slots[i]
+		local f    = frames[i]
+		if(i <= count) then
+			local unitMissing = slot and f and (not f.unit or not UnitExists(f.unit))
+			if(not slot or unitMissing) then
+				phs[i] = phs[i] or createPlaceholder(anchor, i)
+				phs[i]:ClearAllPoints()
+				phs[i]:SetAllPoints(f)
+				F.Widgets.SetSize(phs[i], width, height)
+				if(slot) then
+					setPlaceholderMode(phs[i], 'empty', slotIdentityText(slot))
+				else
+					setPlaceholderMode(phs[i], 'unassigned')
+				end
+				phs[i]:Show()
+			elseif(phs[i]) then
+				phs[i]:Hide()
+			end
 		elseif(phs[i]) then
 			phs[i]:Hide()
 		end
 	end
 
 	updatePolling()
+
+	if(not deferShow) then
+		anchor:Show()
+	end
+end
+
+--- Convenience wrapper: Hide → Layout → Resolve → Show, atomic from the
+--- user's perspective. Used by every call site that needs both a layout
+--- refresh AND unit resolution (enable toggle, count/width changes,
+--- preset switch). Prevents the stale-state flash described on Layout's
+--- deferShow param.
+function F.Units.Pinned.Refresh()
+	local anchor = F.Units.Pinned.anchor
+	if(not anchor) then return end
+	anchor:Hide()
+	F.Units.Pinned.Layout(true)
+	F.Units.Pinned.Resolve()
+	local config = F.Units.Pinned.GetConfig()
+	if(config and config.enabled) then
+		anchor:Show()
+	end
 end
 
 -- ============================================================
@@ -348,6 +573,59 @@ end
 -- ============================================================
 local pendingResolve = false
 
+local function slotToToken(slot)
+	if(not slot) then return nil end
+	if(slot.type == 'unit') then
+		return slot.value
+	elseif(slot.type == 'name') then
+		return findUnitForName(slot.value)
+	elseif(slot.type == 'nametarget') then
+		local base = findUnitForName(slot.value)
+		return base and (base .. 'target') or nil
+	end
+	return nil
+end
+
+local function applySlotToFrame(frame, slot)
+	local token = slotToToken(slot)
+	setFrameUnit(frame, token)
+	-- Hide live frames with no unit. Layout calls f:Show() on all 9 before
+	-- Resolve runs; then anchor:Show() cascades visibility to every child,
+	-- and the unassigned frames render their stale oUF seed state (spawned
+	-- as 'player' — so a white health/power bar and the player's name) for
+	-- the one or two frames it takes oUF's secure unit-watch driver to
+	-- hide them. The placeholder's 0.6-alpha background lets that bleed
+	-- through as a visible white flash on every enable toggle. Hiding
+	-- here — before anchor:Show — eliminates the window.
+	-- Guarded on combat because :Show/:Hide on secure buttons is blocked
+	-- mid-combat; setFrameUnit has the same guard and would already have
+	-- bailed, leaving visibility unchanged, which is safe.
+	if(not InCombatLockdown()) then
+		if(token and not frame:IsShown()) then
+			frame:Show()
+		elseif(not token and frame:IsShown()) then
+			frame:Hide()
+		end
+	end
+	if(frame.SlotIdentity) then
+		local labelText = slotIdentityText(slot)
+		-- SlotIdentity is anchored ABOVE the frame (BOTTOM→TOP). In combat,
+		-- multiple target-chain frames produce a row of floating labels over
+		-- the grid — visual noise when the player is busy and the identity is
+		-- redundant anyway (the placeholder shows identity when the target is
+		-- missing, and the unit name shows when it's present).
+		if(labelText and not InCombatLockdown()) then
+			frame.SlotIdentity:SetText(labelText)
+			frame.SlotIdentity:Show()
+		else
+			frame.SlotIdentity:Hide()
+		end
+	end
+end
+
+--- Re-resolve every slot. Used by initial spawn, preset switch, and roster
+--- updates — anywhere the tokens may have shifted for reasons other than a
+--- single assignment change.
 function F.Units.Pinned.Resolve()
 	if(InCombatLockdown()) then
 		pendingResolve = true
@@ -363,35 +641,157 @@ function F.Units.Pinned.Resolve()
 	for i = 1, MAX_SLOTS do
 		local frame = frames[i]
 		if(frame) then
-			local slot  = slots[i]
-			local token = nil
-			if(slot) then
-				if(slot.type == 'unit') then
-					token = slot.value
-				elseif(slot.type == 'name') then
-					token = findUnitForName(slot.value)
-				elseif(slot.type == 'nametarget') then
-					local base = findUnitForName(slot.value)
-					token = base and (base .. 'target') or nil
-				end
-			end
-			setFrameUnit(frame, token)
-			if(frame.SlotIdentity) then
-				local labelText = slotIdentityText(slot)
-				if(labelText) then
-					frame.SlotIdentity:SetText(labelText)
-					frame.SlotIdentity:Show()
-				else
-					frame.SlotIdentity:Hide()
-				end
-			end
-			if(frame.ReassignGear and not slot) then
-				frame.ReassignGear:SetAlpha(0)
-				frame.ReassignGear:EnableMouse(false)
-			end
+			applySlotToFrame(frame, slots[i])
+			F.Units.Pinned.RefreshPlaceholder(i)
 		end
 	end
 	updatePolling()
+end
+
+--- Apply changes to a single slot only. Used by dropdown assignment so the
+--- other eight frames and their placeholders don't re-anchor or redraw.
+function F.Units.Pinned.ApplySlot(slotIndex)
+	if(InCombatLockdown()) then
+		pendingResolve = true
+		return
+	end
+	local config = F.Units.Pinned.GetConfig()
+	local frames = F.Units.Pinned.frames
+	if(not config or not frames) then return end
+
+	local frame = frames[slotIndex]
+	if(not frame) then return end
+
+	local slots = config.slots or {}
+	local slot  = slots[slotIndex]
+
+	-- Re-snap the frame and inner wrappers. Health/Power wrappers were
+	-- pixel-snapped at the Style-time effective scale; on non-1.0 UI scales
+	-- they drift ~1px wider than the outer frame and spill past the dark bg.
+	local width  = config.width
+	local height = config.height
+	F.Widgets.SetSize(frame, width, height)
+	if(frame.Health and frame.Health._wrapper) then F.Widgets.ReSize(frame.Health._wrapper) end
+	if(frame.Power  and frame.Power._wrapper)  then F.Widgets.ReSize(frame.Power._wrapper)  end
+
+	applySlotToFrame(frame, slot)
+
+	F.Units.Pinned.RefreshPlaceholder(slotIndex)
+
+	updatePolling()
+end
+
+--- Re-evaluate placeholder visibility/mode for a single slot. Called from
+--- ApplySlot (assignment change) and from the poll loop (target appeared or
+--- disappeared for a nametarget/focustarget slot).
+function F.Units.Pinned.RefreshPlaceholder(slotIndex)
+	local config = F.Units.Pinned.GetConfig()
+	local frames = F.Units.Pinned.frames
+	if(not config or not frames) then return end
+	local frame = frames[slotIndex]
+	if(not frame) then return end
+
+	local count = math.max(1, math.min(config.count or 3, MAX_SLOTS))
+	local width, height = config.width, config.height
+	local slot = (config.slots or {})[slotIndex]
+	local unitMissing = slot and (not frame.unit or not UnitExists(frame.unit))
+
+	F.Units.Pinned.placeholders = F.Units.Pinned.placeholders or {}
+	local phs = F.Units.Pinned.placeholders
+
+	if(slotIndex > count) then
+		if(phs[slotIndex]) then phs[slotIndex]:Hide() end
+		return
+	end
+
+	-- In combat, the 'empty' placeholder (assigned slot whose target doesn't
+	-- currently exist — e.g. "Captain Garrick's Target" when Garrick has no
+	-- target) just adds visual noise over the target frame area and can't be
+	-- changed anyway. Only show it out of combat; the 'unassigned' mode
+	-- (slot 1's always-visible anchor) is still rendered.
+	if(slot and unitMissing and InCombatLockdown()) then
+		if(phs[slotIndex]) then phs[slotIndex]:Hide() end
+		return
+	end
+
+	if(not slot or unitMissing) then
+		phs[slotIndex] = phs[slotIndex] or createPlaceholder(F.Units.Pinned.anchor, slotIndex)
+		phs[slotIndex]:ClearAllPoints()
+		phs[slotIndex]:SetAllPoints(frame)
+		F.Widgets.SetSize(phs[slotIndex], width, height)
+		if(slot) then
+			setPlaceholderMode(phs[slotIndex], 'empty', slotIdentityText(slot))
+		else
+			setPlaceholderMode(phs[slotIndex], 'unassigned')
+		end
+		phs[slotIndex]:Show()
+	elseif(phs[slotIndex]) then
+		phs[slotIndex]:Hide()
+	end
+end
+
+-- ============================================================
+-- Gear hover poll
+-- Parent OnEnter/OnLeave fire unreliably on live pinned frames — aura
+-- icons, overlays, and the MouseoverHighlight child all swallow mouse
+-- motion. Poll IsMouseOver() every frame on the (unanimated) anchor instead.
+-- ============================================================
+local FRAME_HOVER_ALPHA, GEAR_HOVER_ALPHA = 0.8, 1
+
+local function updateGearHover(frame)
+	local gear = frame.ReassignGear
+	if(not gear) then return end
+
+	-- Hide gear when the frame can't accept one: combat lockdown,
+	-- unassigned slot, no unit, or not visible (secure driver hid the
+	-- frame because the unit doesn't currently exist).
+	if(InCombatLockdown() or not frame._pinnedSlotIndex or not frame.unit or not frame:IsVisible()) then
+		if(gear:IsShown()) then gear:Hide() end
+		return
+	end
+
+	local frameOver = frame:IsMouseOver()
+	local gearOver = gear:IsMouseOver()
+
+	if(frameOver or gearOver) then
+		if(not gear:IsShown()) then gear:Show() end
+		gear:SetAlpha(gearOver and GEAR_HOVER_ALPHA or FRAME_HOVER_ALPHA)
+	elseif(gear:IsShown()) then
+		gear:Hide()
+	end
+end
+
+--- Placeholder hover + gear state, driven by the same poll as live frames.
+--- HookScript('OnEnter'/'OnLeave') on the placeholder was unreliable — the
+--- live frame's aura children can intercept events and leave OnLeave unfired.
+local function updatePlaceholderGearHover(ph)
+	if(not ph:IsVisible()) then
+		if(ph._gear and ph._gear:IsShown()) then ph._gear:Hide() end
+		return
+	end
+
+	if(ph._menuOpen) then
+		ph:SetAlpha(1)
+		return
+	end
+
+	local gear = ph._gear
+	local phOver = ph:IsMouseOver()
+	local gearOver = gear and gear:IsMouseOver()
+	local canShowGear = gear and ph._mode == 'empty' and not InCombatLockdown()
+
+	if(phOver or gearOver) then
+		ph:SetAlpha(1)
+		if(canShowGear) then
+			if(not gear:IsShown()) then gear:Show() end
+			gear:SetAlpha(gearOver and GEAR_HOVER_ALPHA or FRAME_HOVER_ALPHA)
+		elseif(gear and gear:IsShown()) then
+			gear:Hide()
+		end
+	else
+		ph:SetAlpha(ph._restingAlpha or 0)
+		if(gear and gear:IsShown()) then gear:Hide() end
+	end
 end
 
 -- ============================================================
@@ -402,6 +802,11 @@ function F.Units.Pinned.Spawn()
 	oUF:SetActiveStyle('FramedPinned')
 
 	local anchor = CreateFrame('Frame', 'FramedPinnedAnchor', UIParent)
+	-- Hide immediately — frames will be parented to this anchor and each
+	-- oUF:Spawn('player') seeds them with player's bars/name. Without the
+	-- pre-hide, all 9 frames briefly render the player's state between
+	-- spawn and Resolve setting unit=nil on unassigned slots.
+	anchor:Hide()
 	F.Widgets.SetSize(anchor, 1, 1)
 	F.Units.Pinned.anchor = anchor
 	F.Units.Pinned.ApplyPosition()
@@ -415,8 +820,19 @@ function F.Units.Pinned.Spawn()
 	end
 	F.Units.Pinned.frames = frames
 
-	F.Units.Pinned.Layout()
-	F.Units.Pinned.Resolve()
+	F.Units.Pinned.Refresh()
+
+	anchor:SetScript('OnUpdate', function()
+		for _, frame in next, F.Units.Pinned.frames do
+			updateGearHover(frame)
+		end
+		local phs = F.Units.Pinned.placeholders
+		if(phs) then
+			for _, ph in next, phs do
+				updatePlaceholderGearHover(ph)
+			end
+		end
+	end)
 end
 
 --- Fallback: the real implementation lives in Settings/Cards/Pinned.lua and
@@ -434,8 +850,41 @@ F.EventBus:Register('GROUP_ROSTER_UPDATE', function()
 	F.Units.Pinned.Resolve()
 end, 'Pinned.Resolve')
 
+local function refreshAllPlaceholders()
+	for i = 1, MAX_SLOTS do
+		F.Units.Pinned.RefreshPlaceholder(i)
+	end
+end
+
+local function setAllSlotIdentities(visible)
+	local frames = F.Units.Pinned.frames
+	if(not frames) then return end
+	local config = F.Units.Pinned.GetConfig()
+	local slots = (config and config.slots) or {}
+	for i = 1, MAX_SLOTS do
+		local f = frames[i]
+		if(f and f.SlotIdentity) then
+			local text = visible and slotIdentityText(slots[i])
+			if(text) then
+				f.SlotIdentity:SetText(text)
+				f.SlotIdentity:Show()
+			else
+				f.SlotIdentity:Hide()
+			end
+		end
+	end
+end
+
 F.EventBus:Register('PLAYER_REGEN_ENABLED', function()
 	if(pendingResolve) then
 		F.Units.Pinned.Resolve()
 	end
+	-- Empty placeholders and SlotIdentity labels were suppressed in combat.
+	refreshAllPlaceholders()
+	setAllSlotIdentities(true)
 end, 'Pinned.CombatFlush')
+
+F.EventBus:Register('PLAYER_REGEN_DISABLED', function()
+	refreshAllPlaceholders()
+	setAllSlotIdentities(false)
+end, 'Pinned.CombatHidePlaceholders')

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -8,6 +8,66 @@ F.Units.Pinned = F.Units.Pinned or {}
 local MAX_SLOTS = 9
 
 -- ============================================================
+-- Roster / unit resolution
+-- ============================================================
+
+--- Convert UnitName(token) into storage format ('Name' or 'Name-Realm').
+local function fullUnitName(token)
+	if(not UnitExists(token)) then return nil end
+	local name, realm = UnitName(token)
+	if(not name) then return nil end
+	if(realm and realm ~= '') then
+		return name .. '-' .. realm
+	end
+	return name
+end
+F.Units.Pinned.FullUnitName = fullUnitName
+
+--- Scan the current group for a player matching storedName.
+local function findUnitForName(storedName)
+	if(not storedName) then return nil end
+	if(IsInRaid()) then
+		for i = 1, GetNumGroupMembers() do
+			if(fullUnitName('raid' .. i) == storedName) then
+				return 'raid' .. i
+			end
+		end
+	elseif(IsInGroup()) then
+		for i = 1, GetNumGroupMembers() - 1 do
+			if(fullUnitName('party' .. i) == storedName) then
+				return 'party' .. i
+			end
+		end
+		if(fullUnitName('player') == storedName) then
+			return 'player'
+		end
+	else
+		if(fullUnitName('player') == storedName) then
+			return 'player'
+		end
+	end
+	return nil
+end
+F.Units.Pinned.FindUnitForName = findUnitForName
+
+--- Swap a frame's unit. Updates secure attribute + frame.unit mirror.
+--- Combat-safe: returns false if InCombatLockdown prevents SetAttribute.
+local function setFrameUnit(frame, token)
+	if(InCombatLockdown()) then return false end
+	if(token) then
+		frame:SetAttribute('unit', token)
+		frame.unit = token
+	else
+		frame:SetAttribute('unit', nil)
+		frame.unit = nil
+	end
+	if(frame.UpdateAllElements) then
+		frame:UpdateAllElements('RefreshUnit')
+	end
+	return true
+end
+
+-- ============================================================
 -- Config accessor
 -- ============================================================
 function F.Units.Pinned.GetConfig()
@@ -93,6 +153,43 @@ function F.Units.Pinned.Layout()
 end
 
 -- ============================================================
+-- Resolve
+-- ============================================================
+local pendingResolve = false
+
+function F.Units.Pinned.Resolve()
+	if(InCombatLockdown()) then
+		pendingResolve = true
+		return
+	end
+	pendingResolve = false
+
+	local config = F.Units.Pinned.GetConfig()
+	local frames = F.Units.Pinned.frames
+	if(not config or not frames) then return end
+
+	local slots = config.slots or {}
+	for i = 1, MAX_SLOTS do
+		local frame = frames[i]
+		if(frame) then
+			local slot  = slots[i]
+			local token = nil
+			if(slot) then
+				if(slot.type == 'unit') then
+					token = slot.value
+				elseif(slot.type == 'name') then
+					token = findUnitForName(slot.value)
+				elseif(slot.type == 'nametarget') then
+					local base = findUnitForName(slot.value)
+					token = base and (base .. 'target') or nil
+				end
+			end
+			setFrameUnit(frame, token)
+		end
+	end
+end
+
+-- ============================================================
 -- Spawn
 -- ============================================================
 function F.Units.Pinned.Spawn()
@@ -113,4 +210,18 @@ function F.Units.Pinned.Spawn()
 	F.Units.Pinned.frames = frames
 
 	F.Units.Pinned.Layout()
+	F.Units.Pinned.Resolve()
 end
+
+-- ============================================================
+-- Event registration
+-- ============================================================
+F.EventBus:Register('GROUP_ROSTER_UPDATE', function()
+	F.Units.Pinned.Resolve()
+end, 'Pinned.Resolve')
+
+F.EventBus:Register('PLAYER_REGEN_ENABLED', function()
+	if(pendingResolve) then
+		F.Units.Pinned.Resolve()
+	end
+end, 'Pinned.CombatFlush')

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -68,6 +68,68 @@ local function setFrameUnit(frame, token)
 end
 
 -- ============================================================
+-- Derived-unit polling
+-- WoW fires no event when a unit's target changes. Polls GUID of each
+-- polling slot at 0.2s intervals; fires RefreshUnit on change.
+-- ============================================================
+local POLL_INTERVAL = 0.2
+local pollFrame     = CreateFrame('Frame')
+local pollElapsed   = 0
+local lastGUIDs     = {}
+
+local function slotNeedsPolling(slot)
+	if(not slot) then return false end
+	if(slot.type == 'nametarget') then return true end
+	if(slot.type == 'unit' and slot.value == 'focustarget') then return true end
+	return false
+end
+
+local function onPollUpdate(_, elapsed)
+	pollElapsed = pollElapsed + elapsed
+	if(pollElapsed < POLL_INTERVAL) then return end
+	pollElapsed = 0
+
+	local config = F.Units.Pinned.GetConfig()
+	local frames = F.Units.Pinned.frames
+	if(not config or not frames) then return end
+	local slots = config.slots or {}
+
+	for i = 1, MAX_SLOTS do
+		local slot  = slots[i]
+		local frame = frames[i]
+		if(slotNeedsPolling(slot) and frame and frame.unit) then
+			local newGUID = UnitGUID(frame.unit)
+			if(newGUID ~= lastGUIDs[i]) then
+				lastGUIDs[i] = newGUID
+				if(frame.UpdateAllElements) then
+					frame:UpdateAllElements('RefreshUnit')
+				end
+			end
+		else
+			lastGUIDs[i] = nil
+		end
+	end
+end
+
+local function updatePolling()
+	local config = F.Units.Pinned.GetConfig()
+	if(not config or not config.enabled) then
+		pollFrame:SetScript('OnUpdate', nil)
+		return
+	end
+
+	local slots = config.slots or {}
+	for i = 1, MAX_SLOTS do
+		if(slotNeedsPolling(slots[i])) then
+			pollFrame:SetScript('OnUpdate', onPollUpdate)
+			return
+		end
+	end
+	pollFrame:SetScript('OnUpdate', nil)
+end
+F.Units.Pinned.UpdatePolling = updatePolling
+
+-- ============================================================
 -- Config accessor
 -- ============================================================
 function F.Units.Pinned.GetConfig()
@@ -150,6 +212,7 @@ function F.Units.Pinned.Layout()
 	F.Widgets.SetSize(anchor,
 		columns * width + (columns - 1) * spacing,
 		rows    * height + (rows    - 1) * spacing)
+	updatePolling()
 end
 
 -- ============================================================
@@ -187,6 +250,7 @@ function F.Units.Pinned.Resolve()
 			setFrameUnit(frame, token)
 		end
 	end
+	updatePolling()
 end
 
 -- ============================================================

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -185,21 +185,29 @@ local function Style(self, unit)
 		gear._icon = icon
 
 		gear:SetAlpha(0)
+		gear:EnableMouse(false)
 		gear:RegisterForClicks('LeftButtonUp')
 
 		-- Hide gear during combat
 		self:HookScript('OnEnter', function(frame)
 			if(InCombatLockdown()) then return end
 			if(frame._pinnedSlotIndex) then
+				gear:EnableMouse(true)
 				gear:SetAlpha(0.8)
 			end
 		end)
 		self:HookScript('OnLeave', function()
 			gear:SetAlpha(0)
+			gear:EnableMouse(false)
 		end)
 		gear:SetScript('OnEnter', function(self) self:SetAlpha(1) end)
 		gear:SetScript('OnLeave', function(self)
-			if(self:GetParent():IsMouseOver()) then self:SetAlpha(0.8) else self:SetAlpha(0) end
+			if(self:GetParent():IsMouseOver()) then
+				self:SetAlpha(0.8)
+			else
+				self:SetAlpha(0)
+				self:EnableMouse(false)
+			end
 		end)
 
 		gear:SetScript('OnClick', function(g)
@@ -376,12 +384,9 @@ function F.Units.Pinned.Resolve()
 					frame.SlotIdentity:Hide()
 				end
 			end
-			if(frame.ReassignGear) then
-				if(slot) then
-					-- Gear visible-on-hover; don't force show here
-				else
-					frame.ReassignGear:SetAlpha(0)
-				end
+			if(frame.ReassignGear and not slot) then
+				frame.ReassignGear:SetAlpha(0)
+				frame.ReassignGear:EnableMouse(false)
 			end
 		end
 	end

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -67,6 +67,18 @@ local function setFrameUnit(frame, token)
 	return true
 end
 
+local function slotIdentityText(slot)
+	if(not slot) then return nil end
+	if(slot.type == 'nametarget') then
+		return (slot.value or '?') .. "'s Target"
+	elseif(slot.type == 'unit') then
+		if(slot.value == 'focus')       then return 'Focus'        end
+		if(slot.value == 'focustarget') then return 'Focus Target' end
+		return slot.value
+	end
+	return nil
+end
+
 -- ============================================================
 -- Derived-unit polling
 -- WoW fires no event when a unit's target changes. Polls GUID of each
@@ -152,6 +164,13 @@ local function Style(self, unit)
 		F.StyleBuilder.Apply(self, unit, config, 'pinned')
 	else
 		F.Widgets.SetSize(self, 160, 40)
+	end
+
+	if(not self.SlotIdentity) then
+		local fs = F.Widgets.CreateFontString(self, F.Constants.Font.sizeSmall, F.Constants.Colors.textSecondary)
+		fs:SetPoint('BOTTOM', self, 'TOP', 0, 2)
+		fs:SetAlpha(0.7)
+		self.SlotIdentity = fs
 	end
 
 	F.Widgets.RegisterForUIScale(self)
@@ -248,6 +267,15 @@ function F.Units.Pinned.Resolve()
 				end
 			end
 			setFrameUnit(frame, token)
+			if(frame.SlotIdentity) then
+				local labelText = slotIdentityText(slot)
+				if(labelText) then
+					frame.SlotIdentity:SetText(labelText)
+					frame.SlotIdentity:Show()
+				else
+					frame.SlotIdentity:Hide()
+				end
+			end
 		end
 	end
 	updatePolling()

--- a/Units/StyleBuilder.lua
+++ b/Units/StyleBuilder.lua
@@ -156,11 +156,15 @@ function F.StyleBuilder.Apply(self, unit, config, unitType)
 	-- 2. Dark background texture
 	-- --------------------------------------------------------
 
+	-- SetColorTexture synthesizes a solid-color quad on the GPU with no
+	-- texture file load. SetTexture([[Interface\BUTTONS\WHITE8x8]]) +
+	-- SetVertexColor has a first-paint window where the white texture is
+	-- visible before the vertex color is applied — seen as a white flash
+	-- on all 9 pinned slots when the feature is first enabled.
 	local bg = self:CreateTexture(nil, 'BACKGROUND')
 	bg:SetAllPoints(self)
-	bg:SetTexture([[Interface\BUTTONS\WHITE8x8]])
 	local bgC = C.Colors.background
-	bg:SetVertexColor(bgC[1], bgC[2], bgC[3], bgC[4] or 1)
+	bg:SetColorTexture(bgC[1], bgC[2], bgC[3], bgC[4] or 1)
 
 	-- --------------------------------------------------------
 	-- 3. Calculate health / power bar heights

--- a/Units/StyleBuilder.lua
+++ b/Units/StyleBuilder.lua
@@ -54,6 +54,24 @@ function F.StyleBuilder.GetConfig(unitType)
 		end
 	end
 
+	-- Pinned has no canonical owner in PresetInfo (shared across Party/Raid/
+	-- Arena, none of them own it via groupKey). Style() still needs a valid
+	-- pinnedConfig as a template to wire Health/Name elements at Spawn time,
+	-- even when the active preset is Solo. Fall back to any base group preset
+	-- that has a pinned config. Visibility gating happens in Pinned.Refresh
+	-- via its own current-preset lookup, so this fallback won't accidentally
+	-- show pinned anchors under Solo.
+	if(unitType == 'pinned') then
+		for name, info in next, C.PresetInfo do
+			if(info.isBase and info.groupKey) then
+				local _, groupData = F.AutoSwitch.ResolvePreset(name)
+				if(groupData and groupData.unitConfigs and groupData.unitConfigs.pinned) then
+					return groupData.unitConfigs.pinned
+				end
+			end
+		end
+	end
+
 	return nil
 end
 

--- a/Widgets/Dropdown.lua
+++ b/Widgets/Dropdown.lua
@@ -569,6 +569,61 @@ OpenDropdownList = function(owner)
 end
 
 -- ============================================================
+-- OpenPopupMenu — chrome-free menu anchored to an arbitrary frame.
+-- Satisfies the OpenDropdownList owner contract without rendering
+-- a dropdown button. The caller gets a pure popup list that appears
+-- directly below the given anchor frame.
+-- ============================================================
+
+local popupOwner
+
+--- Open a popup menu anchored below `anchor`.
+--- @param anchor   Frame    Frame the menu appears beneath
+--- @param items    table    Dropdown items array
+--- @param value    any      Currently-selected value (for highlight)
+--- @param onSelect function  Receives (value, ownerFrame)
+function Widgets.OpenPopupMenu(anchor, items, value, onSelect)
+	if(not popupOwner) then
+		popupOwner = CreateFrame('Frame', nil, UIParent)
+		function popupOwner:_SelectItem(item)
+			self._value = item.value
+			if(self._onSelect) then
+				self._onSelect(item.value, self)
+			end
+		end
+		-- OpenDropdownList calls _onClose on the owner when the list closes.
+		-- Use it to release the anchor so its hover state can return to rest.
+		function popupOwner:_onClose()
+			local a = self._anchor
+			self._anchor = nil
+			if(a) then
+				a._menuOpen = nil
+				local onLeave = a:GetScript('OnLeave')
+				if(onLeave) then onLeave(a) end
+			end
+		end
+	end
+
+	popupOwner:SetParent(anchor:GetParent() or UIParent)
+	popupOwner:SetFrameStrata('DIALOG')
+	popupOwner:ClearAllPoints()
+	popupOwner:SetPoint('TOPLEFT',  anchor, 'TOPLEFT',  0, 0)
+	popupOwner:SetPoint('TOPRIGHT', anchor, 'TOPRIGHT', 0, 0)
+	popupOwner:SetHeight(anchor:GetHeight())
+
+	popupOwner._items    = items or {}
+	popupOwner._value    = value
+	popupOwner._onSelect = onSelect
+	popupOwner._anchor   = anchor
+
+	-- Flag the anchor so its own OnLeave can choose to stay visible while the
+	-- menu is open. The anchor's OnLeave opts in by checking `self._menuOpen`.
+	anchor._menuOpen = true
+
+	OpenDropdownList(popupOwner)
+end
+
+-- ============================================================
 -- CreateDropdown — standard dropdown widget
 -- ============================================================
 

--- a/docs/superpowers/plans/2026-04-18-pinned-frames.md
+++ b/docs/superpowers/plans/2026-04-18-pinned-frames.md
@@ -1,0 +1,1727 @@
+# Pinned Frames Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement name-tracking "pinned" unit frames — up to 9 standalone frames that watch specific group members by name, following players across roster reshuffles, with role-grouped class-colored assignment UI in both the Settings card and on the live frames, full aura configuration as a first-class unit type, and EditMode integration.
+
+**Architecture:** Nine frames pre-spawned via `oUF:Spawn('player', 'FramedPinnedN')` once at addon load (placeholder unit replaced via `SetAttribute('unit', ...)` immediately after resolution). A resolver scans the roster on `GROUP_ROSTER_UPDATE`, matches stored names to current unit tokens, and mirrors both the secure attribute and `frame.unit`. Static tokens (`focus`, `focustarget`) and derived tokens (`nametarget`) are supported. A throttled `OnUpdate` (0.2s, GUID-diff) handles `focustarget`/`nametarget`. Layout is a grid anchored off `F.Units.Pinned.anchor`. All assignment changes during combat are queued and flushed on `PLAYER_REGEN_ENABLED`. Frames are tagged with `_framedUnitType = 'pinned'` so the generic `FrameConfigPreset` handler picks them up on preset activation. Aura config lives at `presets.<name>.auras.pinned` and appears in the Auras panel's unit-type dropdown via `Settings._getUnitTypeItems()`.
+
+**Tech Stack:** Lua 5.1, WoW Interface 12.0.0/12.0.1, embedded oUF (`F.oUF`), Framed conventions (tabs, `if(cond) then`, single quotes, `for _, v in next, tbl do`), Framed Config API + EventBus + StyleBuilder + FrameSettingsBuilder + Widgets (`CreateDropdown`, `StartCard`/`EndCard`, `CreateCardGrid`).
+
+**Reference files in this codebase:**
+- `Units/Boss.lua` — simplest multi-frame pattern
+- `Units/Party.lua` — combat-deferred layout
+- `Units/LiveUpdate/FrameConfigLayout.lua` — CONFIG_CHANGED blueprint
+- `Units/LiveUpdate/FrameConfigPreset.lua:460` — PRESET_CHANGED generic handler (already iterates `_framedUnitType`-tagged frames)
+- `Units/LiveUpdate/FrameConfigShared.lua` — `guardConfigChanged`, `debouncedApply`, `applyOrQueue`
+- `Settings/Panels/Boss.lua` — thin panel wrapper template
+- `Settings/Panels/Buffs.lua` — aura panel structure (reference for what the 10 aura panels share)
+- `Settings/Framework.lua:104` — `Settings._getUnitTypeItems()` (where pinned must appear)
+- `Settings/FrameSettingsBuilder.lua` — shared preview/summary/card layout
+- `Widgets/Dropdown.lua:492` — `_decorateRow` hook for custom row rendering
+- `Presets/Defaults.lua:408` — `F.PresetDefaults.GetAll()` preset factory
+- `Presets/AuraDefaults.lua:299` — `F.AuraDefaults.Group(sizes)`
+- `EditMode/EditMode.lua:37-47` — `FRAME_KEYS` registry
+- `Core/Constants.lua:96` — `PresetInfo`
+
+---
+
+## File Structure
+
+**New files:**
+- `Units/Pinned.lua` (~500 lines) — Style, Spawn, resolver, combat deferral, grid layout, refreshOnUpdate, slot identity label, placeholder overlays, reassign hover gear, EditMode click hook
+- `Units/LiveUpdate/FrameConfigPinned.lua` (~90 lines) — CONFIG_CHANGED + PRESET_CHANGED handlers
+- `Settings/Panels/Pinned.lua` (~15 lines) — sidebar registration
+- `Settings/Cards/Pinned.lua` (~220 lines) — per-slot assignment list with role-grouped dropdown
+
+**Modified files:**
+- `Presets/Defaults.lua` — add `pinnedConfig()`, register in Party/Raid/Arena + derived; add `auras.pinned` to each
+- `Presets/AuraDefaults.lua` — no structural change (pinned reuses `F.AuraDefaults.Group`)
+- `Settings/Framework.lua` — extend `Settings._getUnitTypeItems()` to include `pinned` when active preset has `auras.pinned`
+- `Settings/FrameSettingsBuilder.lua` — register `pinned` in `GROUP_TYPES`/`GROUP_COUNTS`, per-unit-type branches
+- `EditMode/EditMode.lua` — add entry to `FRAME_KEYS`; ensure inline settings panel opens on click
+- `Framed.toc` — register new files in load order
+- `Init.lua` — `F.Units.Pinned.Spawn()` call in `oUF:Factory`
+
+---
+
+## Design Decisions Made During Planning
+
+**These are deviations or clarifications from the spec that the engineer should know about:**
+
+1. **Right-click reassignment → gear-icon-on-hover instead.** The spec says "Right-click assigned pin: opens dropdown to reassign/unassign." But Framed frames already bind `*type2` via click-casting (`ClickCasting/ClickCasting.lua:34,255`) for `togglemenu` by default, user-rebindable. Adding a plain right-click reassign handler would collide with the user's click-cast bindings and with Blizzard's unit context menu. **Resolution:** Show a small gear icon in the top-right corner of each assigned pin when hovered AND out of combat. Left-click the gear → dropdown opens. The underlying frame's right-click remains fully available for click-casting.
+
+2. **Empty-slot placeholders stay non-secure.** Placeholders for unassigned slots are non-secure frames (dashed border + "+ Click to assign" hint). Left-click opens the dropdown. Since they're non-secure, they work in combat too — but assignment itself is combat-deferred via `pendingResolve`.
+
+3. **EditMode click-to-configure.** The spec says "Clicking a pinned frame in edit mode opens the standard inline settings panel." This is the first time pinned needs this, so Task 11 adds the EditMode click hook. Verify whether Framed's EditMode already supports click-to-configure for other unit types — if so, pinned piggybacks on that path.
+
+4. **Aura config path is `presets.<name>.auras.pinned`** — confirmed by reading `Presets/Defaults.lua:427,471,490,498` (auras live at the top-level `auras.<unitType>` table, NOT inside `unitConfigs`).
+
+5. **Pinned appears in the aura unit-type dropdown via `Settings._getUnitTypeItems()`**, not by registering 10 new aura panels. The existing 10 aura panels (`Buffs`, `Debuffs`, `Defensives`, `Dispels`, etc.) already dispatch on `Settings.GetEditingUnitType()` — extending the unit-type list is the single point of change.
+
+---
+
+## Testing Approach
+
+**No unit test harness for WoW addon behavior.** Verification is:
+
+1. **Lua syntax check** — `luac -p <file>` (parses without executing)
+2. **`/reload` in WoW** — addon loads without errors
+3. **Manual scenario verification** — specific in-game interaction steps
+
+Each task lists verification commands. Run them in the order given; if any fail, stop and fix before proceeding.
+
+**Standing setup:** Sync `/Users/josiahtoppin/Documents/Projects/Framed/` into the WoW `Interface/AddOns/Framed/` folder before each `/reload`. Per user's `feedback_wow_sync.md` memory.
+
+---
+
+## Task 1: Add `pinnedConfig()` defaults and `auras.pinned` in group presets
+
+**Why first:** Every downstream task reads these paths via `F.Config:Get`. `EnsureDefaults`/`DeepMerge` must backfill to existing SavedVariables before any code runs.
+
+**Files:**
+- Modify: `Presets/Defaults.lua`
+
+- [ ] **Step 1: Add `pinnedConfig()` helper**
+
+Open `Presets/Defaults.lua`. Immediately below the `baseUnitConfig()` closing `end`, add:
+
+```lua
+-- Pinned frames: shared style across up to 9 slots, per-slot name-tracking.
+-- Opt-in by default (enabled = false). Solo preset omits this block entirely.
+local function pinnedConfig()
+	local cfg = baseUnitConfig()
+	cfg.enabled  = false
+	cfg.count    = 3
+	cfg.columns  = 3
+	cfg.width    = 160
+	cfg.height   = 40
+	cfg.spacing  = 2
+	cfg.slots    = {}  -- keys 1..9; nil = unassigned
+	cfg.position = { x = 0, y = 0, anchor = 'CENTER' }
+	return cfg
+end
+```
+
+- [ ] **Step 2: Register `pinned` in Party preset's `unitConfigs`**
+
+Find the Party preset block (around line 430). Inside `unitConfigs = { ... }`, add:
+
+```lua
+pinned = pinnedConfig(),
+```
+
+- [ ] **Step 3: Register `pinned` in Party preset's `auras`**
+
+The Party preset builds `partyAuras` before the block. Locate the `partyAuras.party = A.Group(PARTY_AURA_SIZES)` line (around line 428). Add below it:
+
+```lua
+partyAuras.pinned = A.Group(PARTY_AURA_SIZES)
+```
+
+- [ ] **Step 4: Register `pinned` in Raid preset**
+
+Same as Steps 2-3 for the Raid preset block (around line 474). Add `pinned = pinnedConfig()` inside `unitConfigs`, and after `raidAuras.raid = A.Group(RAID_AURA_SIZES)`:
+
+```lua
+raidAuras.pinned = A.Group(RAID_AURA_SIZES)
+```
+
+- [ ] **Step 5: Register `pinned` in Arena preset**
+
+Same pattern (block around line 500). Add `pinned = pinnedConfig()` inside `unitConfigs`, and after `arenaAuras.arena = A.Arena()`:
+
+```lua
+arenaAuras.pinned = A.Group(PARTY_AURA_SIZES)
+```
+
+- [ ] **Step 6: Verify derived presets inherit via DeepCopy**
+
+Read `F.PresetDefaults.GetAll` lines 524-531 — derived presets copy from Raid via `F.DeepCopy`. Since Raid now has `pinned` in both `unitConfigs` and `auras`, derived presets inherit automatically. No code change required.
+
+- [ ] **Step 7: Verify Solo preset has NO pinned block**
+
+Lines 411-424: confirm Solo's `unitConfigs` contains no `pinned` key and `auras = soloUnitAuras()` has no `pinned` sub-table (because `soloUnitAuras()` returns the base aura set without group extensions).
+
+- [ ] **Step 8: Syntax check**
+
+```bash
+luac -p /Users/josiahtoppin/Documents/Projects/Framed/Presets/Defaults.lua
+```
+
+Expected: no output.
+
+- [ ] **Step 9: `/reload` test**
+
+Sync + `/reload`. No errors. Run `/framed config` — presets list should show Party/Raid/Arena.
+
+- [ ] **Step 10: Verify SavedVariables backfill**
+
+```
+/dump FramedDB.presets.Party.unitConfigs.pinned
+/dump FramedDB.presets.Party.auras.pinned
+```
+
+Both should print populated tables (pinned.enabled = false, auras.pinned = the Group aura set).
+
+- [ ] **Step 11: Commit**
+
+```bash
+cd /Users/josiahtoppin/Documents/Projects/Framed
+git add Presets/Defaults.lua
+git commit -m "feat(pinned): add pinnedConfig and auras.pinned defaults"
+git push
+```
+
+---
+
+## Task 2: Minimal `Units/Pinned.lua` — Style, Spawn, grid layout (placeholder unit)
+
+**Why next:** Simplest testable checkpoint — frames on screen with a known placeholder unit. Proves TOC wiring, oUF integration, anchor setup, and layout math before resolver complexity.
+
+**Files:**
+- Create: `Units/Pinned.lua`
+- Modify: `Framed.toc`
+- Modify: `Init.lua`
+
+- [ ] **Step 1: Create `Units/Pinned.lua` skeleton**
+
+```lua
+local _, Framed = ...
+local F = Framed
+local oUF = F.oUF
+
+F.Units        = F.Units        or {}
+F.Units.Pinned = F.Units.Pinned or {}
+
+local MAX_SLOTS = 9
+
+-- ============================================================
+-- Config accessor
+-- ============================================================
+function F.Units.Pinned.GetConfig()
+	local presetName = F.PresetManager and F.PresetManager.GetActive()
+	if(not presetName) then return nil end
+	return F.Config:Get('presets.' .. presetName .. '.unitConfigs.pinned')
+end
+
+-- ============================================================
+-- Style
+-- ============================================================
+local function Style(self, unit)
+	self:SetFrameStrata('LOW')
+	self:RegisterForClicks('AnyUp')
+	self._framedUnitType = 'pinned'
+
+	local config = F.Units.Pinned.GetConfig()
+	if(config) then
+		F.Widgets.SetSize(self, config.width or 160, config.height or 40)
+		F.StyleBuilder.Apply(self, config, 'pinned')
+	else
+		F.Widgets.SetSize(self, 160, 40)
+	end
+
+	F.Widgets.RegisterForUIScale(self)
+end
+
+-- ============================================================
+-- Position
+-- ============================================================
+function F.Units.Pinned.ApplyPosition()
+	local anchor = F.Units.Pinned.anchor
+	if(not anchor) then return end
+	local config = F.Units.Pinned.GetConfig()
+	local pos = (config and config.position) or { x = 0, y = 0, anchor = 'CENTER' }
+	anchor:ClearAllPoints()
+	anchor:SetPoint(pos.anchor or 'CENTER', UIParent, pos.anchor or 'CENTER', pos.x or 0, pos.y or 0)
+end
+
+-- ============================================================
+-- Layout (grid)
+-- ============================================================
+function F.Units.Pinned.Layout()
+	local anchor = F.Units.Pinned.anchor
+	local frames = F.Units.Pinned.frames
+	if(not anchor or not frames) then return end
+
+	local config = F.Units.Pinned.GetConfig()
+	if(not config or not config.enabled) then
+		anchor:Hide()
+		return
+	end
+	anchor:Show()
+
+	local count   = math.max(1, math.min(config.count   or 3, MAX_SLOTS))
+	local columns = math.max(1, math.min(config.columns or 3, count))
+	local width   = config.width   or 160
+	local height  = config.height  or 40
+	local spacing = config.spacing or 2
+
+	for i = 1, MAX_SLOTS do
+		local f = frames[i]
+		if(f) then
+			if(i <= count) then
+				local row = math.ceil(i / columns) - 1
+				local col = ((i - 1) % columns)
+				f:ClearAllPoints()
+				f:SetPoint('TOPLEFT', anchor, 'TOPLEFT',
+					col * (width + spacing),
+					-(row * (height + spacing)))
+				F.Widgets.SetSize(f, width, height)
+				f:Show()
+			else
+				f:Hide()
+			end
+		end
+	end
+
+	local rows = math.ceil(count / columns)
+	F.Widgets.SetSize(anchor,
+		columns * width + (columns - 1) * spacing,
+		rows    * height + (rows    - 1) * spacing)
+end
+
+-- ============================================================
+-- Spawn
+-- ============================================================
+function F.Units.Pinned.Spawn()
+	oUF:RegisterStyle('FramedPinned', Style)
+	oUF:SetActiveStyle('FramedPinned')
+
+	local anchor = CreateFrame('Frame', 'FramedPinnedAnchor', UIParent)
+	F.Widgets.SetSize(anchor, 1, 1)
+	F.Units.Pinned.anchor = anchor
+	F.Units.Pinned.ApplyPosition()
+
+	local frames = {}
+	for i = 1, MAX_SLOTS do
+		local frame = oUF:Spawn('player', 'FramedPinnedFrame' .. i)
+		frame:SetParent(anchor)
+		frames[i] = frame
+	end
+	F.Units.Pinned.frames = frames
+
+	F.Units.Pinned.Layout()
+end
+```
+
+- [ ] **Step 2: Register in `Framed.toc`**
+
+After `Units/Arena.lua`, add:
+
+```
+Units/Pinned.lua
+```
+
+- [ ] **Step 3: Register spawn call in `Init.lua`**
+
+In the `oUF:Factory(function(self) ... end)` block (around line 120), add after `F.Units.Arena.Spawn()`:
+
+```lua
+F.Units.Pinned.Spawn()
+```
+
+- [ ] **Step 4: Syntax check**
+
+```bash
+luac -p /Users/josiahtoppin/Documents/Projects/Framed/Units/Pinned.lua
+luac -p /Users/josiahtoppin/Documents/Projects/Framed/Init.lua
+```
+
+Expected: no output.
+
+- [ ] **Step 5: `/reload` + smoke test**
+
+`/reload`. No errors. Frames hidden (enabled = false).
+
+```
+/run F.Config:Set('presets.Party.unitConfigs.pinned.enabled', true); F.Units.Pinned.Layout()
+```
+
+Expected: 3 frames in a 3x3 shape at screen center, each showing `'player'`.
+
+- [ ] **Step 6: Disable and commit**
+
+```
+/run F.Config:Set('presets.Party.unitConfigs.pinned.enabled', false); F.Units.Pinned.Layout()
+```
+
+```bash
+git add Units/Pinned.lua Framed.toc Init.lua
+git commit -m "feat(pinned): spawn 9 frames with grid layout (placeholder unit)"
+git push
+```
+
+---
+
+## Task 3: Name-based unit resolver + combat deferral
+
+**Why now:** Core feature — replace the placeholder `'player'` unit with real name-tracking.
+
+**Files:**
+- Modify: `Units/Pinned.lua`
+
+- [ ] **Step 1: Add resolver helpers near the top of `Units/Pinned.lua` (after `MAX_SLOTS`)**
+
+```lua
+-- ============================================================
+-- Roster / unit resolution
+-- ============================================================
+
+--- Convert UnitName(token) into storage format ('Name' or 'Name-Realm').
+local function fullUnitName(token)
+	if(not UnitExists(token)) then return nil end
+	local name, realm = UnitName(token)
+	if(not name) then return nil end
+	if(realm and realm ~= '') then
+		return name .. '-' .. realm
+	end
+	return name
+end
+F.Units.Pinned.FullUnitName = fullUnitName
+
+--- Scan the current group for a player matching storedName.
+local function findUnitForName(storedName)
+	if(not storedName) then return nil end
+	if(IsInRaid()) then
+		for i = 1, GetNumGroupMembers() do
+			if(fullUnitName('raid' .. i) == storedName) then
+				return 'raid' .. i
+			end
+		end
+	elseif(IsInGroup()) then
+		for i = 1, GetNumGroupMembers() - 1 do
+			if(fullUnitName('party' .. i) == storedName) then
+				return 'party' .. i
+			end
+		end
+		if(fullUnitName('player') == storedName) then
+			return 'player'
+		end
+	else
+		if(fullUnitName('player') == storedName) then
+			return 'player'
+		end
+	end
+	return nil
+end
+F.Units.Pinned.FindUnitForName = findUnitForName
+```
+
+- [ ] **Step 2: Add `setFrameUnit` helper**
+
+```lua
+--- Swap a frame's unit. Updates secure attribute + frame.unit mirror.
+--- Combat-safe: returns false if InCombatLockdown prevents SetAttribute.
+local function setFrameUnit(frame, token)
+	if(InCombatLockdown()) then return false end
+	if(token) then
+		frame:SetAttribute('unit', token)
+		frame.unit = token
+	else
+		frame:SetAttribute('unit', nil)
+		frame.unit = nil
+	end
+	if(frame.UpdateAllElements) then
+		frame:UpdateAllElements('RefreshUnit')
+	end
+	return true
+end
+```
+
+- [ ] **Step 3: Add `Resolve` function**
+
+```lua
+local pendingResolve = false
+
+function F.Units.Pinned.Resolve()
+	if(InCombatLockdown()) then
+		pendingResolve = true
+		return
+	end
+	pendingResolve = false
+
+	local config = F.Units.Pinned.GetConfig()
+	local frames = F.Units.Pinned.frames
+	if(not config or not frames) then return end
+
+	local slots = config.slots or {}
+	for i = 1, MAX_SLOTS do
+		local frame = frames[i]
+		if(frame) then
+			local slot  = slots[i]
+			local token = nil
+			if(slot) then
+				if(slot.type == 'unit') then
+					token = slot.value
+				elseif(slot.type == 'name') then
+					token = findUnitForName(slot.value)
+				elseif(slot.type == 'nametarget') then
+					local base = findUnitForName(slot.value)
+					token = base and (base .. 'target') or nil
+				end
+			end
+			setFrameUnit(frame, token)
+		end
+	end
+end
+```
+
+- [ ] **Step 4: Register events at the bottom of the file**
+
+```lua
+-- ============================================================
+-- Event registration
+-- ============================================================
+F.EventBus:Register('GROUP_ROSTER_UPDATE', function()
+	F.Units.Pinned.Resolve()
+end, 'Pinned.Resolve')
+
+F.EventBus:Register('PLAYER_REGEN_ENABLED', function()
+	if(pendingResolve) then
+		F.Units.Pinned.Resolve()
+	end
+end, 'Pinned.CombatFlush')
+```
+
+- [ ] **Step 5: Call `Resolve` at the end of `Spawn`**
+
+After `F.Units.Pinned.Layout()` in `Spawn`, add:
+
+```lua
+F.Units.Pinned.Resolve()
+```
+
+- [ ] **Step 6: Syntax check + `/reload`**
+
+```bash
+luac -p /Users/josiahtoppin/Documents/Projects/Framed/Units/Pinned.lua
+```
+
+`/reload` — no errors.
+
+- [ ] **Step 7: Manual resolver test**
+
+Join a party with a friend. Run:
+
+```
+/run F.Config:Set('presets.Party.unitConfigs.pinned.enabled', true)
+/run F.Config:Set('presets.Party.unitConfigs.pinned.slots', { [1] = { type = 'name', value = F.Units.Pinned.FullUnitName('player') }, [2] = { type = 'unit', value = 'focus' } })
+/run F.Units.Pinned.Layout(); F.Units.Pinned.Resolve()
+```
+
+Expected: slot 1 shows you; slot 2 shows focus if set (otherwise hidden).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Units/Pinned.lua
+git commit -m "feat(pinned): name-based unit resolver + combat deferral"
+git push
+```
+
+---
+
+## Task 4: `refreshOnUpdate` polling for `focustarget` and `nametarget`
+
+**Why now:** Without this, `focustarget` and `nametarget` slots show stale units — WoW fires no event when a unit's target changes.
+
+**Files:**
+- Modify: `Units/Pinned.lua`
+
+- [ ] **Step 1: Add polling infrastructure below the resolver helpers**
+
+```lua
+-- ============================================================
+-- Derived-unit polling
+-- WoW fires no event when a unit's target changes. Polls GUID of each
+-- polling slot at 0.2s intervals; fires RefreshUnit on change.
+-- ============================================================
+local POLL_INTERVAL = 0.2
+local pollFrame     = CreateFrame('Frame')
+local pollElapsed   = 0
+local lastGUIDs     = {}
+
+local function slotNeedsPolling(slot)
+	if(not slot) then return false end
+	if(slot.type == 'nametarget') then return true end
+	if(slot.type == 'unit' and slot.value == 'focustarget') then return true end
+	return false
+end
+
+local function onPollUpdate(_, elapsed)
+	pollElapsed = pollElapsed + elapsed
+	if(pollElapsed < POLL_INTERVAL) then return end
+	pollElapsed = 0
+
+	local config = F.Units.Pinned.GetConfig()
+	local frames = F.Units.Pinned.frames
+	if(not config or not frames) then return end
+	local slots = config.slots or {}
+
+	for i = 1, MAX_SLOTS do
+		local slot  = slots[i]
+		local frame = frames[i]
+		if(slotNeedsPolling(slot) and frame and frame.unit) then
+			local newGUID = UnitGUID(frame.unit)
+			if(newGUID ~= lastGUIDs[i]) then
+				lastGUIDs[i] = newGUID
+				if(frame.UpdateAllElements) then
+					frame:UpdateAllElements('RefreshUnit')
+				end
+			end
+		else
+			lastGUIDs[i] = nil
+		end
+	end
+end
+
+local function updatePolling()
+	local config = F.Units.Pinned.GetConfig()
+	if(not config or not config.enabled) then
+		pollFrame:SetScript('OnUpdate', nil)
+		return
+	end
+
+	local slots = config.slots or {}
+	for i = 1, MAX_SLOTS do
+		if(slotNeedsPolling(slots[i])) then
+			pollFrame:SetScript('OnUpdate', onPollUpdate)
+			return
+		end
+	end
+	pollFrame:SetScript('OnUpdate', nil)
+end
+F.Units.Pinned.UpdatePolling = updatePolling
+```
+
+- [ ] **Step 2: Call `updatePolling` at the end of `Resolve` and `Layout`**
+
+In `Resolve` — add after the slot loop:
+
+```lua
+	updatePolling()
+end
+```
+
+In `Layout` — add before the trailing `end`:
+
+```lua
+	updatePolling()
+end
+```
+
+- [ ] **Step 3: Syntax check + `/reload`**
+
+```bash
+luac -p /Users/josiahtoppin/Documents/Projects/Framed/Units/Pinned.lua
+```
+
+- [ ] **Step 4: Manual polling test**
+
+In a group:
+
+```
+/run F.Config:Set('presets.Party.unitConfigs.pinned.slots', { [1] = { type = 'nametarget', value = F.Units.Pinned.FullUnitName('player') } })
+/run F.Units.Pinned.Resolve()
+```
+
+Target various NPCs. Slot 1 should update within ~0.2s each time your target changes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Units/Pinned.lua
+git commit -m "feat(pinned): throttled OnUpdate for derived unit slots"
+git push
+```
+
+---
+
+## Task 5: Slot identity label
+
+**Why now:** Per spec, `nametarget` and `unit`-type slots need a dimmed label distinguishing them from direct name pins.
+
+**Files:**
+- Modify: `Units/Pinned.lua`
+
+- [ ] **Step 1: Add label creation in `Style`**
+
+Inside the `Style(self, unit)` function, after `F.StyleBuilder.Apply(...)`:
+
+```lua
+	if(not self.SlotIdentity) then
+		local fs = F.Widgets.CreateFontString(self, F.Constants.Font.sizeSmall, F.Constants.Colors.textSecondary)
+		fs:SetPoint('BOTTOM', self, 'TOP', 0, 2)
+		fs:SetAlpha(0.7)
+		self.SlotIdentity = fs
+	end
+```
+
+- [ ] **Step 2: Add `slotIdentityText` helper near the other helpers**
+
+```lua
+local function slotIdentityText(slot)
+	if(not slot) then return nil end
+	if(slot.type == 'nametarget') then
+		return (slot.value or '?') .. "'s Target"
+	elseif(slot.type == 'unit') then
+		if(slot.value == 'focus')       then return 'Focus'        end
+		if(slot.value == 'focustarget') then return 'Focus Target' end
+		return slot.value
+	end
+	return nil
+end
+```
+
+- [ ] **Step 3: Update label in `Resolve`**
+
+Inside the per-slot loop in `Resolve`, after `setFrameUnit(frame, token)`:
+
+```lua
+			if(frame.SlotIdentity) then
+				local labelText = slotIdentityText(slot)
+				if(labelText) then
+					frame.SlotIdentity:SetText(labelText)
+					frame.SlotIdentity:Show()
+				else
+					frame.SlotIdentity:Hide()
+				end
+			end
+```
+
+- [ ] **Step 4: Syntax check + `/reload` + manual test**
+
+Set slots [1] = name, [2] = nametarget, [3] = unit focus. Verify slot 1 has no label, slot 2 shows "Name's Target", slot 3 shows "Focus".
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Units/Pinned.lua
+git commit -m "feat(pinned): dimmed slot identity label"
+git push
+```
+
+---
+
+## Task 6: Empty-slot placeholders (non-secure overlays)
+
+**Why now:** Per spec, empty slots show a dashed-border "+ Click to assign" placeholder on hover. Plus: slot count N but only some assigned → users need to see where the inactive slots are so they can assign them without opening Settings.
+
+**Files:**
+- Modify: `Units/Pinned.lua`
+
+- [ ] **Step 1: Add placeholder creation**
+
+Below the `Layout` function in `Units/Pinned.lua`:
+
+```lua
+-- ============================================================
+-- Empty-slot placeholders
+-- Non-secure overlay frames shown when a slot is unassigned.
+-- Safe in combat (non-secure, no SetAttribute).
+-- ============================================================
+
+local function createPlaceholder(parent, slotIndex)
+	local ph = CreateFrame('Button', nil, parent, 'BackdropTemplate')
+	ph:SetFrameStrata('MEDIUM')
+	ph:SetBackdrop({
+		bgFile   = [[Interface\BUTTONS\WHITE8x8]],
+		edgeFile = [[Interface\BUTTONS\WHITE8x8]],
+		edgeSize = 1,
+	})
+	ph:SetBackdropColor(0.08, 0.08, 0.08, 0.6)
+	ph:SetBackdropBorderColor(0.4, 0.4, 0.4, 0.7)
+
+	local plus = F.Widgets.CreateFontString(ph, F.Constants.Font.sizeLarge, F.Constants.Colors.textSecondary)
+	plus:SetPoint('CENTER', ph, 'CENTER', 0, 4)
+	plus:SetText('+')
+
+	local hint = F.Widgets.CreateFontString(ph, F.Constants.Font.sizeSmall, F.Constants.Colors.textSecondary)
+	hint:SetPoint('BOTTOM', ph, 'BOTTOM', 0, 4)
+	hint:SetAlpha(0.7)
+	hint:SetText('Click to assign')
+
+	ph._slotIndex = slotIndex
+	ph:SetAlpha(0)  -- hidden until hover
+	ph:RegisterForClicks('LeftButtonUp')
+
+	ph:SetScript('OnEnter', function(self) self:SetAlpha(1) end)
+	ph:SetScript('OnLeave', function(self) self:SetAlpha(0) end)
+
+	ph:SetScript('OnClick', function(self)
+		if(F.Units.Pinned.OpenAssignmentMenu) then
+			F.Units.Pinned.OpenAssignmentMenu(self._slotIndex, self)
+		end
+	end)
+
+	return ph
+end
+```
+
+- [ ] **Step 2: Extend `Layout` to manage placeholders**
+
+Modify `F.Units.Pinned.Layout` — before the trailing `updatePolling()`:
+
+```lua
+	-- Manage placeholders for active but unassigned slots
+	F.Units.Pinned.placeholders = F.Units.Pinned.placeholders or {}
+	local phs = F.Units.Pinned.placeholders
+	local slots = config.slots or {}
+
+	for i = 1, MAX_SLOTS do
+		if(i <= count and not slots[i]) then
+			phs[i] = phs[i] or createPlaceholder(anchor, i)
+			local f = frames[i]
+			phs[i]:ClearAllPoints()
+			phs[i]:SetAllPoints(f)
+			F.Widgets.SetSize(phs[i], width, height)
+			phs[i]:Show()
+		elseif(phs[i]) then
+			phs[i]:Hide()
+		end
+	end
+```
+
+- [ ] **Step 3: Add a stub `OpenAssignmentMenu` that Task 8 will replace**
+
+At the bottom of the file (before event registration):
+
+```lua
+--- Placeholder: real implementation lives in Settings/Cards/Pinned.lua
+--- and attaches via F.Units.Pinned.OpenAssignmentMenu = ... on card load.
+--- When invoked before the card is loaded, print a hint.
+function F.Units.Pinned.OpenAssignmentMenu(slotIndex, anchorFrame)
+	print('|cff00ccffFramed|r Pinned: open /framed → Pinned to assign slot ' .. slotIndex)
+end
+```
+
+- [ ] **Step 4: Syntax check + `/reload`**
+
+Enable pinned on Party. Expected: 3 empty placeholders appear with dashed borders; hovering them fades them to full opacity; clicking prints the hint message.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Units/Pinned.lua
+git commit -m "feat(pinned): empty-slot placeholder overlays with click-to-assign"
+git push
+```
+
+---
+
+## Task 7: Hover gear icon on assigned pins (out-of-combat reassign affordance)
+
+**Why now:** Spec calls for right-click reassignment. See *Design Decisions Made During Planning #1* — we use a hover-activated gear icon to avoid colliding with click-casting `*type2` bindings.
+
+**Files:**
+- Modify: `Units/Pinned.lua`
+
+- [ ] **Step 1: Add gear-icon creation in `Style`**
+
+Inside `Style`, after the SlotIdentity block:
+
+```lua
+	if(not self.ReassignGear) then
+		local gear = CreateFrame('Button', nil, self)
+		gear:SetSize(14, 14)
+		gear:SetPoint('TOPRIGHT', self, 'TOPRIGHT', -2, -2)
+		gear:SetFrameLevel(self:GetFrameLevel() + 5)
+
+		local icon = gear:CreateTexture(nil, 'OVERLAY')
+		icon:SetAllPoints(gear)
+		icon:SetTexture(F.Media.GetIcon('Gear') or [[Interface\GossipFrame\BinderGossipIcon]])
+		gear._icon = icon
+
+		gear:SetAlpha(0)
+		gear:RegisterForClicks('LeftButtonUp')
+
+		-- Hide gear during combat
+		self:HookScript('OnEnter', function(frame)
+			if(InCombatLockdown()) then return end
+			if(frame._pinnedSlotIndex) then
+				gear:SetAlpha(0.8)
+			end
+		end)
+		self:HookScript('OnLeave', function()
+			gear:SetAlpha(0)
+		end)
+		gear:SetScript('OnEnter', function(self) self:SetAlpha(1) end)
+		gear:SetScript('OnLeave', function(self)
+			if(self:GetParent():IsMouseOver()) then self:SetAlpha(0.8) else self:SetAlpha(0) end
+		end)
+
+		gear:SetScript('OnClick', function(g)
+			local parent = g:GetParent()
+			if(parent._pinnedSlotIndex and F.Units.Pinned.OpenAssignmentMenu) then
+				F.Units.Pinned.OpenAssignmentMenu(parent._pinnedSlotIndex, parent)
+			end
+		end)
+
+		self.ReassignGear = gear
+	end
+```
+
+- [ ] **Step 2: Tag each frame with its slot index in `Spawn`**
+
+Inside the frame creation loop in `Spawn`:
+
+```lua
+		frame._pinnedSlotIndex = i
+```
+
+Place this line immediately after `frames[i] = frame`.
+
+- [ ] **Step 3: Hide gear when slot is unassigned (via `Resolve`)**
+
+Inside the per-slot loop in `Resolve`, after the SlotIdentity update:
+
+```lua
+			if(frame.ReassignGear) then
+				if(slot) then
+					-- Gear visible-on-hover; don't force show here
+				else
+					frame.ReassignGear:SetAlpha(0)
+				end
+			end
+```
+
+- [ ] **Step 4: Syntax check + `/reload` + manual test**
+
+With pinned enabled and slot 1 assigned: hover the frame → small gear appears top-right. Click gear → assignment menu opens (stub message for now; real menu arrives in Task 8). In combat: hover should NOT reveal gear.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Units/Pinned.lua
+git commit -m "feat(pinned): hover gear icon for reassignment (out of combat)"
+git push
+```
+
+---
+
+## Task 8: `Settings/Cards/Pinned.lua` — role-grouped dropdown + `OpenAssignmentMenu`
+
+**Why now:** Single file that implements BOTH the Settings-card per-slot list AND the `OpenAssignmentMenu` entry point used by Task 6 placeholders + Task 7 gear icons. DRY — one dropdown factory, two call sites.
+
+**Files:**
+- Create: `Settings/Cards/Pinned.lua`
+- Modify: `Framed.toc`
+
+- [ ] **Step 1: Create `Settings/Cards/Pinned.lua`**
+
+```lua
+local _, Framed = ...
+local F = Framed
+local Widgets = F.Widgets
+local C = F.Constants
+
+F.Settings       = F.Settings       or {}
+F.Settings.Cards = F.Settings.Cards or {}
+
+local MAX_SLOTS   = 9
+local ROLES       = { 'TANK', 'HEALER', 'DAMAGER' }
+local ROLE_LABELS = { TANK = 'Tanks', HEALER = 'Healers', DAMAGER = 'DPS' }
+
+-- ============================================================
+-- Helpers
+-- ============================================================
+
+local function classHex(classToken)
+	local c = classToken and RAID_CLASS_COLORS[classToken]
+	if(not c) then return 'ffffff' end
+	return ('%02x%02x%02x'):format(
+		math.floor(c.r * 255), math.floor(c.g * 255), math.floor(c.b * 255))
+end
+
+local function fullUnitName(token)
+	if(F.Units.Pinned and F.Units.Pinned.FullUnitName) then
+		return F.Units.Pinned.FullUnitName(token)
+	end
+	if(not UnitExists(token)) then return nil end
+	local name, realm = UnitName(token)
+	if(not name) then return nil end
+	if(realm and realm ~= '') then return name .. '-' .. realm end
+	return name
+end
+
+local function scanRoster()
+	local roster = {}
+	local function add(token)
+		if(not UnitExists(token)) then return end
+		roster[#roster + 1] = {
+			name  = fullUnitName(token),
+			token = token,
+			class = select(2, UnitClass(token)),
+			role  = UnitGroupRolesAssigned(token) or 'DAMAGER',
+		}
+	end
+	if(IsInRaid()) then
+		for i = 1, GetNumGroupMembers() do add('raid' .. i) end
+	elseif(IsInGroup()) then
+		for i = 1, GetNumGroupMembers() - 1 do add('party' .. i) end
+		add('player')
+	else
+		add('player')
+	end
+	return roster
+end
+
+local function assignedNames(slots, excludeIndex)
+	local set = {}
+	for i = 1, MAX_SLOTS do
+		if(i ~= excludeIndex) then
+			local s = slots[i]
+			if(s and (s.type == 'name' or s.type == 'nametarget') and s.value) then
+				set[s.value] = true
+			end
+		end
+	end
+	return set
+end
+
+-- ============================================================
+-- Dropdown decorators for headers (non-selectable rows)
+-- ============================================================
+
+local function headerDecorator(row, item)
+	row._label:SetTextColor(0.6, 0.6, 0.6, 1)
+	row:SetScript('OnEnter', function() end)
+	row:SetScript('OnLeave', function() end)
+	row:SetScript('OnMouseDown', function() end)  -- swallow clicks
+end
+
+local function classColorDecorator(classToken, indent)
+	local hex = classHex(classToken)
+	return function(row, item)
+		row._label:SetText(((indent and '    ') or '') .. item.text)
+		local r = tonumber(hex:sub(1, 2), 16) / 255
+		local g = tonumber(hex:sub(3, 4), 16) / 255
+		local b = tonumber(hex:sub(5, 6), 16) / 255
+		row._label:SetTextColor(r, g, b, 1)
+	end
+end
+
+-- ============================================================
+-- Build dropdown items
+-- ============================================================
+
+--- @param slotIndex number
+--- @return table items suitable for dropdown:SetItems
+local function buildItems(slotIndex)
+	local config = F.Units.Pinned.GetConfig() or {}
+	local slots  = config.slots or {}
+	local blocked = assignedNames(slots, slotIndex)
+
+	local items = {}
+
+	-- Unit References
+	items[#items + 1] = { text = '— Unit References —', value = '__hdr_unit', _decorateRow = headerDecorator }
+	items[#items + 1] = { text = 'Focus',        value = 'FOCUS' }
+	items[#items + 1] = { text = 'Focus Target', value = 'FOCUSTARGET' }
+
+	-- Role groups
+	local roster = scanRoster()
+	local byRole = { TANK = {}, HEALER = {}, DAMAGER = {} }
+	for _, p in next, roster do
+		local bucket = byRole[p.role] or byRole.DAMAGER
+		bucket[#bucket + 1] = p
+	end
+
+	for _, roleToken in next, ROLES do
+		local bucket = byRole[roleToken]
+		if(bucket and #bucket > 0) then
+			items[#items + 1] = {
+				text  = '— ' .. ROLE_LABELS[roleToken] .. ' —',
+				value = '__hdr_' .. roleToken,
+				_decorateRow = headerDecorator,
+			}
+			for _, p in next, bucket do
+				if(p.name and not blocked[p.name]) then
+					items[#items + 1] = {
+						text  = p.name,
+						value = 'NAME:' .. p.name,
+						_decorateRow = classColorDecorator(p.class, false),
+					}
+					items[#items + 1] = {
+						text  = p.name .. "'s Target",
+						value = 'TARGET:' .. p.name,
+						_decorateRow = classColorDecorator(p.class, true),
+					}
+				end
+			end
+		end
+	end
+
+	-- None
+	items[#items + 1] = { text = '— None —',  value = '__hdr_none', _decorateRow = headerDecorator }
+	items[#items + 1] = { text = '(Unassign)', value = 'UNASSIGN' }
+
+	return items
+end
+
+--- Convert stored slot config into a dropdown value string for SetValue.
+local function slotToValue(slot)
+	if(not slot) then return 'UNASSIGN' end
+	if(slot.type == 'unit' and slot.value == 'focus')       then return 'FOCUS' end
+	if(slot.type == 'unit' and slot.value == 'focustarget') then return 'FOCUSTARGET' end
+	if(slot.type == 'name')                                  then return 'NAME:' .. slot.value end
+	if(slot.type == 'nametarget')                            then return 'TARGET:' .. slot.value end
+	return 'UNASSIGN'
+end
+
+--- Convert dropdown value back to a stored slot config.
+local function valueToSlot(value)
+	if(value == 'UNASSIGN') then return nil end
+	if(value == 'FOCUS')       then return { type = 'unit', value = 'focus' } end
+	if(value == 'FOCUSTARGET') then return { type = 'unit', value = 'focustarget' } end
+	local name = value:match('^NAME:(.+)$')
+	if(name) then return { type = 'name', value = name } end
+	local tgtName = value:match('^TARGET:(.+)$')
+	if(tgtName) then return { type = 'nametarget', value = tgtName } end
+	return nil
+end
+
+--- Persist a slot selection.
+local function persistSlot(slotIndex, value)
+	local presetName = F.PresetManager.GetActive()
+	if(not presetName) then return end
+	local path = 'presets.' .. presetName .. '.unitConfigs.pinned.slots.' .. slotIndex
+	F.Config:Set(path, valueToSlot(value))
+	F.PresetManager.MarkCustomized(presetName)
+end
+
+-- ============================================================
+-- Open assignment menu (detached dropdown anchored to a frame)
+-- Used by Task 6 placeholders and Task 7 gear icons.
+-- ============================================================
+
+local detachedDropdown
+
+function F.Units.Pinned.OpenAssignmentMenu(slotIndex, anchorFrame)
+	if(InCombatLockdown()) then
+		print('|cff00ccffFramed|r Pinned: cannot reassign during combat')
+		return
+	end
+
+	if(not detachedDropdown) then
+		detachedDropdown = Widgets.CreateDropdown(UIParent, 200)
+		detachedDropdown:SetFrameStrata('DIALOG')
+	end
+
+	detachedDropdown:ClearAllPoints()
+	detachedDropdown:SetPoint('TOP', anchorFrame, 'BOTTOM', 0, -2)
+	detachedDropdown:SetItems(buildItems(slotIndex))
+
+	local config = F.Units.Pinned.GetConfig() or {}
+	local slots  = config.slots or {}
+	detachedDropdown:SetValue(slotToValue(slots[slotIndex]))
+
+	detachedDropdown:SetOnSelect(function(value)
+		if(type(value) == 'string' and value:sub(1, 5) == '__hdr') then return end
+		persistSlot(slotIndex, value)
+	end)
+
+	detachedDropdown:Show()
+	if(detachedDropdown.Open) then detachedDropdown:Open() end
+end
+
+-- ============================================================
+-- Settings card (per-slot list)
+-- ============================================================
+
+local function renderSlotRow(parent, slotIndex, yOffset)
+	local row = CreateFrame('Frame', nil, parent)
+	row:SetSize(500, 28)
+	row:SetPoint('TOPLEFT', parent, 'TOPLEFT', 0, yOffset)
+
+	local label = Widgets.CreateFontString(row, C.Font.sizeNormal, C.Colors.textPrimary)
+	label:SetPoint('LEFT', row, 'LEFT', 0, 0)
+	label:SetText('Slot ' .. slotIndex)
+	label:SetWidth(60)
+
+	local dd = Widgets.CreateDropdown(row, 320)
+	dd:ClearAllPoints()
+	dd:SetPoint('LEFT', label, 'RIGHT', 12, 0)
+
+	local function refresh()
+		dd:SetItems(buildItems(slotIndex))
+		local config = F.Units.Pinned.GetConfig() or {}
+		local slots  = config.slots or {}
+		dd:SetValue(slotToValue(slots[slotIndex]))
+	end
+
+	dd:SetOnSelect(function(value)
+		if(type(value) == 'string' and value:sub(1, 5) == '__hdr') then
+			refresh()
+			return
+		end
+		persistSlot(slotIndex, value)
+		refresh()
+	end)
+
+	refresh()
+	row._refresh = refresh
+	return row
+end
+
+function F.Settings.Cards.Pinned(parent, width)
+	local card, inner = Widgets.StartCard(parent, width, 0)
+
+	local title = Widgets.CreateFontString(inner, C.Font.sizeNormal, C.Colors.textActive)
+	title:SetPoint('TOPLEFT', inner, 'TOPLEFT', 0, -4)
+	title:SetText('Slot Assignments')
+
+	local rows = {}
+	local function rebuild()
+		for _, r in next, rows do r:Hide(); r:SetParent(nil) end
+		rows = {}
+		local config = F.Units.Pinned.GetConfig()
+		if(not config) then return end
+		local count = math.max(1, math.min(config.count or 3, MAX_SLOTS))
+
+		local y = -28
+		for i = 1, count do
+			rows[i] = renderSlotRow(inner, i, y)
+			y = y - 32
+		end
+
+		Widgets.EndCard(card, parent, y)
+	end
+
+	rebuild()
+
+	F.EventBus:Register('CONFIG_CHANGED', function(path)
+		if(not path) then return end
+		if(path:match('unitConfigs%.pinned%.count$') or path:match('unitConfigs%.pinned%.slots')) then
+			rebuild()
+		end
+	end, 'PinnedCard.' .. tostring(card) .. '.CC')
+
+	F.EventBus:Register('GROUP_ROSTER_UPDATE', rebuild, 'PinnedCard.' .. tostring(card) .. '.Roster')
+
+	return card
+end
+```
+
+- [ ] **Step 2: Register in `Framed.toc`**
+
+After `Settings/Cards/` entries (or wherever unit-type cards live — match the load-after-Units pattern), add:
+
+```
+Settings/Cards/Pinned.lua
+```
+
+- [ ] **Step 3: Syntax check**
+
+```bash
+luac -p /Users/josiahtoppin/Documents/Projects/Framed/Settings/Cards/Pinned.lua
+```
+
+Expected: no output.
+
+- [ ] **Step 4: `/reload` + test the detached assignment menu**
+
+Enable pinned on Party preset. Click an empty-slot placeholder → dropdown appears below the placeholder with role groups. Select a teammate → frame populates. Hover an assigned pin → gear appears. Click gear → dropdown reopens with current selection highlighted.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Settings/Cards/Pinned.lua Framed.toc
+git commit -m "feat(pinned): role-grouped assignment dropdown for card + in-world"
+git push
+```
+
+---
+
+## Task 9: Extend `FrameSettingsBuilder` for `pinned`; register Pinned panel
+
+**Why now:** The Settings sidebar needs a "Pinned" entry under Frames that renders the shared style cards + the slot assignment card.
+
+**Files:**
+- Modify: `Settings/FrameSettingsBuilder.lua`
+- Create: `Settings/Panels/Pinned.lua`
+- Modify: `Framed.toc`
+
+- [ ] **Step 1: Audit `FrameSettingsBuilder.lua` for unit-type tables and branches**
+
+Open `Settings/FrameSettingsBuilder.lua`. Search for string equality against unit-type literals (`'party'`, `'raid'`, `'arena'`, `'boss'`). For each, decide whether pinned behaves identically. In general pinned behaves as a group type.
+
+Specifically, look for:
+- A `GROUP_TYPES` table — add `pinned = true`
+- A `GROUP_COUNTS` table — add `pinned = 9`
+- Preview-frame spawning logic that switches on unit type — add a `pinned` branch (use multi-frame preview like party/raid)
+- Per-card inclusion gates (e.g., "include spacing card only for groups") — verify pinned is in the inclusion set
+
+- [ ] **Step 2: Append slot assignment card into the pinned panel's CardGrid**
+
+Find the function that adds cards to the grid for a given unit type (likely a `for ... addCard ...` loop or a `CARDS_FOR_UNIT_TYPE` table). Add pinned's slot assignment card either by:
+
+**(a)** Extending a `CARDS_FOR_UNIT_TYPE` table:
+
+```lua
+CARDS_FOR_UNIT_TYPE = {
+	...,
+	pinned = { 'slot-assignments', 'Slot Assignments', F.Settings.Cards.Pinned },
+}
+```
+
+**(b)** Or by adding a branch after the standard cards are added:
+
+```lua
+if(unitType == 'pinned' and F.Settings.Cards.Pinned) then
+	grid:AddCard('slot-assignments', 'Slot Assignments', F.Settings.Cards.Pinned, {})
+end
+```
+
+Use whichever pattern matches the existing file's style.
+
+- [ ] **Step 3: Create `Settings/Panels/Pinned.lua`**
+
+```lua
+local _, Framed = ...
+local F = Framed
+
+F.Settings.RegisterPanel({
+	id       = 'pinned',
+	label    = 'Pinned',
+	section  = 'PRESET_SCOPED',
+	unitType = 'pinned',
+	order    = 65,
+	create   = function(parent)
+		return F.FrameSettingsBuilder.Create(parent, 'pinned')
+	end,
+})
+```
+
+- [ ] **Step 4: Register in `Framed.toc`**
+
+After `Settings/Panels/Boss.lua`:
+
+```
+Settings/Panels/Pinned.lua
+```
+
+- [ ] **Step 5: Syntax check**
+
+```bash
+luac -p /Users/josiahtoppin/Documents/Projects/Framed/Settings/Panels/Pinned.lua
+luac -p /Users/josiahtoppin/Documents/Projects/Framed/Settings/FrameSettingsBuilder.lua
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Scenario tests**
+
+- Solo preset active → `/framed` → sidebar has no "Pinned" entry.
+- Party preset active → `/framed` → sidebar shows "Pinned". Open it → preview, summary, sliders for count/columns/spacing, standard style cards, and the slot assignment card.
+- Change count slider 3 → 9 → slot assignment card rebuilds to show 9 rows. Frames in-world reflow to a 3x3 (columns default 3).
+- Assign slot 1 → in-world frame shows teammate.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Settings/FrameSettingsBuilder.lua Settings/Panels/Pinned.lua Framed.toc
+git commit -m "feat(pinned): register Pinned settings panel with slot assignment card"
+git push
+```
+
+---
+
+## Task 10: `FrameConfigPinned.lua` — LiveUpdate + PRESET_CHANGED handler
+
+**Why now:** Without this, settings-panel changes require `/reload`, and preset switching doesn't re-layout pinned frames.
+
+**Files:**
+- Create: `Units/LiveUpdate/FrameConfigPinned.lua`
+- Modify: `Framed.toc`
+
+- [ ] **Step 1: Create `Units/LiveUpdate/FrameConfigPinned.lua`**
+
+```lua
+local _, Framed = ...
+local F = Framed
+
+local Shared = F.LiveUpdate and F.LiveUpdate.FrameConfigShared
+if(not Shared) then return end
+
+local guardConfigChanged = Shared.guardConfigChanged
+local debouncedApply     = Shared.debouncedApply
+
+-- ============================================================
+-- CONFIG_CHANGED: per-key routing
+-- ============================================================
+
+local function onConfigChanged(path)
+	local unitType, key = guardConfigChanged(path)
+	if(unitType ~= 'pinned') then return end
+
+	if(key == 'position.x' or key == 'position.y' or key == 'position.anchor') then
+		F.Units.Pinned.ApplyPosition()
+	elseif(key == 'enabled' or key == 'count' or key == 'columns'
+	    or key == 'width' or key == 'height' or key == 'spacing') then
+		debouncedApply('pinned.layout', function()
+			F.Units.Pinned.Layout()
+			F.Units.Pinned.Resolve()
+		end)
+	elseif(key and key:match('^slots')) then
+		F.Units.Pinned.Resolve()
+		F.Units.Pinned.Layout()  -- placeholders toggle
+	else
+		-- Shared style change: re-apply StyleBuilder to live frames
+		debouncedApply('pinned.style', function()
+			local config = F.Units.Pinned.GetConfig()
+			local frames = F.Units.Pinned.frames
+			if(not config or not frames) then return end
+			for i = 1, 9 do
+				local f = frames[i]
+				if(f) then
+					F.StyleBuilder.Apply(f, config, 'pinned')
+					if(f.UpdateAllElements) then f:UpdateAllElements('RefreshStyle') end
+				end
+			end
+		end)
+	end
+end
+F.EventBus:Register('CONFIG_CHANGED', onConfigChanged, 'FrameConfigPinned.CC')
+
+-- ============================================================
+-- PRESET_CHANGED: full re-apply
+-- ============================================================
+
+F.EventBus:Register('PRESET_CHANGED', function()
+	F.Units.Pinned.ApplyPosition()
+	F.Units.Pinned.Layout()
+	F.Units.Pinned.Resolve()
+end, 'FrameConfigPinned.PresetChanged')
+```
+
+- [ ] **Step 2: Register in `Framed.toc`**
+
+After `Units/LiveUpdate/FrameConfigLayout.lua`:
+
+```
+Units/LiveUpdate/FrameConfigPinned.lua
+```
+
+- [ ] **Step 3: Syntax check + `/reload`**
+
+```bash
+luac -p /Users/josiahtoppin/Documents/Projects/Framed/Units/LiveUpdate/FrameConfigPinned.lua
+```
+
+- [ ] **Step 4: LiveUpdate tests**
+
+- Change columns slider → frames reflow within ~50ms.
+- Change `enabled` toggle → frames appear/disappear live.
+- Assign slot in Settings card → frame populates without `/reload`.
+
+- [ ] **Step 5: Preset switch test**
+
+With pinned enabled on Party (3 frames assigned), switch to Raid preset (`/framed` → preset dropdown). Raid's pinned defaults to disabled → frames hide. Switch back to Party → frames reappear with Party's assignments.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Units/LiveUpdate/FrameConfigPinned.lua Framed.toc
+git commit -m "feat(pinned): LiveUpdate + PRESET_CHANGED handler"
+git push
+```
+
+---
+
+## Task 11: EditMode integration — `FRAME_KEYS` entry + click-to-configure
+
+**Why now:** Users need drag-to-position and click-in-edit-mode-to-open-settings, matching other Framed unit types.
+
+**Files:**
+- Modify: `EditMode/EditMode.lua`
+
+- [ ] **Step 1: Add `FRAME_KEYS` entry**
+
+Open `EditMode/EditMode.lua`. Locate `FRAME_KEYS` (lines 37-47). Add after the `arena` entry:
+
+```lua
+{ key = 'pinned', label = 'Pinned Frames', isGroup = true,
+  getter = function() return F.Units.Pinned and F.Units.Pinned.anchor end },
+```
+
+- [ ] **Step 2: Audit the inline-settings click hook**
+
+Search `EditMode/EditMode.lua` for where clicking a frame in edit mode opens the inline settings panel. This may be:
+- A generic `OnClick` hook applied to every registered frame via `FRAME_KEYS`
+- A per-unit-type hook registered elsewhere
+
+If it's generic (uses the `FRAME_KEYS` getter), pinned works automatically once Step 1 lands. If it's per-unit-type, add a branch for pinned that opens `/framed` → Pinned panel (`F.Settings.Toggle` + `F.Settings.SetActivePanel('pinned')`).
+
+- [ ] **Step 3: Verify drag persistence writes to `unitConfigs.pinned.position.x/y`**
+
+Trace the EditMode drag handler's config-write path. Confirm it writes to `presets.<active>.unitConfigs.<key>.position.*` where `<key>` comes from the `FRAME_KEYS` entry. If so, pinned inherits persistence automatically.
+
+- [ ] **Step 4: Syntax check + `/reload`**
+
+```bash
+luac -p /Users/josiahtoppin/Documents/Projects/Framed/EditMode/EditMode.lua
+```
+
+- [ ] **Step 5: EditMode tests**
+
+- `/framed edit` → "Pinned Frames" drag handle appears over the pinned grid.
+- Drag the handle → grid moves. Exit edit mode → `/reload` → position persists.
+- Click a pinned frame in edit mode → inline settings panel opens showing the Pinned panel's shared style cards + the slot assignment card (if Step 2 is generic) OR the Pinned settings tab (if Step 2 requires per-unit-type wiring).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add EditMode/EditMode.lua
+git commit -m "feat(pinned): EditMode integration + click-to-configure"
+git push
+```
+
+---
+
+## Task 12: Auras panel — register `pinned` in `Settings._getUnitTypeItems()`
+
+**Why now:** This is the single change that makes pinned appear as a selectable unit type across ALL 10 aura sub-panels (Buffs, Debuffs, Defensives, Dispels, Externals, MissingBuffs, PrivateAuras, TargetedSpells, LossOfControl, CrowdControl). Each aura panel already dispatches on `Settings.GetEditingUnitType()` — they need no per-panel modification.
+
+**Files:**
+- Modify: `Settings/Framework.lua`
+
+- [ ] **Step 1: Extend `Settings._getUnitTypeItems` to append pinned when available**
+
+Open `Settings/Framework.lua`. Find `Settings._getUnitTypeItems` (line 104). Currently:
+
+```lua
+function Settings._getUnitTypeItems()
+	local presetName = Settings.GetEditingPreset()
+	local info = C.PresetInfo[presetName]
+	local items = {
+		{ text = 'Player',           value = 'player' },
+		...
+	}
+	if(info and info.groupKey) then
+		items[#items + 1] = { text = info.groupLabel, value = info.groupKey }
+	end
+	return items
+end
+```
+
+After the existing `groupKey` append, add:
+
+```lua
+	-- Pinned appears as an additional group-tier unit type whenever the
+	-- active preset has an auras.pinned block (which Solo lacks).
+	if(presetName and F.Config and F.Config:Get('presets.' .. presetName .. '.auras.pinned')) then
+		items[#items + 1] = { text = 'Pinned Frames', value = 'pinned' }
+	end
+	return items
+end
+```
+
+- [ ] **Step 2: Verify aura panels route through this function**
+
+Open `Settings/Panels/Buffs.lua:210` — `local unitType = F.Settings.GetEditingUnitType()` — and `makeConfigHelpers(unitType)` builds the path `presets.<preset>.auras.<unitType>.buffs.indicators`. So when `unitType = 'pinned'`, the path becomes `presets.Party.auras.pinned.buffs.indicators`, which matches the defaults registered in Task 1. **No per-panel modification required.**
+
+Sanity-check one other panel (e.g., `Settings/Panels/Defensives.lua`) — confirm the same pattern.
+
+- [ ] **Step 3: Syntax check + `/reload`**
+
+```bash
+luac -p /Users/josiahtoppin/Documents/Projects/Framed/Settings/Framework.lua
+```
+
+- [ ] **Step 4: Scenario test**
+
+- Party preset active → `/framed` → Auras → Buffs → unit-type dropdown shows: Player, Target, Target of Target, Focus, Pet, Boss, **Party Frames**, **Pinned Frames**.
+- Select Pinned Frames → buffs indicators for pinned render and dispatch correctly.
+- Assign a pin, apply a buff to that player → buff shows on the pinned frame.
+- Switch to Solo preset → Auras → Buffs → "Pinned Frames" is absent (no `auras.pinned` in Solo).
+
+- [ ] **Step 5: Aura live-update test**
+
+With a pin assigned, in the Auras → Debuffs panel for Pinned Frames, enable a new indicator. Verify it appears on the pinned frame without `/reload`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Settings/Framework.lua
+git commit -m "feat(pinned): register pinned as aura unit type in all aura panels"
+git push
+```
+
+---
+
+## Task 13: StyleBuilder verification + frame tagging audit
+
+**Why now:** Pinned frames are tagged `_framedUnitType = 'pinned'` (Task 2 Step 1). The generic `FrameConfigPreset` handler at `Units/LiveUpdate/FrameConfigPreset.lua:460` iterates `oUF.objects` by `_framedUnitType` and calls `F.StyleBuilder.GetConfig(unitType)`. If StyleBuilder doesn't know `pinned`, this path silently no-ops.
+
+**Files:**
+- Audit: `Units/StyleBuilder.lua`
+- Audit: `Units/LiveUpdate/FrameConfigPreset.lua`
+
+- [ ] **Step 1: Verify `F.StyleBuilder.GetConfig('pinned')` returns the pinned config**
+
+Open `Units/StyleBuilder.lua`. Search for `GetConfig`. Confirm it reads `F.Config:Get('presets.' .. active .. '.unitConfigs.' .. unitType)` — i.e., unit-type-agnostic. If so, pinned works automatically.
+
+If `GetConfig` has a unit-type switch/whitelist, add `pinned`.
+
+- [ ] **Step 2: Verify `F.StyleBuilder.GetAuraConfig('pinned', key)` works**
+
+Search for `GetAuraConfig`. Confirm it reads `presets.<active>.auras.<unitType>.<key>`. Because Task 1 added `auras.pinned`, this should work without modification.
+
+- [ ] **Step 3: Verify `F.StyleBuilder.Apply(frame, config, 'pinned')` from Task 2 Style function works**
+
+Search for `StyleBuilder.Apply`. Confirm the third arg (unit type) doesn't gate element setup by a whitelist. If it does, add `pinned` to the whitelist.
+
+- [ ] **Step 4: Verify `FrameConfigPreset.lua` aura loop handles `pinned`**
+
+Read `Units/LiveUpdate/FrameConfigPreset.lua:473-492`. The loop uses `auraUnitType = unitType` for non-partypet frames, then reads `F.StyleBuilder.GetAuraConfig(auraUnitType, aura.key)`. Since pinned has `auras.pinned` in the preset and `_framedUnitType = 'pinned'` on the frame, this loop handles pinned without modification.
+
+- [ ] **Step 5: If any Step 1-3 audit found gaps, commit the fix**
+
+If no gaps found: no commit. If gaps: one focused commit per gap.
+
+---
+
+## Task 14: Edge case verification sweep
+
+**Why now:** Walk through every edge case in the spec and confirm behavior before declaring feature-complete.
+
+**Files:**
+- None (audit only; any fixes get their own focused commits)
+
+- [ ] **Step 1: Player leaves group**
+
+In a party with slot 1 pinned to a teammate, have them leave. Expected: `GROUP_ROSTER_UPDATE` → `Resolve` → `findUnitForName` returns nil → frame hides via `RegisterUnitWatch`. Rejoining restores the pin.
+
+- [ ] **Step 2: Preset switch with combat lockdown**
+
+Enter combat. In combat, trigger a preset switch (via AutoSwitch or manual). Expected: `PRESET_CHANGED` handler fires, `Resolve` hits `InCombatLockdown` → queues `pendingResolve = true`. On `PLAYER_REGEN_ENABLED`, resolve runs with the new preset's assignments.
+
+- [ ] **Step 3: Empty group**
+
+Solo with Party preset active, pinned enabled, slot 1 = name, slot 2 = focus. Expected: slot 1 hides, slot 2 still works if focus exists.
+
+- [ ] **Step 4: Slot count reduced**
+
+count = 9 → 3. Slots 4-9 hide. Raising back → they restore.
+
+- [ ] **Step 5: Role change**
+
+In party, teammate changes spec/role. Open a dropdown → they appear under the new role group on next open (roster is rescanned on every open).
+
+- [ ] **Step 6: Feature disabled**
+
+Toggle `enabled = false`. All frames and placeholders hide. Polling stops.
+
+- [ ] **Step 7: Cross-realm**
+
+In a cross-realm group, confirm `fullUnitName` returns `'Name-Realm'` format, dropdown displays that format, and stored slot value matches scanner output.
+
+- [ ] **Step 8: Connected-realm**
+
+Connected-realm teammates return `realm = nil` from `UnitName`. Storage format is short name. Scanner matches short name. No change needed.
+
+- [ ] **Step 9: Duplicate prevention**
+
+Assign slot 1 = Bob (name). Open slot 2 dropdown → Bob's name is absent from the role list. Unassign slot 1 → open slot 2 → Bob reappears.
+
+- [ ] **Step 10: Taint check**
+
+With pinned enabled and assigned, enter combat (training dummy). Verify no Lua errors, no taint warnings in chat. Keep BugSack or equivalent open for visibility.
+
+- [ ] **Step 11: If any check fails**
+
+Commit a focused fix per failure, e.g., `fix(pinned): duplicate filter missed cross-realm suffix`. Do not bundle multiple fixes.
+
+---
+
+## Task 15: CHANGELOG + final integration pass
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Golden path manual test**
+
+1. Fresh WoW session, `/reload`
+2. `/framed` → Settings → Party preset → Pinned panel → enable toggle on
+3. Assign slot 1 = self, slot 2 = self's target, slot 3 = Focus
+4. Verify 3 frames visible and tracking
+5. Columns slider 3 → 1 → 3, live reflow
+6. `/framed edit` → drag grid → exit → `/reload` → position persists
+7. Auras → Buffs → Pinned Frames → add an indicator, verify it renders
+8. Enter combat briefly, verify no taint
+9. Switch to Raid preset, verify separate config
+10. Switch to Solo, verify Pinned panel and aura entry both absent
+11. Hover an empty slot → placeholder fades in, click → dropdown opens
+12. Hover an assigned pin → gear icon appears, click → dropdown opens
+13. Unassign via dropdown → slot returns to placeholder state
+
+- [ ] **Step 2: Update `CHANGELOG.md`**
+
+Add at the top of `CHANGELOG.md` (per `feedback_release_changelog.md`: update CHANGELOG before any TOC bump):
+
+```markdown
+## [Unreleased]
+
+### Added
+- **Pinned Frames** — up to 9 standalone frames that track specific group members by name. Follows players across roster reshuffles. Supports Focus / Focus Target / name-target slots. Role-grouped class-colored assignment dropdown (Settings card, in-world placeholder click, and hover-gear icon). Full aura configuration as a first-class unit type. Per-preset; absent in Solo.
+```
+
+- [ ] **Step 3: Final commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(pinned): changelog entry"
+git push
+```
+
+- [ ] **Step 4: Open PR from `working-testing` to `main`**
+
+Per `feedback_git_workflow.md`: worktree → working → main via GitHub PR. No TOC bump or tag — that's the user's release workflow.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec Section | Task(s) |
+|---|---|
+| Data model | 1 |
+| Frame spawning | 2 |
+| Name-based resolution | 3 |
+| Name-target resolution | 3, 4 |
+| Static token resolution | 3 |
+| Combat deferral | 3, 14 |
+| Grid layout | 2 |
+| EditMode integration (FRAME_KEYS + inline settings) | 11 |
+| LiveUpdate | 10 |
+| Role-grouped dropdown with class colors, duplicate filter | 8 |
+| Frame interaction (empty placeholders + assigned gear) | 6, 7 |
+| Aura configuration (first-class unit type) | 1, 12 |
+| Slot identity label | 5 |
+| Cross-realm handling | 3, 14 |
+| OnUpdate throttle | 4 |
+| Settings card | 8, 9 |
+| Edge cases (all 6) | 14 |
+| File surface (all 9 files) | All |
+
+**Type consistency:**
+- Slot shape: `{ type = 'name'|'nametarget'|'unit', value = <string> }` everywhere.
+- Dropdown value encoding: `'UNASSIGN' | 'FOCUS' | 'FOCUSTARGET' | 'NAME:<name>' | 'TARGET:<name>' | '__hdr_*'`. `valueToSlot`/`slotToValue` are the only converters.
+- Function names stable: `F.Units.Pinned.{GetConfig, Layout, Resolve, ApplyPosition, UpdatePolling, OpenAssignmentMenu, FullUnitName, FindUnitForName}`.
+- `MAX_SLOTS = 9` is duplicated in `Units/Pinned.lua` and `Settings/Cards/Pinned.lua` (intentional — avoids load-order dependency).
+- Frame tag: `_framedUnitType = 'pinned'` set in `Style`, consumed by `FrameConfigPreset.lua:462` generic handler.
+
+**Known audit-required points (flagged in tasks, not failures):**
+- Task 9 Step 1: `FrameSettingsBuilder` unit-type branches — exact table names vary, engineer matches real code.
+- Task 11 Step 2: EditMode click-to-configure — may already be generic (via `FRAME_KEYS.getter`) or may need per-unit-type wiring.
+- Task 13: StyleBuilder could be unit-type-agnostic (no change) or have a whitelist (add `pinned`).
+
+**Design decision deviations** (documented in "Design Decisions Made During Planning"):
+1. Right-click reassign → hover gear icon (avoids click-cast conflict).
+2. Empty-slot placeholders are non-secure (combat-safe).
+3. EditMode click-to-configure delegates to the `FRAME_KEYS`/inline-settings generic path if it exists.
+
+**No placeholders, TBDs, or "implement later"**. Every code step shows the code. Where audit is required, the task says so explicitly.


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                  

  Promotes 28 commits from `working-testing`, headlined by the new **Pinned Frames** feature.                                                                                                   
   
  ## What's new                                                                                                                                                                                 
                                                                                                                                                                                              
  ### Pinned Frames
  Up to 9 standalone frames that track specific group members by name and follow them across roster reshuffles. Supports Focus, Focus Target, and name-target slot types. Per-preset (absent in
  Solo).                                                                                                                                                                                        
   
  - Role-grouped, class-colored assignment dropdown — available from the Settings card, from empty-slot placeholder clicks, and from a hover-gear icon on assigned pins (out of combat)         
  - Dedicated Settings panel with master enable toggle, inline slot assignment, and LiveUpdate routing so edits apply without `/reload`                                                       
  - Empty-slot placeholders render a dimmed identity label (Pin 1 … Pin 9) and act as click targets for assignment                                                                              
  - First-class aura configuration across all 10 aura sub-panels (registered as a unit type)                                                                                                    
  - EditMode integration — drag to position (CENTER anchor convention), click in edit mode to open the inline panel, sidebar entry hides when the active preset has no `pinnedConfig`           
                                                                                                                                                                                                
  ### FramePreview                                                                                                                                                                              
  - Pinned grid now renders alongside the other unit types in previews                                                                                                                          
  - Name-tag position reads from `statusText.position` instead of stale anchor keys that caused drift                                                                                           
                                                                                                                                                                                                
  ### EventBus                                                                                                                                                                                  
  - Bridges `PLAYER_REGEN_ENABLED`, so combat-flush listeners can register via `F.EventBus:Register` instead of rolling their own event frames                                                  
                                                                                                                                                                                                
  ### Internal                                                                                                                                                                                  
  - Drop Cell references from in-code comments (licensing hygiene — Cell is ARR)                                                                                                                
  - Drop defensive `SettingsCards.Pinned` existence guard for idiom consistency                                                                                                                 
  - Collapse empty stub branches in the pinned gear-icon path                                                                                                                                   
   