### PR TITLE
Release v0.8.12-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+## v0.8.12-alpha
+
+- **Pinned Frames in Edit Mode** — the drag catcher and selected preview now render the full 9-slot grid instead of a single fake frame, so moving pinned frames in edit mode reflects what you'll actually see in-game
+- Pinned anchor convention flipped to TOPLEFT to match boss/arena (drag math, catcher bounds, and live layout now agree); existing CENTER-anchored pinned saves are auto-migrated on load to the equivalent TOPLEFT offset so nothing visually shifts
+- Pinned geometry edits (width, height, columns, spacing) live-update without the grid flashing during resize, and Resize Anchor compensation keeps the pivot edge visually fixed instead of bouncing back on each slider tick
+- Pinned placeholder identity labels ("Pin 1" … "Pin 9") and slot name tags ("Click to assign", character name) now scale with `Name font size` (primary and primary−2, floor 8) — previously hardcoded text looked oversized at non-1.0 UI scales
+- Fix edit-mode first drag doing nothing visible — clicking-and-dragging immediately (without releasing first) now selects the frame so the preview appears as you drag
+- Fix group position sliders (party, raid, arena, boss) not moving the real frame during slider drag in edit mode — the handler only supported solo CENTER anchoring
+- Fix edit-mode preview not rebuilding when position/size sliders change — preview now tracks slider motion in real time via the EditCache
+- Fix inline edit panel sliders and dropdowns sometimes missing clicks — split into a sibling shield + panel so children hit-test uncontested; inline panel rebuilds on preset switch so sliders read the active preset's config
+- Fix boss and arena frames saving off-screen after a drag — they were written as TOPLEFT offsets but reapplied as CENTER offsets on reload/preset change. Now TOPLEFT end-to-end via a `PSEUDO_GROUPS` cascade path; existing saves self-heal because the stored values were already in TOPLEFT space
+- Narrow pinned settings card keeps a 2-column quick-nav summary (was collapsing to 1 column and pushing most rows below the fold); summary rows reflow mid-animation so labels no longer clip past the card edge while the card width tweens
+- Preset switches now redirect away from preset-specific panels (e.g. pinned under Solo) even while Settings is hidden, so reopening doesn't flash a stale panel
+- Inline edit panel stripped down to just Position & Layout — edit mode is strictly for positioning; all other settings live in the main Settings window with live previews
+- Internal cleanup: drop inert `config.count` from pinned (always capped at 9, no UI), consolidate pinned frame-scale handling onto a single anchor-level `RegisterForUIScale` (removes the per-frame gear counter-scale workaround), and rename a shadowed migration local to keep luacheck clean
+
 ## v0.8.11-alpha
 
 - **Pinned Frames** — up to 9 standalone frames that track specific group members by name, following players across roster reshuffles. Supports Focus / Focus Target / name-target slots. Role-grouped class-colored assignment dropdown available from the Settings card, empty-slot placeholder click, and a hover-gear icon on assigned pins (out of combat). First-class aura configuration across all 10 aura sub-panels. Per-preset; absent in Solo

--- a/EditMode/ClickCatchers.lua
+++ b/EditMode/ClickCatchers.lua
@@ -190,6 +190,16 @@ local function CreateCatcher(def, overlay)
 	end)
 
 	catcher:SetScript('OnDragStart', function(self)
+		-- Select the frame first so PreviewManager builds its preview before
+		-- the catcher goes invisible. Without this, a first-drag (click+drag
+		-- without any prior click-release) shows nothing moving — the catcher
+		-- hides itself via ApplySelectedVisuals, but no preview exists to take
+		-- its place and the real frame is occluded by the dim overlay. Select
+		-- happens on OnClick (click-release) and OnDragStop, neither of which
+		-- fires before the first OnUpdate of a first-drag.
+		if(EditMode.GetSelectedFrameKey() ~= self._frameKey) then
+			EditMode.SetSelectedFrameKey(self._frameKey)
+		end
 		-- Switch to selected visuals during drag
 		ApplySelectedVisuals(self)
 

--- a/EditMode/EditMode.lua
+++ b/EditMode/EditMode.lua
@@ -44,7 +44,7 @@ local FRAME_KEYS = {
 	{ key = 'raid',         label = 'Raid Frames',      isGroup = true,  getter = function() return F.Units.Raid and F.Units.Raid.header end },
 	{ key = 'boss',         label = 'Boss Frames',      isGroup = true,  getter = function() return F.Units.Boss and F.Units.Boss.frames and F.Units.Boss.frames[1] end },
 	{ key = 'arena',        label = 'Arena Frames',     isGroup = true,  getter = function() return F.Units.Arena and F.Units.Arena.frames and F.Units.Arena.frames[1] end },
-	{ key = 'pinned',       label = 'Pinned Frames',    isGroup = false, getter = function() return F.Units.Pinned and F.Units.Pinned.anchor end },
+	{ key = 'pinned',       label = 'Pinned Frames',    isGroup = true,  getter = function() return F.Units.Pinned and F.Units.Pinned.anchor end },
 }
 
 EditMode.FRAME_KEYS = FRAME_KEYS

--- a/EditMode/InlinePanel.lua
+++ b/EditMode/InlinePanel.lua
@@ -13,46 +13,11 @@ local PANEL_WIDTH    = 380
 local PANEL_MIN_H    = 300
 local EDGE_MARGIN    = 16
 
-local panel        = nil
-local currentKey   = nil
-local contentFrame = nil
-local activePanelId = nil  -- 'frame' or an aura group id
-local currentSide  = nil   -- 'RIGHT' or 'LEFT'
-local targetRef    = nil   -- reference to the frame the panel is anchored to
-local dragTicker   = nil   -- hidden frame for OnUpdate during drag
-
---- All aura group panels in display order.
-local AURA_GROUPS = {
-	{ id = 'buffs',          label = 'Buffs' },
-	{ id = 'debuffs',        label = 'Debuffs' },
-	{ id = 'externals',      label = 'Externals' },
-	{ id = 'defensives',     label = 'Defensives' },
-	{ id = 'targetedspells', label = 'Targeted Spells' },
-	{ id = 'dispels',        label = 'Dispels' },
-	{ id = 'missingbuffs',   label = 'Missing Buffs' },
-	{ id = 'privateauras',   label = 'Private Auras' },
-	{ id = 'lossofcontrol',  label = 'Loss of Control' },
-	{ id = 'crowdcontrol',   label = 'Crowd Control' },
-}
-
---- Find a registered panel's create function by its id.
---- @param panelId string
---- @return function|nil create
-local function GetPanelCreate(panelId)
-	for _, p in next, F.Settings._panels do
-		if(p.id == panelId) then
-			return p.create
-		end
-	end
-	return nil
-end
-
---- Dim all aura elements on a frame except the active group.
---- @param frameKey string  The selected frame key
---- @param activeGroup string|nil  The active aura group id, or nil to restore all
-local function DimNonActiveAuras(frameKey, activeGroup)
-	F.EventBus:Fire('EDIT_MODE_AURA_DIM', frameKey, activeGroup)
-end
+local panel       = nil
+local currentKey  = nil
+local currentSide = nil   -- 'RIGHT' or 'LEFT'
+local targetRef   = nil   -- reference to the frame the panel is anchored to
+local dragTicker  = nil   -- hidden frame for OnUpdate during drag
 
 local function DestroyPanel()
 	if(dragTicker) then
@@ -63,7 +28,6 @@ local function DestroyPanel()
 		panel:Hide()
 		panel:SetParent(EditMode._trashFrame)
 		panel = nil
-		contentFrame = nil
 		currentKey = nil
 		currentSide = nil
 		targetRef = nil
@@ -132,12 +96,15 @@ local function BuildPanel(frameKey, targetFrame)
 
 	currentKey = frameKey
 
-	-- Create panel frame
-	panel = Widgets.CreateBorderedFrame(overlay, PANEL_WIDTH, PANEL_MIN_H, C.Colors.panel, C.Colors.border)
+	-- Transparent container — the single card inside provides the visuals.
+	-- The panel exists only to size, anchor, and eat mouse clicks so the
+	-- bg click-catcher underneath doesn't deselect the frame.
+	panel = CreateFrame('Frame', nil, overlay)
+	panel:SetSize(PANEL_WIDTH, PANEL_MIN_H)
 	panel:SetFrameLevel(overlay:GetFrameLevel() + 30)
 	panel:SetFrameStrata('TOOLTIP')
 	panel:SetClampedToScreen(true)
-	panel:EnableMouse(true)  -- consume clicks so they don't deselect via overlay
+	panel:EnableMouse(true)
 
 	-- Position relative to target frame (absolute anchor to UIParent so
 	-- slider-driven frame moves don't drag the panel along)
@@ -154,100 +121,26 @@ local function BuildPanel(frameKey, targetFrame)
 		end
 	end
 
-	local frameLabel = frameDef and frameDef.label or frameKey
-
-	-- ── Panel selector dropdown ─────────────────────────────
-	-- First item = frame settings, rest = aura groups
-	local ddItems = {
-		{ text = frameLabel .. ' Settings', value = 'frame' },
-	}
-	for _, group in next, AURA_GROUPS do
-		ddItems[#ddItems + 1] = { text = group.label, value = group.id }
+	-- ── Resolve unit type (group frames use their group key) ─
+	local unitType = frameKey
+	if(frameDef and frameDef.isGroup) then
+		local info = C.PresetInfo[F.Settings.GetEditingPreset()]
+		unitType = (info and info.groupKey) or frameKey
 	end
 
-	local panelDD = Widgets.CreateDropdown(panel, PANEL_WIDTH - C.Spacing.normal * 2)
-	panelDD:SetItems(ddItems)
-	panelDD:ClearAllPoints()
-	panelDD:SetPoint('TOP', panel, 'TOP', 0, -C.Spacing.tight)
+	-- ── Render the Position & Layout card directly ──────────
+	local widgetW = PANEL_WIDTH - C.Spacing.normal * 2
+	local getCfg = function(path) return F.EditCache.Get(unitType, path) end
+	local setCfg = function(path, value) F.EditCache.Set(unitType, path, value) end
+	local onResize = function() end  -- Preview auto-updates via EDIT_CACHE_VALUE_CHANGED
 
-	-- ── Content area ────────────────────────────────────────
-	local ddHeight = panelDD.GetHeight and panelDD:GetHeight() or 24
-	contentFrame = CreateFrame('Frame', nil, panel)
-	contentFrame:SetPoint('TOPLEFT', panelDD, 'BOTTOMLEFT', 0, -C.Spacing.tight)
-	contentFrame:SetPoint('BOTTOMRIGHT', panel, 'BOTTOMRIGHT', 0, 0)
-	contentFrame._explicitWidth = PANEL_WIDTH
-	contentFrame._explicitHeight = PANEL_MIN_H - ddHeight - C.Spacing.tight * 2
+	local card = F.SettingsCards.PositionAndLayout(panel, widgetW, unitType, getCfg, setCfg, onResize)
+	card:ClearAllPoints()
+	card:SetPoint('TOPLEFT', panel, 'TOPLEFT', C.Spacing.normal, -C.Spacing.normal)
 
-	-- ── Clear content helper ────────────────────────────────
-	local function ClearContent()
-		for _, child in next, { contentFrame:GetChildren() } do
-			child:Hide()
-			child:SetParent(EditMode._trashFrame)
-		end
-	end
+	-- Fit panel height to card
+	panel:SetHeight(card:GetHeight() + C.Spacing.normal * 2)
 
-	-- ── Show frame settings ─────────────────────────────────
-	local function ShowFrameSettings()
-		activePanelId = 'frame'
-		DimNonActiveAuras(currentKey, nil)
-		ClearContent()
-
-		local unitType = frameKey
-		if(frameDef and frameDef.isGroup) then
-			local info = C.PresetInfo[F.Settings.GetEditingPreset()]
-			unitType = (info and info.groupKey) or frameKey
-		end
-
-		local scrollPanel = F.FrameSettingsBuilder.Create(contentFrame, unitType)
-		scrollPanel:SetAllPoints(contentFrame)
-		scrollPanel:Show()
-	end
-
-	-- ── Show aura group settings ────────────────────────────
-	local function ShowAuraGroup(groupId)
-		activePanelId = groupId
-		ClearContent()
-
-		local createFn = GetPanelCreate(groupId)
-		if(not createFn) then
-			local noPanel = Widgets.CreateFontString(contentFrame, C.Font.sizeNormal, C.Colors.textSecondary)
-			noPanel:SetPoint('CENTER', contentFrame, 'CENTER', 0, 0)
-			noPanel:SetText('Panel not available')
-			DimNonActiveAuras(currentKey, groupId)
-			return
-		end
-
-		local auraPanel = createFn(contentFrame)
-		if(auraPanel) then
-			auraPanel:ClearAllPoints()
-			auraPanel:SetAllPoints(contentFrame)
-			auraPanel._width = nil
-			auraPanel._height = nil
-			auraPanel:Show()
-		end
-
-		DimNonActiveAuras(currentKey, groupId)
-	end
-
-	-- ── Dropdown selection handler ──────────────────────────
-	panelDD:SetOnSelect(function(value)
-		if(value == 'frame') then
-			ShowFrameSettings()
-		else
-			ShowAuraGroup(value)
-		end
-	end)
-
-	-- Default: restore previous selection or frame settings
-	local defaultPanel = activePanelId or 'frame'
-	panelDD:SetValue(defaultPanel)
-	if(defaultPanel == 'frame') then
-		ShowFrameSettings()
-	else
-		ShowAuraGroup(defaultPanel)
-	end
-
-	-- Slide in animation
 	Widgets.FadeIn(panel)
 end
 
@@ -324,10 +217,5 @@ F.EventBus:Register('EDIT_MODE_DRAG_STOPPED', function(frameKey)
 end, 'InlinePanel.dragStop')
 
 F.EventBus:Register('EDIT_MODE_EXITED', function()
-	-- Restore aura visibility
-	if(currentKey) then
-		DimNonActiveAuras(currentKey, nil)
-	end
-	activePanelId = nil
 	DestroyPanel()
 end, 'InlinePanel')

--- a/EditMode/InlinePanel.lua
+++ b/EditMode/InlinePanel.lua
@@ -13,22 +13,30 @@ local PANEL_WIDTH    = 380
 local PANEL_MIN_H    = 300
 local EDGE_MARGIN    = 16
 
-local panel       = nil
-local currentKey  = nil
-local currentSide = nil   -- 'RIGHT' or 'LEFT'
-local targetRef   = nil   -- reference to the frame the panel is anchored to
-local dragTicker  = nil   -- hidden frame for OnUpdate during drag
+local panel        = nil
+local shield       = nil
+local currentKey   = nil
+local currentPreset = nil  -- preset the panel was built against
+local currentSide  = nil   -- 'RIGHT' or 'LEFT'
+local targetRef    = nil   -- reference to the frame the panel is anchored to
+local dragTicker   = nil   -- hidden frame for OnUpdate during drag
 
 local function DestroyPanel()
 	if(dragTicker) then
 		dragTicker:SetScript('OnUpdate', nil)
 		dragTicker:Hide()
 	end
+	if(shield) then
+		shield:Hide()
+		shield:SetParent(EditMode._trashFrame)
+		shield = nil
+	end
 	if(panel) then
 		panel:Hide()
 		panel:SetParent(EditMode._trashFrame)
 		panel = nil
 		currentKey = nil
+		currentPreset = nil
 		currentSide = nil
 		targetRef = nil
 	end
@@ -78,6 +86,10 @@ local function AnchorPanelAbsolute(side)
 		local leftX = (targetRef:GetLeft() or 0) * ratio
 		panel:SetPoint('TOPRIGHT', UIParent, 'BOTTOMLEFT', leftX - EDGE_MARGIN, topY)
 	end
+	if(shield) then
+		shield:ClearAllPoints()
+		shield:SetAllPoints(panel)
+	end
 end
 
 --- Re-anchor the panel to the opposite side if needed.
@@ -95,16 +107,31 @@ local function BuildPanel(frameKey, targetFrame)
 	if(not overlay) then return end
 
 	currentKey = frameKey
+	currentPreset = F.Settings.GetEditingPreset()
 
-	-- Transparent container — the single card inside provides the visuals.
-	-- The panel exists only to size, anchor, and eat mouse clicks so the
-	-- bg click-catcher underneath doesn't deselect the frame.
+	-- Shield: SIBLING of the panel (child of overlay) at a strictly LOWER
+	-- frame level than the panel. Sized and anchored to match the panel so
+	-- it absorbs any click on the panel footprint that misses a widget.
+	-- Keeping shield and panel as siblings (not ancestor/descendant) avoids
+	-- any chance of the mouse-enabled shield shadowing its own descendant
+	-- widgets via WoW's hit-testing quirks.
+	shield = CreateFrame('Frame', nil, overlay)
+	shield:SetSize(PANEL_WIDTH, PANEL_MIN_H)
+	shield:SetFrameLevel(overlay:GetFrameLevel() + 79)
+	shield:EnableMouse(true)
+	-- Explicit no-op handler so the click is truly consumed — an
+	-- EnableMouse(true) frame with no script handler can still let events
+	-- fall through in some WoW contexts.
+	shield:SetScript('OnMouseDown', function() end)
+
+	-- Transparent container. Lives above the shield; its widget subtree
+	-- provides all visuals and hit-testing. Panel itself is NOT mouse-
+	-- enabled so it never competes with its own children for clicks.
 	panel = CreateFrame('Frame', nil, overlay)
 	panel:SetSize(PANEL_WIDTH, PANEL_MIN_H)
-	panel:SetFrameLevel(overlay:GetFrameLevel() + 30)
-	panel:SetFrameStrata('TOOLTIP')
+	panel:SetFrameLevel(overlay:GetFrameLevel() + 80)
 	panel:SetClampedToScreen(true)
-	panel:EnableMouse(true)
+	panel:EnableMouse(false)
 
 	-- Position relative to target frame (absolute anchor to UIParent so
 	-- slider-driven frame moves don't drag the panel along)
@@ -112,23 +139,11 @@ local function BuildPanel(frameKey, targetFrame)
 	currentSide = GetSmartSide(targetFrame)
 	AnchorPanelAbsolute(currentSide)
 
-	-- ── Resolve frame definition ────────────────────────────
-	local frameDef = nil
-	for _, def in next, EditMode.FRAME_KEYS do
-		if(def.key == frameKey) then
-			frameDef = def
-			break
-		end
-	end
-
-	-- ── Resolve unit type (group frames use their group key) ─
-	local unitType = frameKey
-	if(frameDef and frameDef.isGroup) then
-		local info = C.PresetInfo[F.Settings.GetEditingPreset()]
-		unitType = (info and info.groupKey) or frameKey
-	end
-
 	-- ── Render the Position & Layout card directly ──────────
+	-- Each frame key owns its own unitConfigs node, so the EditCache is
+	-- addressed by frameKey directly — do NOT remap to the preset's
+	-- groupKey, or Boss/Pinned/Party/Arena all alias to the same entry.
+	local unitType = frameKey
 	local widgetW = PANEL_WIDTH - C.Spacing.normal * 2
 	local getCfg = function(path) return F.EditCache.Get(unitType, path) end
 	local setCfg = function(path, value) F.EditCache.Set(unitType, path, value) end
@@ -138,8 +153,11 @@ local function BuildPanel(frameKey, targetFrame)
 	card:ClearAllPoints()
 	card:SetPoint('TOPLEFT', panel, 'TOPLEFT', C.Spacing.normal, -C.Spacing.normal)
 
-	-- Fit panel height to card
+	-- Fit panel height to card, then sync shield to the final rect
 	panel:SetHeight(card:GetHeight() + C.Spacing.normal * 2)
+	shield:SetHeight(panel:GetHeight())
+	shield:ClearAllPoints()
+	shield:SetAllPoints(panel)
 
 	Widgets.FadeIn(panel)
 end
@@ -178,14 +196,19 @@ F.EventBus:Register('EDIT_MODE_FRAME_SELECTED', function(frameKey)
 		return
 	end
 
-	-- Already showing for this frame — just update side, don't rebuild
-	if(panel and currentKey == frameKey) then
+	-- Already showing for this frame AND preset — just update side, don't
+	-- rebuild. If the preset changed (e.g. EDIT_MODE_PRESET_SWITCHED re-
+	-- selects the same frame key after a preset swap), fall through and
+	-- rebuild so the sliders/anchor/dropdowns read from the new preset's
+	-- config instead of the old preset's cached state.
+	if(panel and currentKey == frameKey and currentPreset == F.Settings.GetEditingPreset()) then
 		UpdatePanelSide()
 		return
 	end
 
-	-- If switching frames, animate out then build new
-	if(panel and currentKey ~= frameKey) then
+	-- If switching frames OR the editing preset changed, animate out then
+	-- build fresh so the rebuilt panel reads the new preset's config.
+	if(panel) then
 		Widgets.FadeOut(panel, C.Animation.durationFast, function()
 			BuildPanel(frameKey, targetFrame)
 		end)

--- a/EditMode/ResizeHandles.lua
+++ b/EditMode/ResizeHandles.lua
@@ -188,16 +188,76 @@ end, 'ResizeHandles')
 
 -- Sync real frame when width/height/position changes via sliders
 F.EventBus:Register('EDIT_CACHE_VALUE_CHANGED', function(frameKey, configPath, value)
+	-- Pinned routes every edit-cache change through its own APIs:
+	-- position.x/y → ApplyPosition (anchor parents all slots)
+	-- anchorPoint / width / height / columns / spacing → Layout
+	-- (Layout's `if(f.unit) then f:Show() end` guard keeps unassigned
+	-- frames hidden, so we don't need Refresh's anchor:Hide/Show wrapper
+	-- — which itself produces a brief frames-gone flash on width changes.)
+	-- GetConfig overlays EditCache so Layout sees the live values.
+	if(frameKey == 'pinned') then
+		if(not F.Units.Pinned) then return end
+		local pinnedAnchor = F.Units.Pinned.anchor
+
+		if(configPath == 'position.x' or configPath == 'position.y') then
+			-- ApplyPosition alone — the anchor parents all 9 slots, so moving
+			-- the anchor is enough. Calling Layout here re-Shows unassigned
+			-- frames (Layout's unconditional f:Show) and they briefly render
+			-- their stale 'player' seed state before anything hides them.
+			F.Units.Pinned.ApplyPosition()
+			return
+		end
+		if(configPath == 'anchorPoint') then
+			-- Layout alone. Tokens unchanged, so Resolve would early-return
+			-- per slot anyway; skipping Refresh's anchor:Hide/Show wrapper
+			-- avoids a visible gap. Layout's f.unit guard keeps unassigned
+			-- frames hidden.
+			F.Units.Pinned.Layout()
+			return
+		end
+
+		local dimensionChange = (configPath == 'width' or configPath == 'height'
+			or configPath == 'columns' or configPath == 'spacing')
+		if(not dimensionChange) then return end
+
+		-- Snapshot bg size before Layout so we can compute delta for resize-
+		-- anchor compensation. Mirrors the party/raid groupResizeShift pattern:
+		-- grid bounds grow, but the chosen pivot corner/edge stays visually
+		-- fixed. Without this, bg always grows from TOPLEFT regardless of the
+		-- user's Resize Anchor setting.
+		local oldBgW = (pinnedAnchor and pinnedAnchor._width)  or (pinnedAnchor and pinnedAnchor:GetWidth())  or 0
+		local oldBgH = (pinnedAnchor and pinnedAnchor._height) or (pinnedAnchor and pinnedAnchor:GetHeight()) or 0
+
+		F.Units.Pinned.Layout()
+
+		local newBgW = (pinnedAnchor and pinnedAnchor._width)  or (pinnedAnchor and pinnedAnchor:GetWidth())  or 0
+		local newBgH = (pinnedAnchor and pinnedAnchor._height) or (pinnedAnchor and pinnedAnchor:GetHeight()) or 0
+		local dw = newBgW - oldBgW
+		local dh = newBgH - oldBgH
+		if(dw == 0 and dh == 0) then return end
+
+		local resizeAnchor = F.EditCache.Get('pinned', 'position.anchor') or 'TOPLEFT'
+		if(resizeAnchor == 'TOPLEFT') then return end
+
+		local Shared = F.LiveUpdate and F.LiveUpdate.FrameConfigShared
+		if(not Shared or not Shared.groupResizeShift) then return end
+
+		local dx, dy = Shared.groupResizeShift('TOPLEFT', resizeAnchor, dw, dh)
+		if(dx == 0 and dy == 0) then return end
+
+		local curX = F.EditCache.Get('pinned', 'position.x') or 0
+		local curY = F.EditCache.Get('pinned', 'position.y') or 0
+		F.EditCache.Set('pinned', 'position.x', Widgets.Round(curX + dx))
+		F.EditCache.Set('pinned', 'position.y', Widgets.Round(curY + dy))
+		return
+	end
+
 	local isSize = (configPath == 'width' or configPath == 'height')
 	local isPos = (configPath == 'position.x' or configPath == 'position.y')
 	if(not isSize and not isPos) then return end
 
 	for _, def in next, EditMode.FRAME_KEYS do
 		if(def.key == frameKey) then
-			-- Skip group frames for position — headers use their own anchor
-			-- (TOPLEFT) and aren't directly dragged in edit mode
-			if(def.isGroup and isPos) then break end
-
 			local frame = def.getter()
 			if(not frame) then break end
 
@@ -217,15 +277,25 @@ F.EventBus:Register('EDIT_CACHE_VALUE_CHANGED', function(frameKey, configPath, v
 				local scaleRatio = fScale / uiScale
 				local uiW = UIParent:GetWidth()
 				local uiH = UIParent:GetHeight()
-				local halfFW = w / 2 * scaleRatio
-				local halfFH = h / 2 * scaleRatio
-				local uiHalfW = uiW / 2
-				local uiHalfH = uiH / 2
-				x = math.max(-(uiHalfW - halfFW) / scaleRatio, math.min((uiHalfW - halfFW) / scaleRatio, x))
-				y = math.max(-(uiHalfH - halfFH) / scaleRatio, math.min((uiHalfH - halfFH) / scaleRatio, y))
 
+				-- Group frames use TOPLEFT anchor (matching LiveUpdate and
+				-- edit-mode drag), solo frames use CENTER.
 				frame:ClearAllPoints()
-				Widgets.SetPoint(frame, 'CENTER', UIParent, 'CENTER', x, y)
+				if(def.isGroup) then
+					local maxX = (uiW - w * scaleRatio) / scaleRatio
+					local minY = -(uiH - h * scaleRatio) / scaleRatio
+					x = math.max(0, math.min(maxX, x))
+					y = math.min(0, math.max(minY, y))
+					Widgets.SetPoint(frame, 'TOPLEFT', UIParent, 'TOPLEFT', x, y)
+				else
+					local halfFW = w / 2 * scaleRatio
+					local halfFH = h / 2 * scaleRatio
+					local uiHalfW = uiW / 2
+					local uiHalfH = uiH / 2
+					x = math.max(-(uiHalfW - halfFW) / scaleRatio, math.min((uiHalfW - halfFW) / scaleRatio, x))
+					y = math.max(-(uiHalfH - halfFH) / scaleRatio, math.min((uiHalfH - halfFH) / scaleRatio, y))
+					Widgets.SetPoint(frame, 'CENTER', UIParent, 'CENTER', x, y)
+				end
 			end
 			break
 		end

--- a/Framed.toc
+++ b/Framed.toc
@@ -2,7 +2,7 @@
 ## Title: Framed
 ## Notes: Modern, customizable unit frames and raid frames
 ## Author: Moodibs
-## Version: 0.8.11-alpha
+## Version: 0.8.12-alpha
 ## X-Curse-Project-ID: 1513359
 ## SavedVariables: FramedDB, FramedBackupDB, FramedSnapshotsDB
 ## SavedVariablesPerCharacter: FramedCharDB

--- a/Presets/Defaults.lua
+++ b/Presets/Defaults.lua
@@ -148,6 +148,9 @@ local function pinnedConfig()
 	-- + spacing=2) centered on screen — visually equivalent to CENTER (0,0).
 	cfg.position    = { x = -242, y = 62, anchor = 'TOPLEFT' }
 	cfg.anchorPoint = 'TOPLEFT'
+	-- Flag for EnsureDefaults: signals this pinned config is already in
+	-- TOPLEFT-relative coordinates so the one-shot anchor migration skips it.
+	cfg._anchorMigrated = true
 	return cfg
 end
 
@@ -638,22 +641,52 @@ function F.PresetDefaults.EnsureDefaults()
 					end
 				end
 
-				-- Migrate pinned position CENTER→TOPLEFT. The edit-mode drag
-				-- path saves TOPLEFT offsets; switching defaults to TOPLEFT
-				-- means older CENTER coords would render the grid in the wrong
-				-- place. Convert once so the grid stays at the same visual
-				-- screen position as before.
+				-- One-shot migration: convert pre-0.8 pinned coords (which used
+				-- position.anchor as the real SetPoint anchor) into TOPLEFT
+				-- space. ApplyPosition now always anchors TOPLEFT→TOPLEFT; the
+				-- anchor field is resize-preference metadata only. Gated by
+				-- _anchorMigrated so re-selecting a non-TOPLEFT anchor via
+				-- edit mode doesn't re-apply the offset math on next reload.
+				--
+				-- Legacy SetPoint: frame.A at UIParent.A + (x, y). In TOPLEFT
+				-- space: x' = x + (UIParent A offset from TL) - (frame A
+				-- offset from TL), and similarly for y'. All offsets use
+				-- WoW SetPoint coordinates (+x right, +y up).
 				if(savedUC.pinned and savedUC.pinned.position
-					and savedUC.pinned.position.anchor == 'CENTER') then
-					local p      = savedUC.pinned
-					local cols   = p.columns or 3
-					local rows   = math.ceil(9 / cols)
-					local gridW  = cols * (p.width  or 160) + (cols - 1) * (p.spacing or 2)
-					local gridH  = rows * (p.height or 40)  + (rows - 1) * (p.spacing or 2)
-					p.position.x      = (p.position.x or 0) - gridW / 2
-					p.position.y      = (p.position.y or 0) + gridH / 2
+					and not savedUC.pinned._anchorMigrated
+					and savedUC.pinned.position.anchor
+					and savedUC.pinned.position.anchor ~= 'TOPLEFT') then
+					local p    = savedUC.pinned
+					local cols = p.columns or 3
+					local rows = math.ceil(9 / cols)
+					local W    = cols * (p.width  or 160) + (cols - 1) * (p.spacing or 2)
+					local H    = rows * (p.height or 40)  + (rows - 1) * (p.spacing or 2)
+					local UW   = UIParent:GetWidth()
+					local UH   = UIParent:GetHeight()
+					local A    = p.position.anchor
+
+					local ux, uy = 0, 0
+					if(A == 'TOP' or A == 'CENTER' or A == 'BOTTOM') then ux = UW / 2 end
+					if(A == 'TOPRIGHT' or A == 'RIGHT' or A == 'BOTTOMRIGHT') then ux = UW end
+					if(A == 'LEFT' or A == 'CENTER' or A == 'RIGHT') then uy = -UH / 2 end
+					if(A == 'BOTTOMLEFT' or A == 'BOTTOM' or A == 'BOTTOMRIGHT') then uy = -UH end
+
+					local fx, fy = 0, 0
+					if(A == 'TOP' or A == 'CENTER' or A == 'BOTTOM') then fx = W / 2 end
+					if(A == 'TOPRIGHT' or A == 'RIGHT' or A == 'BOTTOMRIGHT') then fx = W end
+					if(A == 'LEFT' or A == 'CENTER' or A == 'RIGHT') then fy = -H / 2 end
+					if(A == 'BOTTOMLEFT' or A == 'BOTTOM' or A == 'BOTTOMRIGHT') then fy = -H end
+
+					p.position.x      = (p.position.x or 0) + ux - fx
+					p.position.y      = (p.position.y or 0) + uy - fy
 					p.position.anchor = 'TOPLEFT'
 					p.anchorPoint     = 'TOPLEFT'
+				end
+				-- Stamp the flag on every pinned config (migrated or already
+				-- TOPLEFT) so this migration never runs again. New configs
+				-- from Defaults also satisfy the flag via DeepMerge backfill.
+				if(savedUC.pinned) then
+					savedUC.pinned._anchorMigrated = true
 				end
 
 				-- Strip pinned from Solo. An earlier default incorrectly seeded

--- a/Presets/Defaults.lua
+++ b/Presets/Defaults.lua
@@ -663,19 +663,19 @@ function F.PresetDefaults.EnsureDefaults()
 					local H    = rows * (p.height or 40)  + (rows - 1) * (p.spacing or 2)
 					local UW   = UIParent:GetWidth()
 					local UH   = UIParent:GetHeight()
-					local A    = p.position.anchor
+					local anch = p.position.anchor
 
 					local ux, uy = 0, 0
-					if(A == 'TOP' or A == 'CENTER' or A == 'BOTTOM') then ux = UW / 2 end
-					if(A == 'TOPRIGHT' or A == 'RIGHT' or A == 'BOTTOMRIGHT') then ux = UW end
-					if(A == 'LEFT' or A == 'CENTER' or A == 'RIGHT') then uy = -UH / 2 end
-					if(A == 'BOTTOMLEFT' or A == 'BOTTOM' or A == 'BOTTOMRIGHT') then uy = -UH end
+					if(anch == 'TOP' or anch == 'CENTER' or anch == 'BOTTOM') then ux = UW / 2 end
+					if(anch == 'TOPRIGHT' or anch == 'RIGHT' or anch == 'BOTTOMRIGHT') then ux = UW end
+					if(anch == 'LEFT' or anch == 'CENTER' or anch == 'RIGHT') then uy = -UH / 2 end
+					if(anch == 'BOTTOMLEFT' or anch == 'BOTTOM' or anch == 'BOTTOMRIGHT') then uy = -UH end
 
 					local fx, fy = 0, 0
-					if(A == 'TOP' or A == 'CENTER' or A == 'BOTTOM') then fx = W / 2 end
-					if(A == 'TOPRIGHT' or A == 'RIGHT' or A == 'BOTTOMRIGHT') then fx = W end
-					if(A == 'LEFT' or A == 'CENTER' or A == 'RIGHT') then fy = -H / 2 end
-					if(A == 'BOTTOMLEFT' or A == 'BOTTOM' or A == 'BOTTOMRIGHT') then fy = -H end
+					if(anch == 'TOP' or anch == 'CENTER' or anch == 'BOTTOM') then fx = W / 2 end
+					if(anch == 'TOPRIGHT' or anch == 'RIGHT' or anch == 'BOTTOMRIGHT') then fx = W end
+					if(anch == 'LEFT' or anch == 'CENTER' or anch == 'RIGHT') then fy = -H / 2 end
+					if(anch == 'BOTTOMLEFT' or anch == 'BOTTOM' or anch == 'BOTTOMRIGHT') then fy = -H end
 
 					p.position.x      = (p.position.x or 0) + ux - fx
 					p.position.y      = (p.position.y or 0) + uy - fy

--- a/Presets/Defaults.lua
+++ b/Presets/Defaults.lua
@@ -136,14 +136,19 @@ end
 -- Opt-in by default (enabled = false). Solo preset omits this block entirely.
 local function pinnedConfig()
 	local cfg = baseUnitConfig()
-	cfg.enabled  = false
-	cfg.count    = 9
-	cfg.columns  = 3
-	cfg.width    = 160
-	cfg.height   = 40
-	cfg.spacing  = 2
-	cfg.slots    = {}  -- keys 1..9; nil = unassigned
-	cfg.position = { x = 0, y = 0, anchor = 'CENTER' }
+	cfg.enabled     = false
+	cfg.count       = 9
+	cfg.columns     = 3
+	cfg.width       = 160
+	cfg.height      = 40
+	cfg.spacing     = 2
+	cfg.slots       = {}  -- keys 1..9; nil = unassigned
+	-- Pinned anchors TOPLEFT so edit-mode drag math (which saves TOPLEFT offsets)
+	-- and the multi-frame catcher/preview stay consistent with boss/arena.
+	-- (-242, 62) is the TOPLEFT coord of the 484×124 default grid (3×3 × 160×40
+	-- + spacing=2) centered on screen — visually equivalent to CENTER (0,0).
+	cfg.position    = { x = -242, y = 62, anchor = 'TOPLEFT' }
+	cfg.anchorPoint = 'TOPLEFT'
 	return cfg
 end
 
@@ -639,6 +644,24 @@ function F.PresetDefaults.EnsureDefaults()
 				-- don't get stuck with 3 slots and no UI control to change it.
 				if(savedUC.pinned and savedUC.pinned.count == 3) then
 					savedUC.pinned.count = 9
+				end
+
+				-- Migrate pinned position CENTER→TOPLEFT. The edit-mode drag
+				-- path saves TOPLEFT offsets; switching defaults to TOPLEFT
+				-- means older CENTER coords would render the grid in the wrong
+				-- place. Convert once so the grid stays at the same visual
+				-- screen position as before.
+				if(savedUC.pinned and savedUC.pinned.position
+					and savedUC.pinned.position.anchor == 'CENTER') then
+					local p      = savedUC.pinned
+					local cols   = p.columns or 3
+					local rows   = math.ceil(9 / cols)
+					local gridW  = cols * (p.width  or 160) + (cols - 1) * (p.spacing or 2)
+					local gridH  = rows * (p.height or 40)  + (rows - 1) * (p.spacing or 2)
+					p.position.x      = (p.position.x or 0) - gridW / 2
+					p.position.y      = (p.position.y or 0) + gridH / 2
+					p.position.anchor = 'TOPLEFT'
+					p.anchorPoint     = 'TOPLEFT'
 				end
 
 				-- Strip pinned from Solo. An earlier default incorrectly seeded

--- a/Presets/Defaults.lua
+++ b/Presets/Defaults.lua
@@ -277,7 +277,7 @@ local function bossConfig()
 	local c = baseUnitConfig()
 	c.width       = 160
 	c.height      = 30
-	c.position    = { x = 300, y = 100, anchor = 'CENTER' }
+	c.position    = { x = 1100, y = -280, anchor = 'TOPLEFT' }
 	c.spacing     = 4
 	c.orientation = 'vertical'
 	c.anchorPoint = 'TOPLEFT'
@@ -351,7 +351,7 @@ local function arenaConfig()
 	local c = baseUnitConfig()
 	c.width       = 160
 	c.height      = 30
-	c.position    = { x = 300, y = 100, anchor = 'CENTER' }
+	c.position    = { x = 1100, y = -500, anchor = 'TOPLEFT' }
 	c.spacing     = 4
 	c.orientation = 'vertical'
 	c.anchorPoint = 'TOPLEFT'

--- a/Presets/Defaults.lua
+++ b/Presets/Defaults.lua
@@ -137,7 +137,6 @@ end
 local function pinnedConfig()
 	local cfg = baseUnitConfig()
 	cfg.enabled     = false
-	cfg.count       = 9
 	cfg.columns     = 3
 	cfg.width       = 160
 	cfg.height      = 40
@@ -637,13 +636,6 @@ function F.PresetDefaults.EnsureDefaults()
 					if(savedUC[ut] and savedUC[ut].statusIcons) then
 						savedUC[ut].statusIcons.raidRole = false
 					end
-				end
-
-				-- Migrate pinned.count: old default was 3, new is 9. Bump any
-				-- save that still matches the old default so existing users
-				-- don't get stuck with 3 slots and no UI control to change it.
-				if(savedUC.pinned and savedUC.pinned.count == 3) then
-					savedUC.pinned.count = 9
 				end
 
 				-- Migrate pinned position CENTER→TOPLEFT. The edit-mode drag

--- a/Preview/PreviewManager.lua
+++ b/Preview/PreviewManager.lua
@@ -457,11 +457,11 @@ F.EventBus:Register('EDIT_MODE_EXITED', function()
 	end
 end, 'PreviewManager.exited')
 
--- Live update from EditCache (skip position/size — they don't affect preview)
+-- Live update from EditCache. getUnitConfig() merges EditCache over saved
+-- config, so rebuilding here picks up width/height/position changes from
+-- the inline panel sliders.
 F.EventBus:Register('EDIT_CACHE_VALUE_CHANGED', function(frameKey, configPath, value)
 	if(frameKey ~= activeFrameKey) then return end
-	if(configPath == 'position.x' or configPath == 'position.y'
-		or configPath == 'width' or configPath == 'height') then return end
 	PM.ShowPreview(activeFrameKey)
 end, 'PreviewManager.cacheChanged')
 

--- a/Preview/PreviewManager.lua
+++ b/Preview/PreviewManager.lua
@@ -233,7 +233,7 @@ local function showGroupPreview(frameKey)
 		colY = goDown and -(h + spacing) or (h + spacing)
 	end
 
-	-- Position anchor from config (TOPLEFT for party/raid, CENTER for arena/boss)
+	-- Position anchor from config (TOPLEFT for all real/pseudo groups)
 	local posAnchor = (config.position and config.position.anchor) or 'CENTER'
 	local baseX = EditCache.Get(frameKey, 'position.x') or (config.position and config.position.x) or 0
 	local baseY = EditCache.Get(frameKey, 'position.y') or (config.position and config.position.y) or 0

--- a/Preview/PreviewManager.lua
+++ b/Preview/PreviewManager.lua
@@ -28,18 +28,20 @@ local SOLO_FAKES = {
 	pet          = function() return { name = 'Pet',           class = 'HUNTER',   healthPct = 1.0, powerPct = 1.0 } end,
 }
 
-local GROUP_TYPES = { party = true, raid = true, arena = true, boss = true }
+local GROUP_TYPES = { party = true, raid = true, arena = true, boss = true, pinned = true }
 
 local GROUP_FRAME_COUNTS = {
-	party = 5,
-	raid  = 20,
-	arena = 3,
-	boss  = 4,
+	party  = 5,
+	raid   = 20,
+	arena  = 3,
+	boss   = 4,
+	pinned = 9,
 }
 
 local GROUP_FAKES = nil  -- Lazy-init from Preview.GetFakeUnits
 
 local UNITS_PER_COLUMN = 5
+local PINNED_MAX_SLOTS = 9
 
 function PM.GetGroupPreviewCount(frameKey)
 	return GROUP_FRAME_COUNTS[frameKey]
@@ -71,8 +73,16 @@ function PM.GetGroupBounds(config, frameKey)
 	local w = config.width
 	local h = config.height
 	local spacing = config.spacing
-	local isVertical = (config.orientation == 'vertical')
 
+	-- Pinned uses a row-major grid wrapping at config.columns (user-settable),
+	-- not the UNITS_PER_COLUMN=5 column-flow used by party/raid/boss/arena.
+	if(frameKey == 'pinned') then
+		local cols = config.columns
+		local rows = math.ceil(PINNED_MAX_SLOTS / cols)
+		return cols * w + (cols - 1) * spacing, rows * h + (rows - 1) * spacing
+	end
+
+	local isVertical = (config.orientation == 'vertical')
 	local cols = math.ceil(count / UNITS_PER_COLUMN)
 	local rows = math.min(count, UNITS_PER_COLUMN)
 
@@ -188,12 +198,65 @@ end
 -- Group preview
 -- ============================================================
 
+-- Pinned has a row-major grid (wraps at config.columns) and none of the
+-- party/raid concerns (role sort, party-pet, orientation, anchorPoint growth
+-- direction). Kept as its own code path so the shared showGroupPreview below
+-- stays focused on header-backed groups.
+local function showPinnedPreview(container, config, realFrame, auraConfig)
+	if(not GROUP_FAKES) then
+		GROUP_FAKES = F.Preview.GetFakeUnits(5)
+	end
+
+	local cols    = config.columns
+	local w       = config.width
+	local h       = config.height
+	local spacing = config.spacing
+
+	local posAnchor = (config.position and config.position.anchor) or 'TOPLEFT'
+	local baseX = EditCache.Get('pinned', 'position.x') or (config.position and config.position.x) or 0
+	local baseY = EditCache.Get('pinned', 'position.y') or (config.position and config.position.y) or 0
+
+	for i = 1, PINNED_MAX_SLOTS do
+		local row = math.floor((i - 1) / cols)
+		local col = (i - 1) % cols
+		local offX =  col * (w + spacing)
+		local offY = -row * (h + spacing)
+
+		local fakeUnit = GROUP_FAKES[((i - 1) % #GROUP_FAKES) + 1]
+		local unit = {
+			name      = fakeUnit.name .. (i > #GROUP_FAKES and (' ' .. i) or ''),
+			class     = fakeUnit.class,
+			role      = fakeUnit.role,
+			healthPct = math.max(0.1, (fakeUnit.healthPct or 0.8) - (i * 0.03)),
+			powerPct  = fakeUnit.powerPct or 0.5,
+		}
+
+		local pf = F.PreviewFrame.Create(container, config, unit, realFrame, auraConfig)
+		if(realFrame) then
+			pf:SetPoint('TOPLEFT', realFrame, 'TOPLEFT', offX, offY)
+		else
+			pf:SetPoint('TOPLEFT', UIParent, posAnchor, baseX + offX, baseY + offY)
+		end
+		previewFrames[i] = pf
+		pf:Show()
+	end
+end
+
 local function showGroupPreview(frameKey)
 	local container = getPreviewContainer()
 	if(not container) then return end
 
 	local config = getUnitConfig(frameKey)
 	if(not config) then return end
+
+	-- Look up real frame for scale sync (needed by every path)
+	local realFrame = getRealFrame(frameKey)
+	local auraConfig = getAuraConfig(frameKey)
+
+	if(frameKey == 'pinned') then
+		showPinnedPreview(container, config, realFrame, auraConfig)
+		return
+	end
 
 	if(not GROUP_FAKES) then
 		GROUP_FAKES = F.Preview.GetFakeUnits(5)
@@ -237,10 +300,6 @@ local function showGroupPreview(frameKey)
 	local posAnchor = (config.position and config.position.anchor) or 'CENTER'
 	local baseX = EditCache.Get(frameKey, 'position.x') or (config.position and config.position.x) or 0
 	local baseY = EditCache.Get(frameKey, 'position.y') or (config.position and config.position.y) or 0
-
-	-- Look up real header frame for scale sync
-	local realFrame = getRealFrame(frameKey)
-	local auraConfig = getAuraConfig(frameKey)
 
 	-- Build full unit list first (so we can bucket by role if needed)
 	local units = {}

--- a/Preview/PreviewManager.lua
+++ b/Preview/PreviewManager.lua
@@ -11,7 +11,6 @@ local PM = F.PreviewManager
 -- ============================================================
 
 local activeFrameKey = nil
-local activeDimGroup = nil  -- current aura group being highlighted (nil = all visible)
 local previewFrames = {}
 local previewContainer = nil
 
@@ -350,15 +349,6 @@ end
 -- Public API
 -- ============================================================
 
-local function applyDimState()
-	if(not activeDimGroup) then return end
-	for _, pf in next, previewFrames do
-		if(pf.SetAuraGroupAlpha) then
-			pf:SetAuraGroupAlpha(activeDimGroup)
-		end
-	end
-end
-
 function PM.ShowPreview(frameKey)
 	destroyPreviews()
 	activeFrameKey = frameKey
@@ -368,14 +358,10 @@ function PM.ShowPreview(frameKey)
 	else
 		showSoloPreview(frameKey)
 	end
-
-	-- Re-apply aura dimming after rebuild
-	applyDimState()
 end
 
 function PM.HidePreview()
 	destroyPreviews()
-	activeDimGroup = nil
 end
 
 function PM.IsAnimationEnabled()
@@ -430,23 +416,3 @@ F.EventBus:Register('CONFIG_CHANGED', function(path)
 	end
 end, 'PreviewManager.auraConfig')
 
--- Map inline panel IDs (lowercase) to aura group keys (camelCase/config keys)
-local PANEL_TO_GROUP = {
-	targetedspells = 'targetedSpells',
-	dispels        = 'dispellable',
-	missingbuffs   = 'missingBuffs',
-	privateauras   = 'privateAuras',
-	lossofcontrol  = 'lossOfControl',
-	crowdcontrol   = 'crowdControl',
-}
-
-F.EventBus:Register('EDIT_MODE_AURA_DIM', function(frameKey, activeGroupId)
-	if(frameKey ~= activeFrameKey) then return end
-	local groupKey = activeGroupId and (PANEL_TO_GROUP[activeGroupId] or activeGroupId) or nil
-	activeDimGroup = groupKey
-	for _, pf in next, previewFrames do
-		if(pf.SetAuraGroupAlpha) then
-			pf:SetAuraGroupAlpha(groupKey)
-		end
-	end
-end, 'PreviewManager.auraDim')

--- a/Settings/Builders/FramePreview.lua
+++ b/Settings/Builders/FramePreview.lua
@@ -757,7 +757,13 @@ end
 -- Public: animate pinned row widths (preview card + its viewport, summary card).
 function FP.AnimatePinnedWidths(previewCard, summaryCard, targetPreviewW, targetSummaryW, onFrame)
 	AnimatePreviewWidth(previewCard, previewCard._viewport, targetPreviewW, onFrame)
-	AnimateSimpleWidth(summaryCard, targetSummaryW)
+	AnimateSimpleWidth(summaryCard, targetSummaryW, function()
+		-- Keep row widths in sync with the tweening card so LEFT/RIGHT-
+		-- anchored labels truncate rather than clipping past the card.
+		if(summaryCard.ResizeRowsToWidth) then
+			summaryCard:ResizeRowsToWidth()
+		end
+	end)
 end
 
 -- Lightweight height refresh used when Focus Mode reflows between rows. The

--- a/Settings/Cards/About.lua
+++ b/Settings/Cards/About.lua
@@ -114,6 +114,24 @@ end
 -- BEGIN GENERATED CHANGELOG
 local CHANGELOG = {
 	{
+		version = 'v0.8.12-alpha',
+		entries = {
+			'**Pinned Frames in Edit Mode** — the drag catcher and selected preview now render the full 9-slot grid instead of a single fake frame, so moving pinned frames in edit mode reflects what you\'ll actually see in-game',
+			'Pinned anchor convention flipped to TOPLEFT to match boss/arena (drag math, catcher bounds, and live layout now agree); existing CENTER-anchored pinned saves are auto-migrated on load to the equivalent TOPLEFT offset so nothing visually shifts',
+			'Pinned geometry edits (width, height, columns, spacing) live-update without the grid flashing during resize, and Resize Anchor compensation keeps the pivot edge visually fixed instead of bouncing back on each slider tick',
+			'Pinned placeholder identity labels ("Pin 1" … "Pin 9") and slot name tags ("Click to assign", character name) now scale with `Name font size` (primary and primary−2, floor 8) — previously hardcoded text looked oversized at non-1.0 UI scales',
+			'Fix edit-mode first drag doing nothing visible — clicking-and-dragging immediately (without releasing first) now selects the frame so the preview appears as you drag',
+			'Fix group position sliders (party, raid, arena, boss) not moving the real frame during slider drag in edit mode — the handler only supported solo CENTER anchoring',
+			'Fix edit-mode preview not rebuilding when position/size sliders change — preview now tracks slider motion in real time via the EditCache',
+			'Fix inline edit panel sliders and dropdowns sometimes missing clicks — split into a sibling shield + panel so children hit-test uncontested; inline panel rebuilds on preset switch so sliders read the active preset\'s config',
+			'Fix boss and arena frames saving off-screen after a drag — they were written as TOPLEFT offsets but reapplied as CENTER offsets on reload/preset change. Now TOPLEFT end-to-end via a `PSEUDO_GROUPS` cascade path; existing saves self-heal because the stored values were already in TOPLEFT space',
+			'Narrow pinned settings card keeps a 2-column quick-nav summary (was collapsing to 1 column and pushing most rows below the fold); summary rows reflow mid-animation so labels no longer clip past the card edge while the card width tweens',
+			'Preset switches now redirect away from preset-specific panels (e.g. pinned under Solo) even while Settings is hidden, so reopening doesn\'t flash a stale panel',
+			'Inline edit panel stripped down to just Position & Layout — edit mode is strictly for positioning; all other settings live in the main Settings window with live previews',
+			'Internal cleanup: drop inert `config.count` from pinned (always capped at 9, no UI), consolidate pinned frame-scale handling onto a single anchor-level `RegisterForUIScale` (removes the per-frame gear counter-scale workaround), and rename a shadowed migration local to keep luacheck clean',
+		},
+	},
+	{
 		version = 'v0.8.11-alpha',
 		entries = {
 			'**Pinned Frames** — up to 9 standalone frames that track specific group members by name, following players across roster reshuffles. Supports Focus / Focus Target / name-target slots. Role-grouped class-colored assignment dropdown available from the Settings card, empty-slot placeholder click, and a hover-gear icon on assigned pins (out of combat). First-class aura configuration across all 10 aura sub-panels. Per-preset; absent in Solo',
@@ -125,33 +143,6 @@ local CHANGELOG = {
 			'Fix pinned gear icon rendering larger on resolved frames than on unresolved (placeholder) frames at non-1.0 UIParent scales — live-frame gears now counter-scale to match the placeholder gear\'s physical size',
 			'Fix `attempt to perform arithmetic on local \'x\' (a nil value)` crash in `FrameConfigText.lua` when toggling Health → Attach to name off. The Health element wasn\'t recording detached anchor values at setup when the text was created attached, so the live toggle had no coordinates to restore to',
 			'Internal cleanup: drop Cell references from in-code comments (licensing hygiene — Cell is ARR), remove the defensive `SettingsCards.Pinned` existence guard for idiom consistency, collapse empty stub branches in the pinned gear-icon path',
-		},
-	},
-	{
-		version = 'v0.8.10-alpha',
-		entries = {
-			'Add **Frame Preview Card** — every Frame settings panel (player/target/party/raid/boss/arena/pet/solo) now renders a live unit frame preview at the top of the panel using your current config, pinned next to a summary card that stays in view while the settings scroll',
-			'Raid preview card includes a 1–40 count stepper saved per character, so you can dial the preview to the group size you\'re actually tuning for',
-			'Party preview includes a pet toggle to preview pet frames alongside party members',
-			'**Focus Mode** — click a settings card (Health Color, Castbar, Auras, etc.) to spotlight the matching element in the preview; other elements dim to 20%. Your selection persists across `/reload`',
-			'Preview card and frames animate smoothly when you change count, toggle Focus Mode, or resize the settings window',
-			'Preview re-renders live as you edit config — structural changes (count, spacing) rebuild, cosmetic changes (colors, textures) just refresh',
-			'Migrate **Defensives** and **Externals** panels to the same pinned Preview | Overview layout for consistency with the Frame panels',
-			'Fix boss and arena previews where per-frame castbars overlapped the next frame instead of sitting cleanly below',
-			'Fix boss/party/arena preview card titles truncating — fixed-count unit cards now get enough width for the title and Focus Mode toggle; raid keeps its auto-sizing',
-			'Scrollbar UX: hover the right-edge strip to reveal the scrollbar (no more stolen clicks from mouse-motion detection), and dragging the thumb keeps it visible and fires lazy-load',
-			'**Buffs/Debuffs** panels: auto-select the first enabled indicator on open; add/delete indicators with a cleaner inline form (Plus/Tick icons)',
-			'**SpellList**: fix spell ID and name truncation, combine hover tooltip, tighten the ID column',
-			'**StatusText**: replace the dead anchor controls with a proper position switch',
-			'**Copy To**: move the control into the sub-header with a dropdown + direct-write button (the old standalone dialog is gone)',
-			'Fix party pet ghost frames when members joined the group; roster now refreshes properly',
-			'Guard party pet cross-zone check against secret values so it doesn\'t error in combat',
-			'Fix `RoleIcon` not refreshing on spec change, and fix style 2 to use the correct quadrant overrides',
-			'Revert a `PartyMemberFrame` state-visibility driver change that was breaking Blizzard\'s own frame cleanup',
-			'Fix `StyleBuilder` preset `groupKey` fallback accidentally applying to derived presets — now scoped to base presets only',
-			'Update summon-pending status text and color',
-			'Add third-party library attribution to the README and mirror it in the About card',
-			'Internal cleanup: drop dead code (`Core/DispelCapability.lua`, `Core/Version.Compare`, `CopyToDialog`), luacheck branch is clean',
 		},
 	},
 }

--- a/Settings/Cards/Pinned.lua
+++ b/Settings/Cards/Pinned.lua
@@ -321,10 +321,8 @@ function F.SettingsCards.Pinned(parent, width, unitType, getConfig, setConfig)
 			Widgets.EndCard(card, parent, cardY)
 			return
 		end
-		local count = math.max(1, math.min(cfg.count or 3, MAX_SLOTS))
-
 		local y = cardY
-		for i = 1, count do
+		for i = 1, MAX_SLOTS do
 			local row = renderSlotRow(inner, i, y, innerW)
 			rows[i] = row
 			y = B.PlaceWidget(row, inner, y, ROW_H)
@@ -337,13 +335,10 @@ function F.SettingsCards.Pinned(parent, width, unitType, getConfig, setConfig)
 
 	F.EventBus:Register('CONFIG_CHANGED', function(path)
 		if(not path) then return end
-		-- count changes the number of rows, so a full rebuild is required.
-		if(path:match('unitConfigs%.pinned%.count$')) then
-			rebuild()
-		-- slot changes keep the same 9 rows — just refresh their dropdowns.
+		-- Slot changes keep the same 9 rows — just refresh their dropdowns.
 		-- Destroying and recreating every row on each assign/unassign caused
 		-- a visible texture flash across all 9 settings widgets.
-		elseif(path:match('unitConfigs%.pinned%.slots')) then
+		if(path:match('unitConfigs%.pinned%.slots')) then
 			for _, r in next, rows do
 				if(r._refresh) then r._refresh() end
 			end

--- a/Settings/Cards/PositionAndLayout.lua
+++ b/Settings/Cards/PositionAndLayout.lua
@@ -6,7 +6,7 @@ local B = F.FrameSettingsBuilder
 F.SettingsCards = F.SettingsCards or {}
 
 
-local GROUP_TYPES = { party = true, raid = true, arena = true }
+local GROUP_TYPES = { party = true, raid = true, arena = true, pinned = true }
 
 function F.SettingsCards.PositionAndLayout(parent, width, unitType, getConfig, setConfig, onResize)
 	local card, inner, cardY = Widgets.StartCard(parent, width, 0)
@@ -62,17 +62,20 @@ function F.SettingsCards.PositionAndLayout(parent, width, unitType, getConfig, s
 		end)
 		cardY = B.PlaceWidget(spacingSlider, inner, cardY, B.SLIDER_H)
 
-		-- Orientation switch
-		cardY = B.PlaceHeading(inner, 'Orientation', 4, cardY)
-		local orientSwitch = Widgets.CreateSwitch(inner, widgetW, B.SWITCH_H, {
-			{ text = 'Vertical',   value = 'vertical' },
-			{ text = 'Horizontal', value = 'horizontal' },
-		})
-		orientSwitch:SetValue(getConfig('orientation'))
-		orientSwitch:SetOnSelect(function(value)
-			setConfig('orientation', value)
-		end)
-		cardY = B.PlaceWidget(orientSwitch, inner, cardY, B.SWITCH_H)
+		-- Orientation switch — pinned is a fixed-column row-major grid,
+		-- so it has no orientation choice.
+		if(unitType ~= 'pinned') then
+			cardY = B.PlaceHeading(inner, 'Orientation', 4, cardY)
+			local orientSwitch = Widgets.CreateSwitch(inner, widgetW, B.SWITCH_H, {
+				{ text = 'Vertical',   value = 'vertical' },
+				{ text = 'Horizontal', value = 'horizontal' },
+			})
+			orientSwitch:SetValue(getConfig('orientation'))
+			orientSwitch:SetOnSelect(function(value)
+				setConfig('orientation', value)
+			end)
+			cardY = B.PlaceWidget(orientSwitch, inner, cardY, B.SWITCH_H)
+		end
 
 		-- Raid preview count slider (edit mode only)
 		if(unitType == 'raid' and F.EditCache and F.EditCache.IsActive()) then

--- a/Settings/FrameSettingsBuilder.lua
+++ b/Settings/FrameSettingsBuilder.lua
@@ -175,6 +175,26 @@ function F.FrameSettingsBuilder.ComputePinnedSplit(totalW, gap, unitType, previe
 	end
 	previewW = math.max(previewW, widthFloor)
 	local summaryW = totalW - previewW - gap
+
+	-- Force the summary to stay 2-col-capable on narrow totals. The summary's
+	-- column count is discrete (innerW >= SUMMARY_2COL_MIN_INNER → 2 cols, else
+	-- 1 col), and a 1-col summary hides most rows below the fold. The preview,
+	-- by contrast, scales continuously via SetScale(innerW / naturalW), so
+	-- stealing width from it just shrinks the preview frames — exactly the
+	-- trade-off we want. PREVIEW_HARD_MIN keeps the preview card's border /
+	-- title legible; below it, we'd rather the summary fall back to 1 col than
+	-- render a preview too small to read.
+	local SUMMARY_2COL_MIN = F.FrameSettingsBuilder.SUMMARY_2COL_MIN_INNER
+		+ F.FrameSettingsBuilder.SUMMARY_CARD_PAD * 2
+	local PREVIEW_HARD_MIN = 80
+	if(summaryW < SUMMARY_2COL_MIN) then
+		local targetSummary = math.min(SUMMARY_2COL_MIN, totalW - PREVIEW_HARD_MIN - gap)
+		if(targetSummary > summaryW) then
+			summaryW = targetSummary
+			previewW = totalW - summaryW - gap
+		end
+	end
+
 	return previewW, summaryW
 end
 
@@ -184,6 +204,14 @@ end
 
 local SUMMARY_ROW_H = 16
 local ICON_SIZE = 12
+local SUMMARY_CARD_PAD = 10
+-- innerW threshold for 2-col layout in BuildSummaryCard's layoutRows.
+-- Exported so ComputePinnedSplit can guarantee the summary always gets
+-- enough width to render at least 2 columns.
+local SUMMARY_2COL_MIN_INNER = 180
+
+F.FrameSettingsBuilder.SUMMARY_CARD_PAD        = SUMMARY_CARD_PAD
+F.FrameSettingsBuilder.SUMMARY_2COL_MIN_INNER  = SUMMARY_2COL_MIN_INNER
 
 local GROUP_ICON_TYPES = { party = true, raid = true, arena = true, pinned = true }
 
@@ -311,13 +339,19 @@ function F.FrameSettingsBuilder.BuildSummaryCard(parent, width, unitType, getCon
 	card:SetWidth(width)
 	Widgets.CreateAccentBar(card, 'top')
 
-	local pad = 10
-	local titleText = Widgets.CreateFontString(card, C.Font.sizeNormal, C.Colors.textActive)
-	titleText:SetPoint('TOPLEFT', card, 'TOPLEFT', pad, -pad)
-	titleText:SetText('Quick Navigation')
-
+	local pad = SUMMARY_CARD_PAD
 	local badgeText = Widgets.CreateFontString(card, C.Font.sizeSmall, C.Colors.textSecondary)
 	badgeText:SetPoint('TOPRIGHT', card, 'TOPRIGHT', -pad, -pad - 1)
+
+	-- Title shares the header row with the badge. Bound its right edge to
+	-- the badge's left so the title ellipsis-truncates when the card is
+	-- narrow instead of overlapping the "N of M enabled" count.
+	local titleText = Widgets.CreateFontString(card, C.Font.sizeNormal, C.Colors.textActive)
+	titleText:SetPoint('TOPLEFT', card, 'TOPLEFT', pad, -pad)
+	titleText:SetPoint('RIGHT', badgeText, 'LEFT', -C.Spacing.base, 0)
+	titleText:SetJustifyH('LEFT')
+	titleText:SetWordWrap(false)
+	titleText:SetText('Quick Navigation')
 
 	local titleH = C.Font.sizeNormal + 6
 
@@ -457,7 +491,7 @@ function F.FrameSettingsBuilder.BuildSummaryCard(parent, width, unitType, getCon
 		local cols
 		if(innerW >= 340) then
 			cols = 3
-		elseif(innerW >= 180) then
+		elseif(innerW >= SUMMARY_2COL_MIN_INNER) then
 			cols = 2
 		else
 			cols = 1
@@ -508,10 +542,22 @@ function F.FrameSettingsBuilder.BuildSummaryCard(parent, width, unitType, getCon
 		card:SetHeight(h)
 	end
 
+	local lastOrderedIds = cardIdOrder
 	layoutRows(cardIdOrder, false)
 
 	function card:Reorder(orderedIds)
+		lastOrderedIds = orderedIds
 		layoutRows(orderedIds, true)
+	end
+
+	-- Re-place rows against the card's *current* width without triggering
+	-- the reorder animation. Used as the per-frame callback while the
+	-- pinned split tweens the summary card narrower — otherwise
+	-- rf:SetWidth() stays pinned at the pre-tween colW and row contents
+	-- (the labels are LEFT/RIGHT-anchored, so truncation depends on the
+	-- row width tracking the card).
+	function card:ResizeRowsToWidth()
+		layoutRows(lastOrderedIds, false)
 	end
 
 	function card:Refresh()

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -596,14 +596,13 @@ F.EventBus:Register('EDITING_PRESET_CHANGED', function()
 			Settings._panelFrames[p.id] = nil
 		end
 	end
-	-- Only rebuild if settings is visible — entering edit mode hides settings
-	-- first, so rebuilding a stale panel would reference a missing unit type
-	if(not Settings._mainFrame or not Settings._mainFrame:IsShown()) then return end
+	if(not Settings._mainFrame) then return end
 	local activeId = Settings._activePanelId
 	if(not activeId) then return end
 	-- Redirect away from preset-specific panels that don't exist under the
-	-- new preset (pinned is absent in Solo). Rebuilding them would crash on
-	-- the first unitConfigs read.
+	-- new preset (pinned is absent in Solo). Must run even while settings
+	-- is hidden so that Toggle()'s pre-FadeIn sync doesn't leave a stale
+	-- pinned panel active when the user reopens under Solo.
 	if(activeId == 'pinned') then
 		local preset = Settings.GetEditingPreset()
 		if(not preset or not F.Config:Get('presets.' .. preset .. '.unitConfigs.pinned')) then

--- a/Units/Arena.lua
+++ b/Units/Arena.lua
@@ -26,18 +26,13 @@ function F.Units.Arena.Spawn()
 	oUF:RegisterStyle('FramedArena', Style)
 	oUF:SetActiveStyle('FramedArena')
 
-	local config = F.StyleBuilder.GetConfig('arena')
-	local baseX = config.position.x
-	local baseY = config.position.y
-	local spacing = config.spacing
-
 	local frames = {}
 	for i = 1, 5 do
 		local arena = oUF:Spawn('arena' .. i, 'FramedArenaFrame' .. i)
-		arena:SetPoint('CENTER', UIParent, 'CENTER', baseX, baseY - (i - 1) * (config.height + spacing))
 		F.Widgets.RegisterForUIScale(arena)
 		frames[i] = arena
 	end
-
 	F.Units.Arena.frames = frames
+
+	F.LiveUpdate.FrameConfigShared.cascadePseudoGroup('arena', F.StyleBuilder.GetConfig('arena'))
 end

--- a/Units/Boss.lua
+++ b/Units/Boss.lua
@@ -22,18 +22,13 @@ function F.Units.Boss.Spawn()
 	oUF:RegisterStyle('FramedBoss', Style)
 	oUF:SetActiveStyle('FramedBoss')
 
-	local config = F.StyleBuilder.GetConfig('boss')
-	local baseX = config.position.x
-	local baseY = config.position.y
-	local spacing = config.spacing
-
 	local frames = {}
 	for i = 1, 5 do
 		local boss = oUF:Spawn('boss' .. i, 'FramedBossFrame' .. i)
-		boss:SetPoint('CENTER', UIParent, 'CENTER', baseX, baseY - (i - 1) * (config.height + spacing))
 		F.Widgets.RegisterForUIScale(boss)
 		frames[i] = boss
 	end
-
 	F.Units.Boss.frames = frames
+
+	F.LiveUpdate.FrameConfigShared.cascadePseudoGroup('boss', F.StyleBuilder.GetConfig('boss'))
 end

--- a/Units/LiveUpdate/FrameConfigLayout.lua
+++ b/Units/LiveUpdate/FrameConfigLayout.lua
@@ -5,8 +5,10 @@ local Widgets = F.Widgets
 local Shared = F.LiveUpdate.FrameConfigShared
 local ForEachFrame    = Shared.ForEachFrame
 local GROUP_TYPES     = Shared.GROUP_TYPES
+local PSEUDO_GROUPS   = Shared.PSEUDO_GROUPS
 local getGroupHeader  = Shared.getGroupHeader
 local repositionFrame = Shared.repositionFrame
+local cascadePseudoGroup = Shared.cascadePseudoGroup
 local resizeShift     = Shared.resizeShift
 local groupResizeShift = Shared.groupResizeShift
 local applyOrQueue     = Shared.applyOrQueue
@@ -261,6 +263,8 @@ F.EventBus:Register('CONFIG_CHANGED', function(path)
 				header:ClearAllPoints()
 				Widgets.SetPoint(header, 'TOPLEFT', UIParent, 'TOPLEFT', x, y)
 			end
+		elseif(PSEUDO_GROUPS[unitType]) then
+			cascadePseudoGroup(unitType, config)
 		else
 			ForEachFrame(unitType, function(frame)
 				repositionFrame(frame, config)
@@ -345,6 +349,35 @@ F.EventBus:Register('CONFIG_CHANGED', function(path)
 						end
 					end)
 				end
+			elseif(PSEUDO_GROUPS[unitType]) then
+				ForEachFrame(unitType, function(frame)
+					Widgets.SetSize(frame, config.width, config.height)
+					if(frame.Health and frame.Health._wrapper) then
+						Widgets.SetSize(frame.Health._wrapper, config.width, healthHeight)
+					end
+					if(frame.Power and frame.Power._wrapper) then
+						Widgets.SetSize(frame.Power._wrapper, config.width, powerHeight)
+						local pos = config.power.position
+						frame.Power._wrapper:ClearAllPoints()
+						frame.Health._wrapper:ClearAllPoints()
+						if(pos == 'top') then
+							frame.Power._wrapper:SetPoint('TOPLEFT', frame, 'TOPLEFT', 0, 0)
+							frame.Health._wrapper:SetPoint('TOPLEFT', frame, 'TOPLEFT', 0, -powerHeight)
+						else
+							frame.Health._wrapper:SetPoint('TOPLEFT', frame, 'TOPLEFT', 0, 0)
+							frame.Power._wrapper:SetPoint('TOPLEFT', frame.Health._wrapper, 'BOTTOMLEFT', 0, 0)
+						end
+						if(frame.Power.SetSharedEdge) then
+							frame.Power:SetSharedEdge(pos)
+						end
+					end
+					local cbCfg = config.castbar
+					if(cbCfg and frame.Castbar and frame.Castbar._wrapper and cbCfg.sizeMode ~= 'detached') then
+						Widgets.SetSize(frame.Castbar._wrapper, config.width, cbCfg.height)
+					end
+				end)
+				-- Re-cascade since frame height affects vertical offsets
+				cascadePseudoGroup(unitType, config)
 			else
 				local anchor = config.position.anchor
 				ForEachFrame(unitType, function(frame)
@@ -404,6 +437,12 @@ F.EventBus:Register('CONFIG_CHANGED', function(path)
 
 	-- Group layout: spacing, orientation, anchorPoint
 	if(key == 'spacing' or key == 'orientation' or key == 'anchorPoint') then
+		if(PSEUDO_GROUPS[unitType]) then
+			if(key == 'anchorPoint') then return end
+			local config = F.StyleBuilder.GetConfig(unitType)
+			cascadePseudoGroup(unitType, config)
+			return
+		end
 		if(not GROUP_TYPES[unitType]) then return end
 		local header = getGroupHeader(unitType)
 		if(not header) then return end

--- a/Units/LiveUpdate/FrameConfigPinned.lua
+++ b/Units/LiveUpdate/FrameConfigPinned.lua
@@ -11,18 +11,84 @@ local function onConfigChanged(path)
 	local unitType, key = guardConfigChanged(path)
 	if(unitType ~= 'pinned') then return end
 
-	if(key == 'position.x' or key == 'position.y' or key == 'position.anchor') then
+	-- position.anchor is resize-preference metadata only — don't re-apply
+	-- position or re-layout when it changes (matches party/raid/solo
+	-- behavior). Layout reads config.anchorPoint for growth direction.
+	if(key == 'position.anchor') then return end
+
+	if(key == 'position.x' or key == 'position.y') then
 		debouncedApply('pinned.position', function()
+			-- ApplyPosition alone — anchor parents all 9 slots. Calling Layout
+			-- here re-Shows unassigned frames (Layout's unconditional f:Show)
+			-- and they flash the stale oUF 'player' seed state before anything
+			-- hides them again.
 			F.Units.Pinned.ApplyPosition()
-			F.Units.Pinned.Layout()
 		end)
-	elseif(key == 'enabled' or key == 'count' or key == 'columns'
-	    or key == 'width' or key == 'height' or key == 'spacing') then
-		-- Refresh = Hide → Layout → Resolve → Show atomic. Keeps the 9
-		-- frames invisible through the whole transition so the user
-		-- never sees them briefly render with their stale 'player' seed
-		-- state before Resolve clears the unit on unassigned slots.
-		debouncedApply('pinned.layout', F.Units.Pinned.Refresh)
+	elseif(key == 'enabled' or key == 'count') then
+		-- Refresh = Hide → Layout → Resolve → Show atomic. Only for
+		-- structural changes (enable toggle, slot count) where we need
+		-- Resolve to re-assign/clear units. Geometry-only keys take the
+		-- Layout-alone path below — Refresh's anchor:Hide/Show wrapper
+		-- creates a brief frames-gone flash that reads as "frames shrank
+		-- and bounced back" on a width change.
+		debouncedApply('pinned.layout', function()
+			F.Units.Pinned.Refresh()
+		end)
+	elseif(key == 'columns' or key == 'width' or key == 'height'
+	    or key == 'spacing' or key == 'anchorPoint') then
+		-- Layout alone. Tokens haven't changed, so Resolve has nothing to
+		-- do — and skipping Refresh's anchor:Hide/Show wrapper avoids the
+		-- flash. Layout's `if(f.unit) then f:Show() end` guard keeps
+		-- unassigned frames hidden, so Bug C's 'player' seed flash stays fixed.
+		-- Dimension changes (width/height/cols/spacing) also shift x/y
+		-- so the Resize Anchor pivot stays visually fixed — without this,
+		-- bg growth always cascades from TOPLEFT. anchorPoint doesn't
+		-- change bg bounds, so its dw/dh is zero and no shift applies.
+		debouncedApply('pinned.layout', function()
+			local anchor = F.Units.Pinned.anchor
+			local oldBgW = (anchor and anchor._width)  or 0
+			local oldBgH = (anchor and anchor._height) or 0
+
+			F.Units.Pinned.Layout()
+
+			local isDim = (key == 'width' or key == 'height'
+				or key == 'columns' or key == 'spacing')
+			if(not isDim) then return end
+
+			local newBgW = (anchor and anchor._width)  or 0
+			local newBgH = (anchor and anchor._height) or 0
+			local dw = newBgW - oldBgW
+			local dh = newBgH - oldBgH
+			if(dw == 0 and dh == 0) then return end
+
+			local config = F.Units.Pinned.GetConfig()
+			local resizeAnchor = (config and config.position and config.position.anchor) or 'TOPLEFT'
+			if(resizeAnchor == 'TOPLEFT') then return end
+			if(not Shared.groupResizeShift) then return end
+
+			local dx, dy = Shared.groupResizeShift('TOPLEFT', resizeAnchor, dw, dh)
+			if(dx == 0 and dy == 0) then return end
+
+			local presetName = F.AutoSwitch.GetCurrentPreset()
+			local basePath = 'presets.' .. presetName .. '.unitConfigs.pinned.position.'
+			local curX = (config.position and config.position.x) or 0
+			local curY = (config.position and config.position.y) or 0
+			F.Config:Set(basePath .. 'x', F.Widgets.Round(curX + dx))
+			F.Config:Set(basePath .. 'y', F.Widgets.Round(curY + dy))
+
+			-- Close the 50ms gap between Layout-writes-position and the
+			-- debounced ApplyPosition that position.x's CC handler would
+			-- queue. Without this, the anchor stays at the old position
+			-- for 50ms while the frames sit at the new size — and with a
+			-- non-TOPLEFT resize anchor the pivot edge visibly drifts
+			-- before snapping back. The queued debounced ApplyPosition
+			-- still fires 50ms later, but it's a visual no-op then.
+			F.Units.Pinned.ApplyPosition()
+		end)
+	elseif(key == 'name.fontSize') then
+		debouncedApply('pinned.labelFonts', function()
+			F.Units.Pinned.ApplyLabelFonts()
+		end)
 	elseif(key and key:match('^slots')) then
 		-- Single-slot path: `slots.N` or `slots.N.<field>`. Only touch frame N
 		-- so the other eight don't re-anchor (which flashed their backdrops).

--- a/Units/LiveUpdate/FrameConfigPreset.lua
+++ b/Units/LiveUpdate/FrameConfigPreset.lua
@@ -8,8 +8,10 @@ local Shared = F.LiveUpdate.FrameConfigShared
 local ForEachFrame = Shared.ForEachFrame
 local STATUS_ELEMENT_MAP = Shared.STATUS_ELEMENT_MAP
 local GROUP_TYPES = Shared.GROUP_TYPES
+local PSEUDO_GROUPS = Shared.PSEUDO_GROUPS
 local getGroupHeader = Shared.getGroupHeader
 local repositionFrame = Shared.repositionFrame
+local cascadePseudoGroup = Shared.cascadePseudoGroup
 local applyOrQueue = Shared.applyOrQueue
 local applyGroupLayoutToHeader = Shared.applyGroupLayoutToHeader
 
@@ -31,7 +33,8 @@ local function applyFullConfig(frame, config)
 	local unitType = frame._framedUnitType
 	-- ── Position (solo frames only) ──────────────────────────
 	-- Pinned frames position via Layout() grid, not per-frame SetPoint.
-	if(not GROUP_TYPES[unitType] and unitType ~= 'pinned') then
+	-- Pseudo-groups (boss/arena) cascade together after the per-frame loop.
+	if(not GROUP_TYPES[unitType] and not PSEUDO_GROUPS[unitType] and unitType ~= 'pinned') then
 		repositionFrame(frame, config)
 	end
 
@@ -505,6 +508,14 @@ F.EventBus:Register('PRESET_CHANGED', function(presetName)
 				applyOrQueue(header, 'initial-width', config.width)
 				applyOrQueue(header, 'initial-height', config.height)
 			end
+		end
+	end
+
+	-- Re-cascade pseudo-groups (boss/arena) from new preset's position + spacing
+	for pseudoType in next, PSEUDO_GROUPS do
+		local config = F.StyleBuilder.GetConfig(pseudoType)
+		if(config) then
+			cascadePseudoGroup(pseudoType, config)
 		end
 	end
 

--- a/Units/LiveUpdate/FrameConfigShared.lua
+++ b/Units/LiveUpdate/FrameConfigShared.lua
@@ -99,6 +99,14 @@ Shared.GROUP_TYPES = {
 	worldraid    = true,
 }
 
+-- Pseudo-groups: multiple individual frames with no SecureGroupHeader.
+-- Positioned as TOPLEFT cascade from a base offset (like the drag system
+-- saves), distinct from solo frames (CENTER) and real groups (header).
+Shared.PSEUDO_GROUPS = {
+	boss  = true,
+	arena = true,
+}
+
 -- ============================================================
 -- Group header lookup
 -- ============================================================
@@ -110,6 +118,40 @@ function Shared.getGroupHeader(unitType)
 		return F.Units.Raid and F.Units.Raid.header
 	end
 	return nil
+end
+
+--- Return the ordered list of frames for a pseudo-group.
+function Shared.getPseudoGroupFrames(unitType)
+	if(unitType == 'boss') then
+		return F.Units.Boss and F.Units.Boss.frames
+	elseif(unitType == 'arena') then
+		return F.Units.Arena and F.Units.Arena.frames
+	end
+	return nil
+end
+
+--- Re-anchor all frames of a pseudo-group (boss/arena) at UIParent TOPLEFT
+--- with a per-frame cascade derived from orientation + spacing + size.
+--- Mirrors the TOPLEFT semantics that the edit-mode drag system saves.
+function Shared.cascadePseudoGroup(unitType, config)
+	local frames = Shared.getPseudoGroupFrames(unitType)
+	if(not frames) then return end
+	local baseX   = config.position.x
+	local baseY   = config.position.y
+	local spacing = config.spacing or 0
+	local orient  = config.orientation or 'vertical'
+	for i, frame in next, frames do
+		local offX, offY
+		if(orient == 'vertical') then
+			offX = baseX
+			offY = baseY - (i - 1) * (config.height + spacing)
+		else
+			offX = baseX + (i - 1) * (config.width + spacing)
+			offY = baseY
+		end
+		frame:ClearAllPoints()
+		Widgets.SetPoint(frame, 'TOPLEFT', UIParent, 'TOPLEFT', offX, offY)
+	end
 end
 
 -- ============================================================

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -494,8 +494,8 @@ function F.Units.Pinned.Layout(deferShow)
 	-- anchor:Show() deferred to the end of the function so positioning
 	-- and placeholder creation happen while the anchor is still hidden.
 
-	local count   = math.max(1, math.min(config.count   or 3, MAX_SLOTS))
-	local columns = math.max(1, math.min(config.columns or 3, count))
+	local count   = MAX_SLOTS
+	local columns = math.max(1, math.min(config.columns or 3, MAX_SLOTS))
 	local width   = config.width   or 160
 	local height  = config.height  or 40
 	local spacing = config.spacing or 2
@@ -708,7 +708,7 @@ function F.Units.Pinned.RefreshPlaceholder(slotIndex)
 	local frame = frames[slotIndex]
 	if(not frame) then return end
 
-	local count = math.max(1, math.min(config.count or 3, MAX_SLOTS))
+	local count = MAX_SLOTS
 	local width, height = config.width, config.height
 	local slot = (config.slots or {})[slotIndex]
 	local unitMissing = slot and (not frame.unit or not UnitExists(frame.unit))

--- a/Units/Pinned.lua
+++ b/Units/Pinned.lua
@@ -224,7 +224,51 @@ function F.Units.Pinned.GetConfig()
 	if(config and config.slots) then
 		normalizeSlotKeys(config.slots)
 	end
+
+	-- Overlay EditCache during edit mode so live-edit values (width, height,
+	-- spacing, columns, anchorPoint, position.x/y) flow through Layout /
+	-- ApplyPosition immediately. Commit flushes these to the real config.
+	-- Shallow-copy so we never mutate the source table.
+	if(config and F.EditCache and F.EditCache.IsActive()) then
+		local edits = F.EditCache.GetEditsForFrame('pinned')
+		if(edits) then
+			local overlay = {}
+			for k, v in next, config do overlay[k] = v end
+			for path, value in next, edits do
+				local head, rest = path:match('^([^.]+)%.(.+)$')
+				if(head and rest) then
+					local sub = {}
+					if(type(overlay[head]) == 'table') then
+						for sk, sv in next, overlay[head] do sub[sk] = sv end
+					end
+					sub[rest] = value
+					overlay[head] = sub
+				else
+					overlay[path] = value
+				end
+			end
+			return overlay
+		end
+	end
+
 	return config
+end
+
+-- ============================================================
+-- Label font sizes
+-- Placeholder + SlotIdentity labels derive from config.name.fontSize so
+-- they track the user's name-text setting instead of hardcoded constants.
+-- Primary = identity text shown when a unit is missing (matches name).
+-- Secondary = "Click to assign" hint + SlotIdentity tag above live frames
+-- (subordinate to the name).
+-- ============================================================
+local LABEL_SECONDARY_FLOOR = 8
+local function labelFontSizes()
+	local config = F.StyleBuilder.GetConfig('pinned')
+	local primary = (config and config.name and config.name.fontSize) or F.Constants.Font.sizeNormal
+	local secondary = primary - 2
+	if(secondary < LABEL_SECONDARY_FLOOR) then secondary = LABEL_SECONDARY_FLOOR end
+	return primary, secondary
 end
 
 -- ============================================================
@@ -247,7 +291,8 @@ local function Style(self, unit)
 	end
 
 	if(not self.SlotIdentity) then
-		local fs = F.Widgets.CreateFontString(self, F.Constants.Font.sizeSmall, F.Constants.Colors.textSecondary)
+		local _, secondary = labelFontSizes()
+		local fs = F.Widgets.CreateFontString(self, secondary, F.Constants.Colors.textSecondary)
 		-- Two horizontal anchors bound width to the frame so long labels
 		-- (e.g. "Some Long Name's Target") truncate with an ellipsis instead
 		-- of overflowing past the frame edges.
@@ -288,18 +333,10 @@ local function Style(self, unit)
 
 		self.ReassignGear = gear
 	end
-
-	F.Widgets.RegisterForUIScale(self)
-
-	-- RegisterForUIScale just applied SetScale(desiredScale / uiParentScale)
-	-- to self. The gear is parented to self and inherits that scale-up, which
-	-- makes it render noticeably larger than placeholder gears (parented to
-	-- the unscaled anchor). Counter-scale the gear to cancel out self's scale
-	-- so both live and placeholder gears render at the same physical size.
-	local selfScale = self:GetScale() or 1
-	if(self.ReassignGear and selfScale > 0) then
-		self.ReassignGear:SetScale(1 / selfScale)
-	end
+	-- UI scale lives on the anchor (see F.Units.Pinned.Spawn), not on
+	-- individual frames — matches party/raid headers. Keeps edit-mode
+	-- catchers (which read anchor:GetEffectiveScale) sized to the same
+	-- visual bounds as the live frames.
 end
 
 -- ============================================================
@@ -309,9 +346,14 @@ function F.Units.Pinned.ApplyPosition()
 	local anchor = F.Units.Pinned.anchor
 	if(not anchor) then return end
 	local config = F.Units.Pinned.GetConfig()
-	local pos = (config and config.position) or { x = 0, y = 0, anchor = 'CENTER' }
+	local pos = (config and config.position) or { x = 0, y = 0 }
+	-- Fixed TOPLEFT→TOPLEFT anchoring to match other group frames
+	-- (party/raid) and the edit-mode drag path, which saves x/y as
+	-- TOPLEFT offsets. position.anchor is resize-preference metadata
+	-- only — it influences how width/height changes shift the grid,
+	-- not the grid's base placement.
 	anchor:ClearAllPoints()
-	anchor:SetPoint(pos.anchor or 'CENTER', UIParent, pos.anchor or 'CENTER', pos.x or 0, pos.y or 0)
+	anchor:SetPoint('TOPLEFT', UIParent, 'TOPLEFT', pos.x or 0, pos.y or 0)
 end
 
 -- ============================================================
@@ -362,7 +404,8 @@ local function createPlaceholder(parent, slotIndex)
 	plus:SetPoint('CENTER', ph, 'CENTER', 0, 4)
 	plus:SetText('+')
 
-	local identity = F.Widgets.CreateFontString(ph, F.Constants.Font.sizeNormal, F.Constants.Colors.textPrimary)
+	local primary, secondary = labelFontSizes()
+	local identity = F.Widgets.CreateFontString(ph, primary, F.Constants.Colors.textPrimary)
 	-- Bound to placeholder width so long identity strings ("Some Long
 	-- Name's Target") truncate with an ellipsis instead of spilling past
 	-- the placeholder edges.
@@ -372,7 +415,7 @@ local function createPlaceholder(parent, slotIndex)
 	identity:SetJustifyH('CENTER')
 	identity:Hide()
 
-	local hint = F.Widgets.CreateFontString(ph, F.Constants.Font.sizeSmall, F.Constants.Colors.textSecondary)
+	local hint = F.Widgets.CreateFontString(ph, secondary, F.Constants.Colors.textSecondary)
 	hint:SetPoint('BOTTOM', ph, 'BOTTOM', 0, 4)
 	hint:SetAlpha(0.7)
 	hint:SetText('Click to assign')
@@ -491,6 +534,7 @@ function F.Units.Pinned.Layout(deferShow)
 		anchor:Hide()
 		return
 	end
+
 	-- anchor:Show() deferred to the end of the function so positioning
 	-- and placeholder creation happen while the anchor is still hidden.
 
@@ -500,25 +544,65 @@ function F.Units.Pinned.Layout(deferShow)
 	local height  = config.height  or 40
 	local spacing = config.spacing or 2
 
+	-- Growth direction follows config.anchorPoint — matches party/raid's
+	-- "Anchor Point" dropdown semantics (4 corners). Slot 1 sits at that
+	-- corner of the anchor frame; remaining slots grow inward. position.anchor
+	-- is independent resize-pivot metadata and never affects layout.
+	local anchorPoint = config.anchorPoint or 'TOPLEFT'
+	local growLeft = (anchorPoint == 'TOPRIGHT' or anchorPoint == 'BOTTOMRIGHT')
+	local growUp   = (anchorPoint == 'BOTTOMLEFT' or anchorPoint == 'BOTTOMRIGHT')
+	local slotCorner = anchorPoint
+
+	local powerHeight   = (config.power and config.power.height) or 0
+	local healthHeight  = height - powerHeight
+	local powerPosition = (config.power and config.power.position) or 'bottom'
+
 	for i = 1, MAX_SLOTS do
 		local f = frames[i]
 		if(f) then
 			if(i <= count) then
 				local row = math.ceil(i / columns) - 1
 				local col = ((i - 1) % columns)
+				local xOff = col * (width + spacing)
+				local yOff = row * (height + spacing)
+				if(growLeft)     then xOff = -xOff end
+				if(not growUp)   then yOff = -yOff end
 				f:ClearAllPoints()
-				f:SetPoint('TOPLEFT', anchor, 'TOPLEFT',
-					col * (width + spacing),
-					-(row * (height + spacing)))
+				f:SetPoint(slotCorner, anchor, slotCorner, xOff, yOff)
 				F.Widgets.SetSize(f, width, height)
-				-- The outer frame was originally pixel-snapped at the pre-scale
-				-- effective scale. Inner wrappers (health/power) captured that
-				-- snap too and were never re-run, so on non-1.0 UI scales they
-				-- render ~1px wider than the frame and spill past the dark bg.
-				-- Re-snap them at the current (post-SetScale) effective scale.
-				if(f.Health and f.Health._wrapper) then F.Widgets.ReSize(f.Health._wrapper) end
-				if(f.Power  and f.Power._wrapper)  then F.Widgets.ReSize(f.Power._wrapper)  end
-				f:Show()
+
+				-- Inner wrappers (health/power) were sized at Style time and
+				-- never re-sized on width/height changes — only ReSize-snapped
+				-- at their pre-change stored dimensions. That left the health
+				-- bar stale whenever the user resized the frame. Mirror the
+				-- party/raid preset-change pattern: explicit SetSize + re-anchor
+				-- so the bars track the outer frame on every layout pass.
+				if(f.Health and f.Health._wrapper) then
+					F.Widgets.SetSize(f.Health._wrapper, width, healthHeight)
+				end
+				if(f.Power and f.Power._wrapper) then
+					F.Widgets.SetSize(f.Power._wrapper, width, powerHeight)
+					f.Power._wrapper:ClearAllPoints()
+					f.Health._wrapper:ClearAllPoints()
+					if(powerPosition == 'top') then
+						f.Power._wrapper:SetPoint('TOPLEFT', f, 'TOPLEFT', 0, 0)
+						f.Health._wrapper:SetPoint('TOPLEFT', f, 'TOPLEFT', 0, -powerHeight)
+					else
+						f.Health._wrapper:SetPoint('TOPLEFT', f, 'TOPLEFT', 0, 0)
+						f.Power._wrapper:SetPoint('TOPLEFT', f.Health._wrapper, 'BOTTOMLEFT', 0, 0)
+					end
+					if(f.Power.SetSharedEdge) then
+						f.Power:SetSharedEdge(powerPosition)
+					end
+				end
+
+				-- Only show frames that have a unit assigned. Unassigned slots
+				-- (f.unit == nil) stay hidden because Resolve already hid them;
+				-- re-showing here would flash their stale oUF 'player' seed
+				-- state whenever Layout runs for a mid-session resize. Cold-
+				-- start / enable-toggle paths go through Refresh, which runs
+				-- Resolve after Layout to set unit + visibility correctly.
+				if(f.unit) then f:Show() end
 			else
 				f:Hide()
 			end
@@ -700,6 +784,42 @@ end
 
 --- Re-evaluate placeholder visibility/mode for a single slot. Called from
 --- ApplySlot (assignment change) and from the poll loop (target appeared or
+--- Refresh placeholder + SlotIdentity fonts after name.fontSize changes.
+--- Walks live frames and placeholders, reapplying primary/secondary sizes.
+function F.Units.Pinned.ApplyLabelFonts()
+	local primary, secondary = labelFontSizes()
+	local fontPath = F.Media.GetActiveFont()
+	local frames = F.Units.Pinned.frames
+	if(frames) then
+		for i = 1, MAX_SLOTS do
+			local f = frames[i]
+			if(f and f.SlotIdentity) then
+				local _, _, flags = f.SlotIdentity:GetFont()
+				f.SlotIdentity:SetFont(fontPath, secondary, flags or '')
+				f.SlotIdentity._fontSize = secondary
+			end
+		end
+	end
+	local phs = F.Units.Pinned.placeholders
+	if(phs) then
+		for i = 1, MAX_SLOTS do
+			local ph = phs[i]
+			if(ph) then
+				if(ph._identityText) then
+					local _, _, flags = ph._identityText:GetFont()
+					ph._identityText:SetFont(fontPath, primary, flags or '')
+					ph._identityText._fontSize = primary
+				end
+				if(ph._hintText) then
+					local _, _, flags = ph._hintText:GetFont()
+					ph._hintText:SetFont(fontPath, secondary, flags or '')
+					ph._hintText._fontSize = secondary
+				end
+			end
+		end
+	end
+end
+
 --- disappeared for a nametarget/focustarget slot).
 function F.Units.Pinned.RefreshPlaceholder(slotIndex)
 	local config = F.Units.Pinned.GetConfig()
@@ -825,6 +945,13 @@ function F.Units.Pinned.Spawn()
 	-- spawn and Resolve setting unit=nil on unassigned slots.
 	anchor:Hide()
 	F.Widgets.SetSize(anchor, 1, 1)
+	-- UI scale lives on the anchor, not on individual frames. Mirrors
+	-- party/raid (Widgets.RegisterForUIScale on the header) so the
+	-- anchor's effective scale matches what users see — which means
+	-- edit-mode catchers (reading anchor:GetEffectiveScale) match the
+	-- live-frame bounds, and placeholders parented to the anchor scale
+	-- in lockstep with their live counterparts.
+	F.Widgets.RegisterForUIScale(anchor)
 	F.Units.Pinned.anchor = anchor
 	F.Units.Pinned.ApplyPosition()
 


### PR DESCRIPTION
  ## Summary
  Release cut for **v0.8.12-alpha**. Pinned edit-mode, group-frame position sliders, boss/arena save-after-drag fix. Full notes in [CHANGELOG.md](CHANGELOG.md#v0812-alpha).
                                                                                                                                                                                                
  Merging this triggers `auto-tag.yml` → `release.yml` (packager + Discord).                                                                                                                    
                                                                                                                                                                                                
  ### Highlights                                                                                                                                                                                
  - **Pinned edit mode** now renders all 9 slots instead of a single fake frame; drag/preview/live-layout agree on TOPLEFT anchor; legacy CENTER saves auto-migrate
  - **Edit-mode first-drag** bug fixed — click-and-drag-immediately now selects + previews the frame                                                                                            
  - **Group position sliders** (party / raid / arena / boss) actually move the real frame in edit mode                                                                                          
  - **Boss / arena save-after-drag** fix — frames stored as TOPLEFT but reapplied as CENTER were landing off-screen on `/reload`; now TOPLEFT end-to-end, existing saves self-heal              
  - **Inline edit panel** sliders and dropdowns reliably receive clicks (sibling shield split)                                                                                                  
  - **Pinned live geometry** no longer flashes on width/height/columns/spacing edits; Resize Anchor pivot edge stays fixed                                                                      
  - **Pinned name/label text** scales with `Name font size` (fixes oversized text at non-1.0 UI scales)                                                                                         
                                                                                                                                                                                                
  ### Version                                                                                                                                                                                   
  - `Framed.toc`: `0.8.11-alpha` → `0.8.12-alpha`                                                                                                                                               
  - About card's Changelog table regenerated (`./tools/sync-changelog.lua`)                                                                                                                     
                                                                                                                                                                                                
  ## Post-merge
  - [ ] Confirm `auto-tag.yml` creates `v0.8.12-alpha` tag                                                                                                                                      
  - [ ] Confirm `release.yml` publishes to CurseForge and posts to Discord