### PR TITLE
 Release v0.8.11-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## [Unreleased]
 
-- **Pinned Frames** — up to 9 standalone frames that track specific group members by name, following players across roster reshuffles. Supports Focus / Focus Target / name-target slots. Role-grouped class-colored assignment dropdown (Settings card, empty-slot placeholder click, and hover-gear icon on assigned pins). First-class aura configuration across all 10 aura sub-panels. Per-preset; absent in Solo
-- EditMode integration for Pinned Frames — drag to position (CENTER anchor convention matches the settings panel), click in edit mode to open the inline Pinned panel
-- Bridge `PLAYER_REGEN_ENABLED` through `EventBus` so combat-deferred listeners can register via `F.EventBus:Register` instead of maintaining their own frames
+## v0.8.11-alpha
+
+- **Pinned Frames** — up to 9 standalone frames that track specific group members by name, following players across roster reshuffles. Supports Focus / Focus Target / name-target slots. Role-grouped class-colored assignment dropdown available from the Settings card, empty-slot placeholder click, and a hover-gear icon on assigned pins (out of combat). First-class aura configuration across all 10 aura sub-panels. Per-preset; absent in Solo
+- Pinned Frames Settings panel with master enable toggle in the preview card, inline slot assignment, and live-update routing so edits apply without `/reload`
+- EditMode integration for Pinned Frames — drag to position (CENTER anchor convention matches the settings panel), click in edit mode to open the inline Pinned panel, hide from the sidebar when the active preset has no `pinnedConfig`
+- Empty-slot placeholders render a dimmed identity label (Pin 1 … Pin 9) and become clickable targets for assignment; placeholder mouse-handling is gated so hidden gear icons don't swallow clicks
+- **FramePreview** now renders the pinned grid alongside the other unit types, and uses `statusText.position` consistently instead of stale anchor keys that caused name tags to drift in the preview
+- Bridge `PLAYER_REGEN_ENABLED` through `EventBus` so combat-flush listeners can register via `F.EventBus:Register` instead of maintaining their own event frames
+- Fix pinned gear icon rendering larger on resolved frames than on unresolved (placeholder) frames at non-1.0 UIParent scales — live-frame gears now counter-scale to match the placeholder gear's physical size
+- Fix `attempt to perform arithmetic on local 'x' (a nil value)` crash in `FrameConfigText.lua` when toggling Health → Attach to name off. The Health element wasn't recording detached anchor values at setup when the text was created attached, so the live toggle had no coordinates to restore to
+- Internal cleanup: drop Cell references from in-code comments (licensing hygiene — Cell is ARR), remove the defensive `SettingsCards.Pinned` existence guard for idiom consistency, collapse empty stub branches in the pinned gear-icon path
 
 ## v0.8.10-alpha
 

--- a/Elements/Core/Name.lua
+++ b/Elements/Core/Name.lua
@@ -98,13 +98,25 @@ function F.Elements.Name.Setup(self, config)
 	-- untruncated long name (visibly spilling past the frame, especially
 	-- on narrow pinned frames). SetWordWrap(false) + a bounded width makes
 	-- the renderer append '...' on every SetText regardless of caller.
+	--
+	-- Bounded width is skipped in attach-to-name mode: StyleBuilder anchors
+	-- Health.text to Name's RIGHT edge and Health.PostUpdate shifts the
+	-- pair left to center them. A fixed-width Name FontString with default
+	-- JustifyH='CENTER' renders as a wide box with the name parked in the
+	-- middle, which puts the Health text at the far-right frame edge and
+	-- defeats the centering shift. SetWidth(0) releases the constraint so
+	-- the FontString tracks its text content width.
 	nameText:SetWordWrap(false)
 	local function updateNameWidth()
 		local w = self:GetWidth() or 0
-		if(w > 8) then
+		if(w <= 8) then return end
+		if(self.Health and self.Health._attachedToName) then
+			nameText:SetWidth(0)
+		else
 			nameText:SetWidth(w - 8)
 		end
 	end
+	self._updateNameWidth = updateNameWidth
 	updateNameWidth()
 	self:HookScript('OnSizeChanged', updateNameWidth)
 

--- a/Framed.toc
+++ b/Framed.toc
@@ -2,7 +2,7 @@
 ## Title: Framed
 ## Notes: Modern, customizable unit frames and raid frames
 ## Author: Moodibs
-## Version: 0.8.10-alpha
+## Version: 0.8.11-alpha
 ## X-Curse-Project-ID: 1513359
 ## SavedVariables: FramedDB, FramedBackupDB, FramedSnapshotsDB
 ## SavedVariablesPerCharacter: FramedCharDB

--- a/Presets/Defaults.lua
+++ b/Presets/Defaults.lua
@@ -413,7 +413,6 @@ local function soloUnitAuras()
 		focus        = A.Solo(14, 6),
 		pet          = A.Minimal(),
 		boss         = A.Boss(),
-		pinned       = A.Minimal(),
 	}
 end
 
@@ -425,6 +424,9 @@ function F.PresetDefaults.GetAll()
 	local presets = {}
 
 	-- Solo
+	-- Note: no `pinned` block — pinned frames are a group-only feature. The
+	-- sidebar / EditMode / Spawn paths gate on the presence of unitConfigs.pinned,
+	-- so omitting it here hides pinned entirely while Solo is the editing preset.
 	presets['Solo'] = {
 		isBase    = true,
 		positions = {},
@@ -435,7 +437,6 @@ function F.PresetDefaults.GetAll()
 			focus        = focusConfig(),
 			pet          = petConfig(),
 			boss         = bossConfig(),
-			pinned       = pinnedConfig(),
 		},
 		auras = soloUnitAuras(),
 	}
@@ -638,6 +639,13 @@ function F.PresetDefaults.EnsureDefaults()
 				-- don't get stuck with 3 slots and no UI control to change it.
 				if(savedUC.pinned and savedUC.pinned.count == 3) then
 					savedUC.pinned.count = 9
+				end
+
+				-- Strip pinned from Solo. An earlier default incorrectly seeded
+				-- Solo with a pinnedConfig, which made the sidebar / EditMode
+				-- treat Solo as pinned-capable. Pinned is a group-only feature.
+				if(name == 'Solo') then
+					savedUC.pinned = nil
 				end
 
 				-- General backfill: deep-merge any missing keys from defaults

--- a/Preview/PreviewFrame.lua
+++ b/Preview/PreviewFrame.lua
@@ -711,21 +711,31 @@ local function BuildAllElements(frame, config, fakeUnit, auraConfig, animated)
 				end
 			end
 
+			-- Multi-slot previews (pinned) desync: each slot picks a random
+			-- starting step and a small duration jitter so the 9 frames drift
+			-- apart instead of drumming in lockstep. Single-frame previews
+			-- (player/target/etc.) keep the deterministic cycle so the card
+			-- always opens at full health.
+			local jitter = (frame._unitType == 'pinned')
+			local startIdx = jitter and math.random(1, #STEPS) or 1
+			local durScale = jitter and (0.8 + math.random() * 0.5) or 1
+
 			local runStep
 			runStep = function(bar, idx)
 				if(not bar:IsShown()) then return end
 				local step = STEPS[idx]
 				if(not step) then runStep(bar, 1); return end
+				local dur = step.dur * durScale
 
 				if(step.from == step.to or not config.health.smooth) then
 					-- Hold, or instant snap + hold for the same duration
 					setBarTo(step.to)
-					Widgets.StartAnimation(bar, 'healthStep', 0, 1, step.dur,
+					Widgets.StartAnimation(bar, 'healthStep', 0, 1, dur,
 						function() end,
 						function(f) runStep(f, idx + 1) end)
 				else
 					-- Smooth transition with ease-out
-					Widgets.StartAnimation(bar, 'healthStep', 0, 1, step.dur,
+					Widgets.StartAnimation(bar, 'healthStep', 0, 1, dur,
 						function(f, t)
 							local inv = 1 - t
 							local eased = 1 - inv * inv * inv
@@ -734,7 +744,7 @@ local function BuildAllElements(frame, config, fakeUnit, auraConfig, animated)
 						function(f) runStep(f, idx + 1) end)
 				end
 			end
-			runStep(healthBar, 1)
+			runStep(healthBar, startIdx)
 		else
 			frame._healthBar:SetValue(fakeUnit.healthPct)
 			if(frame._healthText) then

--- a/Settings/Builders/FramePreview.lua
+++ b/Settings/Builders/FramePreview.lua
@@ -558,12 +558,18 @@ local function RenderGroupPreview(viewport, unitType, count)
 	-- removed, so this is defensive).
 	FadeOutExtras(count)
 
+	-- Pinned preview animates health like the solo previews so the loss color
+	-- behind the fill shows through drain/refill cycles. Other group types
+	-- (raid/party/boss/arena) stay static — dozens of bars all drumming at
+	-- once is distracting and obscures small config differences.
+	local animateHealth = (unitType == 'pinned') or nil
+
 	for i = 1, count do
 		local fakeUnit = sortedFakes[i]
 		local frame = previewFrames[i]
 		local isNew = (frame == nil)
 		if(isNew) then
-			frame = AcquireFrame(viewport) or F.PreviewFrame.Create(viewport, config, fakeUnit, nil, nil, nil, unitType)
+			frame = AcquireFrame(viewport) or F.PreviewFrame.Create(viewport, config, fakeUnit, nil, nil, animateHealth, unitType)
 			-- Pool-acquired frames carry stale _lastX/_lastY from wherever
 			-- they lived before release. Wipe so the slot-identity logic
 			-- below treats this as a fresh placement (snap + fade-in), not
@@ -575,7 +581,7 @@ local function RenderGroupPreview(viewport, unitType, count)
 		frame._unitType = unitType
 		frame._fakeUnit = fakeUnit
 		if(frame._config) then
-			F.PreviewFrame.UpdateFromConfig(frame, config, nil, false, unitType)
+			F.PreviewFrame.UpdateFromConfig(frame, config, nil, animateHealth or false, unitType)
 		end
 
 		local pos = positions[i]

--- a/Settings/Cards/About.lua
+++ b/Settings/Cards/About.lua
@@ -114,6 +114,20 @@ end
 -- BEGIN GENERATED CHANGELOG
 local CHANGELOG = {
 	{
+		version = 'v0.8.11-alpha',
+		entries = {
+			'**Pinned Frames** — up to 9 standalone frames that track specific group members by name, following players across roster reshuffles. Supports Focus / Focus Target / name-target slots. Role-grouped class-colored assignment dropdown available from the Settings card, empty-slot placeholder click, and a hover-gear icon on assigned pins (out of combat). First-class aura configuration across all 10 aura sub-panels. Per-preset; absent in Solo',
+			'Pinned Frames Settings panel with master enable toggle in the preview card, inline slot assignment, and live-update routing so edits apply without `/reload`',
+			'EditMode integration for Pinned Frames — drag to position (CENTER anchor convention matches the settings panel), click in edit mode to open the inline Pinned panel, hide from the sidebar when the active preset has no `pinnedConfig`',
+			'Empty-slot placeholders render a dimmed identity label (Pin 1 … Pin 9) and become clickable targets for assignment; placeholder mouse-handling is gated so hidden gear icons don\'t swallow clicks',
+			'**FramePreview** now renders the pinned grid alongside the other unit types, and uses `statusText.position` consistently instead of stale anchor keys that caused name tags to drift in the preview',
+			'Bridge `PLAYER_REGEN_ENABLED` through `EventBus` so combat-flush listeners can register via `F.EventBus:Register` instead of maintaining their own event frames',
+			'Fix pinned gear icon rendering larger on resolved frames than on unresolved (placeholder) frames at non-1.0 UIParent scales — live-frame gears now counter-scale to match the placeholder gear\'s physical size',
+			'Fix `attempt to perform arithmetic on local \'x\' (a nil value)` crash in `FrameConfigText.lua` when toggling Health → Attach to name off. The Health element wasn\'t recording detached anchor values at setup when the text was created attached, so the live toggle had no coordinates to restore to',
+			'Internal cleanup: drop Cell references from in-code comments (licensing hygiene — Cell is ARR), remove the defensive `SettingsCards.Pinned` existence guard for idiom consistency, collapse empty stub branches in the pinned gear-icon path',
+		},
+	},
+	{
 		version = 'v0.8.10-alpha',
 		entries = {
 			'Add **Frame Preview Card** — every Frame settings panel (player/target/party/raid/boss/arena/pet/solo) now renders a live unit frame preview at the top of the panel using your current config, pinned next to a summary card that stays in view while the settings scroll',
@@ -138,15 +152,6 @@ local CHANGELOG = {
 			'Update summon-pending status text and color',
 			'Add third-party library attribution to the README and mirror it in the About card',
 			'Internal cleanup: drop dead code (`Core/DispelCapability.lua`, `Core/Version.Compare`, `CopyToDialog`), luacheck branch is clean',
-		},
-	},
-	{
-		version = 'v0.8.9-alpha',
-		entries = {
-			'Fix party/raid role sorting being silently ignored — the header was writing a nameList but kept `sortMethod=\'INDEX\'`, which falls through Blizzard\'s sort branches and leaves frames in default order; now uses `sortMethod=\'NAMELIST\'` so role order actually takes effect',
-			'Fix `attempt to compare a secret number value` error from the cast tracker\'s recheck-skip optimization — the spellId comparison now guards against secret values returned by `UnitCastingInfo`/`UnitChannelInfo` in combat',
-			'Fix `ADDON_ACTION_BLOCKED` on `FramedPartyPet1:ClearAllPoints()` when party composition changed mid-combat — pet re-anchor is now deferred until `PLAYER_REGEN_ENABLED` when the secure frames are locked down',
-			'Internal cleanup: drop hardcoded fallback values in the Dispellable element that duplicated canonical defaults from `Presets/Defaults.lua`',
 		},
 	},
 }

--- a/Units/LiveUpdate/FrameConfigText.lua
+++ b/Units/LiveUpdate/FrameConfigText.lua
@@ -71,6 +71,12 @@ F.EventBus:Register('CONFIG_CHANGED', function(path)
 			if(not frame.Health) then return end
 			frame.Health._attachedToName = attached
 
+			-- Refresh the Name FontString's width constraint: attach-to-name
+			-- mode needs a content-sized Name so the Health text anchor and
+			-- centering shift work; detached mode needs a bounded width so
+			-- long names ellipsize.
+			if(frame._updateNameWidth) then frame._updateNameWidth() end
+
 			-- Create text if it doesn't exist yet (only when showText is also on)
 			if(attached and hc.showText and not frame.Health.text) then
 				local textOverlay = frame._textOverlay
@@ -97,10 +103,17 @@ F.EventBus:Register('CONFIG_CHANGED', function(path)
 				frame.Health.text:Show()
 				frame.Health._lastAttachShift = nil
 			else
-				local ap = frame.Health.text._anchorPoint
+				-- Read from live config rather than stashed fields on the
+				-- FontString: earlier text-creation paths may have produced
+				-- FontStrings without _anchorPoint/X/Y set, which crashed on
+				-- x + 1. The config is the source of truth.
+				local ap = hc.textAnchor
 				local anchor = frame.Health._wrapper or frame.Health
-				local x = frame.Health.text._anchorX
-				local y = frame.Health.text._anchorY
+				local x = hc.textAnchorX
+				local y = hc.textAnchorY
+				frame.Health.text._anchorPoint = ap
+				frame.Health.text._anchorX     = x
+				frame.Health.text._anchorY     = y
 				frame.Health.text:SetPoint(ap, anchor, ap, x + 1, y)
 				-- If showText is off and we're detaching, hide the text
 				if(not hc.showText) then


### PR DESCRIPTION
## Summary

Release v0.8.11-alpha. Bundles the Pinned Frames feature and follow-on fixes since v0.8.10.

**Release mechanics:** Framed.toc version bump, CHANGELOG entry, regenerated About.lua changelog card.

**Follow-on fixes bundled with the release:**
- Name truncation regression fix: the bounded `SetWidth` added for pinned name ellipsis parked the name centered in a wide box when Health was anchored in attach-to-name mode, pushing Health text to the far-right edge. Now content-width in attach-to-name, bounded otherwise. Exposed `_updateNameWidth` so the attach-toggle re-runs it.
- Related: `x + 1` nil crash when detaching from a text created in attached mode — read anchor config from live config instead of stashed FontString fields.
- Pinned enable-toggle white flash: live frames with no unit are now explicitly hidden in `applySlotToFrame` so they don't cascade visible and render stale `'player'` seed bars before oUF's state driver catches up.
- Solo preset no longer seeds a `pinnedConfig` (pinned is group-only); backfill migration strips it from existing saves.
- Pinned preview animation: per-slot jitter so 9 slots don't drum in lockstep; pinned group preview now animates health like solo previews.