### PR TITLE
Promote v0.8.14-alpha to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## v0.8.14-alpha
+
+- **12.0.5 compatibility** — fix `bad argument #2 to '?' (Current Field: [isContainer])` error on unit frame spawn; 12.0.5 added a required `isContainer` field to `C_UnitAuras.AddPrivateAuraAnchor`'s args table
+- Add `/framed aurastate [unit]` debug slash — dumps the classified aura flag breakdown for a unit (defaults to target), showing which of `external-defensive`, `important`, `player-cast`, `big-defensive`, `raid`, `boss`, `from-player-or-pet` apply to each aura. Useful for verifying classification correctness as #115's B-series migrations land
+- Internal: AuraState now exposes shared per-frame classification (`GetHelpfulClassified` / `GetHarmfulClassified` / `GetClassifiedByInstanceID`) with write-path invalidation wired through `FullRefresh` and `ApplyUpdateInfo`. No element yet consumes the new API — infrastructure only in this patch, element migrations follow in subsequent releases (#115 B1-B6)
+
 ## v0.8.13-alpha
 
 - **12.0.5 readiness** — fix Buffs `castBy = 'me'` / `'others'` silently filtering to empty when Blizzard marks `sourceUnit` secret in combat (#113); the indicator now falls back to `isFromPlayerOrPlayerPet` when the source is unreachable

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -174,8 +174,12 @@ function AuraState:FullRefresh(unit)
 	wipe(self._harmfulById)
 	self:ResetHelpfulMatches()
 	self:ResetHarmfulMatches()
+	self:ResetHelpfulClassified()
+	self:ResetHarmfulClassified()
 	self:MarkHelpfulDirty()
 	self:MarkHarmfulDirty()
+	self:MarkHelpfulClassifiedDirty()
+	self:MarkHarmfulClassifiedDirty()
 
 	if(not unit or not GetAuraSlots or not GetAuraDataBySlot) then return end
 	if(isCompoundUnit(unit)) then return end
@@ -236,11 +240,13 @@ function AuraState:ApplyUpdateInfo(unit, updateInfo)
 			if(aura and aura.auraInstanceID and isHelpfulAura(unit, aura)) then
 				self._helpfulById[aura.auraInstanceID] = aura
 				self:InvalidateHelpfulMatch(aura.auraInstanceID)
+				self:InvalidateHelpfulClassified(aura.auraInstanceID)
 				helpfulChanged = true
 			end
 			if(aura and aura.auraInstanceID and isHarmfulAura(unit, aura)) then
 				self._harmfulById[aura.auraInstanceID] = aura
 				self:InvalidateHarmfulMatch(aura.auraInstanceID)
+				self:InvalidateHarmfulClassified(aura.auraInstanceID)
 				harmfulChanged = true
 			end
 		end
@@ -252,20 +258,24 @@ function AuraState:ApplyUpdateInfo(unit, updateInfo)
 			if(aura and aura.auraInstanceID and isHelpfulAura(unit, aura)) then
 				self._helpfulById[auraInstanceID] = aura
 				self:InvalidateHelpfulMatch(auraInstanceID)
+				self:InvalidateHelpfulClassified(auraInstanceID)
 				helpfulChanged = true
 			elseif(self._helpfulById[auraInstanceID]) then
 				self._helpfulById[auraInstanceID] = nil
 				self:InvalidateHelpfulMatch(auraInstanceID)
+				self:InvalidateHelpfulClassified(auraInstanceID)
 				helpfulChanged = true
 			end
 
 			if(aura and aura.auraInstanceID and isHarmfulAura(unit, aura)) then
 				self._harmfulById[auraInstanceID] = aura
 				self:InvalidateHarmfulMatch(auraInstanceID)
+				self:InvalidateHarmfulClassified(auraInstanceID)
 				harmfulChanged = true
 			elseif(self._harmfulById[auraInstanceID]) then
 				self._harmfulById[auraInstanceID] = nil
 				self:InvalidateHarmfulMatch(auraInstanceID)
+				self:InvalidateHarmfulClassified(auraInstanceID)
 				harmfulChanged = true
 			end
 		end
@@ -276,11 +286,13 @@ function AuraState:ApplyUpdateInfo(unit, updateInfo)
 			if(self._helpfulById[auraInstanceID]) then
 				self._helpfulById[auraInstanceID] = nil
 				self:InvalidateHelpfulMatch(auraInstanceID)
+				self:InvalidateHelpfulClassified(auraInstanceID)
 				helpfulChanged = true
 			end
 			if(self._harmfulById[auraInstanceID]) then
 				self._harmfulById[auraInstanceID] = nil
 				self:InvalidateHarmfulMatch(auraInstanceID)
+				self:InvalidateHarmfulClassified(auraInstanceID)
 				harmfulChanged = true
 			end
 		end
@@ -288,9 +300,11 @@ function AuraState:ApplyUpdateInfo(unit, updateInfo)
 
 	if(helpfulChanged) then
 		self:MarkHelpfulDirty()
+		self:MarkHelpfulClassifiedDirty()
 	end
 	if(harmfulChanged) then
 		self:MarkHarmfulDirty()
+		self:MarkHarmfulClassifiedDirty()
 	end
 end
 

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -100,6 +100,30 @@ function AuraState:MarkHarmfulDirty()
 	end
 end
 
+function AuraState:ResetHelpfulClassified()
+	wipe(self._helpfulClassifiedById)
+end
+
+function AuraState:ResetHarmfulClassified()
+	wipe(self._harmfulClassifiedById)
+end
+
+function AuraState:InvalidateHelpfulClassified(auraInstanceID)
+	self._helpfulClassifiedById[auraInstanceID] = nil
+end
+
+function AuraState:InvalidateHarmfulClassified(auraInstanceID)
+	self._harmfulClassifiedById[auraInstanceID] = nil
+end
+
+function AuraState:MarkHelpfulClassifiedDirty()
+	self._helpfulClassifiedView.dirty = true
+end
+
+function AuraState:MarkHarmfulClassifiedDirty()
+	self._harmfulClassifiedView.dirty = true
+end
+
 function AuraState:EnsureHelpfulView(filter)
 	local view = self._helpfulViews[filter]
 	if(not view) then

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -376,6 +376,34 @@ function AuraState:GetHarmfulClassified()
 	return view.list
 end
 
+function AuraState:GetClassifiedByInstanceID(auraInstanceID)
+	local entry = self._helpfulClassifiedById[auraInstanceID]
+	if(entry) then
+		return entry
+	end
+
+	local aura = self._helpfulById[auraInstanceID]
+	if(aura) then
+		entry = classify(self._unit, aura, true)
+		self._helpfulClassifiedById[auraInstanceID] = entry
+		return entry
+	end
+
+	entry = self._harmfulClassifiedById[auraInstanceID]
+	if(entry) then
+		return entry
+	end
+
+	aura = self._harmfulById[auraInstanceID]
+	if(aura) then
+		entry = classify(self._unit, aura, false)
+		self._harmfulClassifiedById[auraInstanceID] = entry
+		return entry
+	end
+
+	return nil
+end
+
 function F.AuraState.Create(owner)
 	return setmetatable({
 		_owner = owner,

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -334,6 +334,48 @@ function AuraState:GetHarmful(filter)
 	return view.list
 end
 
+function AuraState:GetHelpfulClassified()
+	local view = self._helpfulClassifiedView
+	if(not view.dirty) then
+		return view.list
+	end
+
+	view.dirty = false
+	wipe(view.list)
+
+	for id, aura in next, self._helpfulById do
+		local entry = self._helpfulClassifiedById[id]
+		if(not entry) then
+			entry = classify(self._unit, aura, true)
+			self._helpfulClassifiedById[id] = entry
+		end
+		view.list[#view.list + 1] = entry
+	end
+
+	return view.list
+end
+
+function AuraState:GetHarmfulClassified()
+	local view = self._harmfulClassifiedView
+	if(not view.dirty) then
+		return view.list
+	end
+
+	view.dirty = false
+	wipe(view.list)
+
+	for id, aura in next, self._harmfulById do
+		local entry = self._harmfulClassifiedById[id]
+		if(not entry) then
+			entry = classify(self._unit, aura, false)
+			self._harmfulClassifiedById[id] = entry
+		end
+		view.list[#view.list + 1] = entry
+	end
+
+	return view.list
+end
+
 function F.AuraState.Create(owner)
 	return setmetatable({
 		_owner = owner,

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -320,8 +320,12 @@ function F.AuraState.Create(owner)
 		_helpfulById = {},
 		_helpfulViews = {},
 		_helpfulMatches = {},
+		_helpfulClassifiedById = {},
+		_helpfulClassifiedView = { dirty = true, list = {} },
 		_harmfulById = {},
 		_harmfulViews = {},
 		_harmfulMatches = {},
+		_harmfulClassifiedById = {},
+		_harmfulClassifiedView = { dirty = true, list = {} },
 	}, AuraState)
 end

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -8,6 +8,31 @@ local GetAuraDataBySlot = C_UnitAuras and C_UnitAuras.GetAuraDataBySlot
 local GetAuraDataByAuraInstanceID = C_UnitAuras and C_UnitAuras.GetAuraDataByAuraInstanceID
 local IsAuraFilteredOutByInstanceID = C_UnitAuras and C_UnitAuras.IsAuraFilteredOutByInstanceID
 
+-- Classify a single aura into a wrapper entry { aura, flags }.
+-- Tier 1 flags are structural passthroughs from AuraData (never secret).
+-- Tier 2 flags use C_UnitAuras filter probes (secret-safe C API).
+local function classify(unit, aura, isHelpful)
+	local id = aura.auraInstanceID
+	local prefix = isHelpful and 'HELPFUL' or 'HARMFUL'
+
+	local flags = {
+		isHelpful         = aura.isHelpful         or false,
+		isHarmful         = aura.isHarmful         or false,
+		isRaid            = aura.isRaid            or false,
+		isBossAura        = aura.isBossAura        or false,
+		isFromPlayerOrPet = aura.isFromPlayerOrPlayerPet or false,
+	}
+
+	flags.isExternalDefensive = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|EXTERNAL_DEFENSIVE') == false
+	flags.isImportant         = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|IMPORTANT')          == false
+	flags.isPlayerCast        = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|PLAYER')             == false
+	flags.isBigDefensive      = isHelpful
+	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HELPFUL|BIG_DEFENSIVE') == false
+	                            or false
+
+	return { aura = aura, flags = flags }
+end
+
 -- Compound unit tokens (e.g. 'party2target', 'playertarget', 'focustarget')
 -- are rejected by C_UnitAuras.GetAuraSlots. Pinned target-chain slots can
 -- produce these tokens — skip aura queries for them rather than erroring.

--- a/Elements/Auras/PrivateAuras.lua
+++ b/Elements/Auras/PrivateAuras.lua
@@ -39,6 +39,7 @@ local function RegisterAnchors(element, unit)
 			parent               = slot.frame,
 			showCountdownFrame   = true,
 			showCountdownNumbers = true,
+			isContainer          = false,
 			iconInfo             = {
 				iconWidth   = iconSize,
 				iconHeight  = iconSize,

--- a/Framed.toc
+++ b/Framed.toc
@@ -2,7 +2,7 @@
 ## Title: Framed
 ## Notes: Modern, customizable unit frames and raid frames
 ## Author: Moodibs
-## Version: 0.8.13-alpha
+## Version: 0.8.14-alpha
 ## X-Curse-Project-ID: 1513359
 ## SavedVariables: FramedDB, FramedBackupDB, FramedSnapshotsDB
 ## SavedVariablesPerCharacter: FramedCharDB

--- a/Init.lua
+++ b/Init.lua
@@ -418,6 +418,38 @@ SlashCmdList['FRAMED'] = function(msg)
 			return
 		end
 		showTestImportPopup(encoded)
+	elseif(cmd == 'aurastate') then
+		local unit = arg1:match('^(%S+)') or 'target'
+		if(not UnitExists(unit)) then
+			print('|cff00ccff Framed|r aurastate: unit "' .. unit .. '" does not exist')
+			return
+		end
+
+		local state = F.AuraState.Create(nil)
+		state:FullRefresh(unit)
+
+		local function formatFlags(flags)
+			local active = {}
+			for k, v in next, flags do
+				if(v) then active[#active + 1] = k end
+			end
+			if(#active == 0) then return '(none)' end
+			table.sort(active)
+			return table.concat(active, ' ')
+		end
+
+		local function dumpList(label, list)
+			print('|cff00ccff Framed|r aurastate ' .. unit .. ' — ' .. label .. ' (' .. #list .. ')')
+			for _, entry in next, list do
+				local id = entry.aura.auraInstanceID
+				local name = F.IsValueNonSecret(entry.aura.name) and entry.aura.name or '<secret>'
+				local spellId = F.IsValueNonSecret(entry.aura.spellId) and tostring(entry.aura.spellId) or '?'
+				print('  [' .. id .. '] ' .. name .. ' (spellId=' .. spellId .. ') ' .. formatFlags(entry.flags))
+			end
+		end
+
+		dumpList('HELPFUL', state:GetHelpfulClassified())
+		dumpList('HARMFUL', state:GetHarmfulClassified())
 	elseif(cmd == 'help') then
 		print('|cff00ccff Framed|r v' .. F.version .. ' — Commands:')
 		print('  /framed — Open settings')
@@ -429,6 +461,7 @@ SlashCmdList['FRAMED'] = function(msg)
 		print('  /framed restore — Restore the most recent reset backup from the Backups panel')
 		print('  /framed debugicons — Debug indicator element state')
 		print('  /framed testimport — Generate a synthetic-diff import string for testing backfill')
+		print('  /framed aurastate [unit] — Dump classified aura flags (default: target)')
 	else
 		-- Default: open settings
 		if(F.Settings and F.Settings.Toggle) then

--- a/Settings/Cards/About.lua
+++ b/Settings/Cards/About.lua
@@ -114,6 +114,14 @@ end
 -- BEGIN GENERATED CHANGELOG
 local CHANGELOG = {
 	{
+		version = 'v0.8.14-alpha',
+		entries = {
+			'**12.0.5 compatibility** — fix `bad argument #2 to \'?\' (Current Field: [isContainer])` error on unit frame spawn; 12.0.5 added a required `isContainer` field to `C_UnitAuras.AddPrivateAuraAnchor`\'s args table',
+			'Add `/framed aurastate [unit]` debug slash — dumps the classified aura flag breakdown for a unit (defaults to target), showing which of `external-defensive`, `important`, `player-cast`, `big-defensive`, `raid`, `boss`, `from-player-or-pet` apply to each aura. Useful for verifying classification correctness as #115\'s B-series migrations land',
+			'Internal: AuraState now exposes shared per-frame classification (`GetHelpfulClassified` / `GetHarmfulClassified` / `GetClassifiedByInstanceID`) with write-path invalidation wired through `FullRefresh` and `ApplyUpdateInfo`. No element yet consumes the new API — infrastructure only in this patch, element migrations follow in subsequent releases (#115 B1-B6)',
+		},
+	},
+	{
 		version = 'v0.8.13-alpha',
 		entries = {
 			'**12.0.5 readiness** — fix Buffs `castBy = \'me\'` / `\'others\'` silently filtering to empty when Blizzard marks `sourceUnit` secret in combat (#113); the indicator now falls back to `isFromPlayerOrPlayerPet` when the source is unreachable',
@@ -122,24 +130,6 @@ local CHANGELOG = {
 			'Halve `IconTicker` per-frame cost and skip redundant threshold setters on aura icons (#114)',
 			'Fix `ADDON_ACTION_BLOCKED` on `FramedPinnedAnchor:Hide` when a roster update arrives mid-combat — Pinned `Refresh()` now defers to `PLAYER_REGEN_ENABLED` if combat is locked down (mirrors the existing `pendingResolve` pattern)',
 			'Buffs aura filter is now derived from the indicator set instead of a separate `buffFilterMode` config key — any indicator with a spell list widens the query to `HELPFUL` so specific tracked spells (e.g. follower Rejuvenation) can surface; otherwise stays on `HELPFUL|RAID_IN_COMBAT` to keep trivial raid buffs out. The vestigial `buffFilterMode` key (never had UI) is dropped and migrated out of existing saves',
-		},
-	},
-	{
-		version = 'v0.8.12-alpha',
-		entries = {
-			'**Pinned Frames in Edit Mode** — the drag catcher and selected preview now render the full 9-slot grid instead of a single fake frame, so moving pinned frames in edit mode reflects what you\'ll actually see in-game',
-			'Pinned anchor convention flipped to TOPLEFT to match boss/arena (drag math, catcher bounds, and live layout now agree); existing CENTER-anchored pinned saves are auto-migrated on load to the equivalent TOPLEFT offset so nothing visually shifts',
-			'Pinned geometry edits (width, height, columns, spacing) live-update without the grid flashing during resize, and Resize Anchor compensation keeps the pivot edge visually fixed instead of bouncing back on each slider tick',
-			'Pinned placeholder identity labels ("Pin 1" … "Pin 9") and slot name tags ("Click to assign", character name) now scale with `Name font size` (primary and primary−2, floor 8) — previously hardcoded text looked oversized at non-1.0 UI scales',
-			'Fix edit-mode first drag doing nothing visible — clicking-and-dragging immediately (without releasing first) now selects the frame so the preview appears as you drag',
-			'Fix group position sliders (party, raid, arena, boss) not moving the real frame during slider drag in edit mode — the handler only supported solo CENTER anchoring',
-			'Fix edit-mode preview not rebuilding when position/size sliders change — preview now tracks slider motion in real time via the EditCache',
-			'Fix inline edit panel sliders and dropdowns sometimes missing clicks — split into a sibling shield + panel so children hit-test uncontested; inline panel rebuilds on preset switch so sliders read the active preset\'s config',
-			'Fix boss and arena frames saving off-screen after a drag — they were written as TOPLEFT offsets but reapplied as CENTER offsets on reload/preset change. Now TOPLEFT end-to-end via a `PSEUDO_GROUPS` cascade path; existing saves self-heal because the stored values were already in TOPLEFT space',
-			'Narrow pinned settings card keeps a 2-column quick-nav summary (was collapsing to 1 column and pushing most rows below the fold); summary rows reflow mid-animation so labels no longer clip past the card edge while the card width tweens',
-			'Preset switches now redirect away from preset-specific panels (e.g. pinned under Solo) even while Settings is hidden, so reopening doesn\'t flash a stale panel',
-			'Inline edit panel stripped down to just Position & Layout — edit mode is strictly for positioning; all other settings live in the main Settings window with live previews',
-			'Internal cleanup: drop inert `config.count` from pinned (always capped at 9, no UI), consolidate pinned frame-scale handling onto a single anchor-level `RegisterForUIScale` (removes the per-frame gear counter-scale workaround), and rename a shadowed migration local to keep luacheck clean',
 		},
 	},
 }

--- a/docs/superpowers/plans/2026-04-21-a1-aurastate-classification.md
+++ b/docs/superpowers/plans/2026-04-21-a1-aurastate-classification.md
@@ -1,0 +1,975 @@
+# A1 — AuraState Classification Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a classification layer to `Core/AuraState.lua` that precomputes per-aura flags (`isExternalDefensive`, `isImportant`, `isPlayerCast`, `isBigDefensive`, plus five structural passthroughs) and exposes them via three instance methods (`GetHelpfulClassified`, `GetHarmfulClassified`, `GetClassifiedByInstanceID`). Ship a `/framed aurastate <unit>` debug slash for live verification. Closes issue #136.
+
+**Architecture:** Lazy-at-read classification keyed by `auraInstanceID`, invalidated from the write path. Classification lives on the existing per-frame AuraState instance (shared idempotently across all aura elements via the `if(not self.FramedAuraState)` guard in each element's Setup). No new event registrations. No changes to existing elements or legacy stores (`_helpfulById`, `_helpfulMatches`). Behavior-neutral for all current elements — they keep using `GetHelpful(filter)` / `GetHarmful(filter)` until the B-series migrates them individually.
+
+**Tech Stack:** Lua 5.1 (WoW 12.0.1), oUF embedded framework (`F.oUF`), `C_UnitAuras` C-level APIs (`IsAuraFilteredOutByInstanceID`), AuraCache generation-based invalidation.
+
+**Reference:** `docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md`
+
+**Branch:** `working-testing` (per `project_framed_worktree`). Each task commits to that branch and pushes.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change type |
+|------|----------------|-------------|
+| `Core/AuraState.lua` | Per-frame aura state with lazy-view pattern; **A1 extends** with classified stores, classify helper, 3 read methods, 4 invalidation methods, 1 debug print function | Modified |
+| `Init.lua` | Slash-command dispatcher (lines 284-438) | Modified — one new `elseif` case + one help line |
+
+No new files. All A1 code fits in two existing files.
+
+---
+
+## Task 1: Add per-instance classified state fields
+
+**Files:**
+- Modify: `Core/AuraState.lua:312-327` (the `F.AuraState.Create` factory)
+
+Per the spec's "Post-A1 store shape" section, each AuraState instance gets two per-classification dicts + two per-classification views, parallel to the existing `_helpfulById` / `_harmfulById` / views pattern.
+
+- [ ] **Step 1: Read current `F.AuraState.Create`**
+
+Run: look at `Core/AuraState.lua` lines 312-327. Current body:
+
+```lua
+function F.AuraState.Create(owner)
+	return setmetatable({
+		_owner = owner,
+		_unit = nil,
+		_initialized = false,
+		_gen = 0,
+		_lastUpdateInfo = nil,
+		_lastUpdateUnit = nil,
+		_helpfulById = {},
+		_helpfulViews = {},
+		_helpfulMatches = {},
+		_harmfulById = {},
+		_harmfulViews = {},
+		_harmfulMatches = {},
+	}, AuraState)
+end
+```
+
+- [ ] **Step 2: Add four classified-store fields**
+
+Edit `Core/AuraState.lua` — replace the `F.AuraState.Create` body with:
+
+```lua
+function F.AuraState.Create(owner)
+	return setmetatable({
+		_owner = owner,
+		_unit = nil,
+		_initialized = false,
+		_gen = 0,
+		_lastUpdateInfo = nil,
+		_lastUpdateUnit = nil,
+		_helpfulById = {},
+		_helpfulViews = {},
+		_helpfulMatches = {},
+		_helpfulClassifiedById = {},
+		_helpfulClassifiedView = { dirty = true, list = {} },
+		_harmfulById = {},
+		_harmfulViews = {},
+		_harmfulMatches = {},
+		_harmfulClassifiedById = {},
+		_harmfulClassifiedView = { dirty = true, list = {} },
+	}, AuraState)
+end
+```
+
+- [ ] **Step 3: `/reload` in-game and verify no startup errors**
+
+In WoW: run `/reload`.
+
+Expected: addon loads without Lua errors. The four new fields exist on every AuraState instance but are not yet read or written by anything — no observable change. Run `/framed events` → UNIT_AURA still registered once; no duplicates.
+
+- [ ] **Step 4: Commit and push**
+
+```bash
+git add Core/AuraState.lua
+git commit -m "$(cat <<'EOF'
+feat(aurastate): add classified store fields
+
+Scaffolding for A1 (#136). Adds per-instance `_helpfulClassifiedById`,
+`_helpfulClassifiedView`, and harmful twins to F.AuraState.Create. No
+reader or writer touches these yet — no observable behavior change.
+EOF
+)"
+git push origin working-testing
+```
+
+---
+
+## Task 2: Add module-local `classify()` helper
+
+**Files:**
+- Modify: `Core/AuraState.lua` — insert new function above line 14 (the `isCompoundUnit` helper)
+
+Per the spec's "Classification function" section. This is a pure function — no state, no side effects, no allocation outside the returned table. Safe to unit-test by reading the call site only.
+
+- [ ] **Step 1: Verify the `IsAuraFilteredOutByInstanceID` module local exists**
+
+Run: look at `Core/AuraState.lua:9`. Current line:
+
+```lua
+local IsAuraFilteredOutByInstanceID = C_UnitAuras and C_UnitAuras.IsAuraFilteredOutByInstanceID
+```
+
+This is already present. `classify()` will close over it — no re-capture needed.
+
+- [ ] **Step 2: Insert the `classify` helper above `isCompoundUnit`**
+
+Edit `Core/AuraState.lua` — find the block starting at line 11:
+
+```lua
+-- Compound unit tokens (e.g. 'party2target', 'playertarget', 'focustarget')
+-- are rejected by C_UnitAuras.GetAuraSlots. Pinned target-chain slots can
+-- produce these tokens — skip aura queries for them rather than erroring.
+local function isCompoundUnit(unit)
+```
+
+Replace that block with:
+
+```lua
+-- Classify a single aura into a wrapper entry { aura, flags }.
+-- Tier 1 flags are structural passthroughs from AuraData (never secret).
+-- Tier 2 flags use C_UnitAuras filter probes (secret-safe C API).
+local function classify(unit, aura, isHelpful)
+	local id = aura.auraInstanceID
+	local prefix = isHelpful and 'HELPFUL' or 'HARMFUL'
+
+	local flags = {
+		isHelpful         = aura.isHelpful         or false,
+		isHarmful         = aura.isHarmful         or false,
+		isRaid            = aura.isRaid            or false,
+		isBossAura        = aura.isBossAura        or false,
+		isFromPlayerOrPet = aura.isFromPlayerOrPlayerPet or false,
+	}
+
+	-- Explicit `== false` (not `not ...`). IsAuraFilteredOutByInstanceID returns
+	-- nil for invalid state; `not nil == true` would promote every aura.
+	flags.isExternalDefensive = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|EXTERNAL_DEFENSIVE') == false
+	flags.isImportant         = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|IMPORTANT')          == false
+	flags.isPlayerCast        = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|PLAYER')             == false
+	flags.isBigDefensive      = isHelpful
+	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HELPFUL|BIG_DEFENSIVE') == false
+	                            or false
+
+	return { aura = aura, flags = flags }
+end
+
+-- Compound unit tokens (e.g. 'party2target', 'playertarget', 'focustarget')
+-- are rejected by C_UnitAuras.GetAuraSlots. Pinned target-chain slots can
+-- produce these tokens — skip aura queries for them rather than erroring.
+local function isCompoundUnit(unit)
+```
+
+- [ ] **Step 3: `/reload` and verify no parse errors**
+
+Run: `/reload` in-game. Expected: addon loads without errors. `classify()` is defined but not called — no observable change.
+
+- [ ] **Step 4: Commit and push**
+
+```bash
+git add Core/AuraState.lua
+git commit -m "$(cat <<'EOF'
+feat(aurastate): add classify() helper
+
+Module-local pure function for A1 (#136). Builds a { aura, flags }
+wrapper entry — five structural passthroughs plus four C-probe flags
+(EXTERNAL_DEFENSIVE, IMPORTANT, PLAYER, BIG_DEFENSIVE). Uses explicit
+`== false` normalization to handle nil returns safely. Not yet wired
+to any caller.
+EOF
+)"
+git push origin working-testing
+```
+
+---
+
+## Task 3: Add `GetHelpfulClassified` and `GetHarmfulClassified` read methods
+
+**Files:**
+- Modify: `Core/AuraState.lua` — append new methods after `GetHarmful` (ends around line 310), before `F.AuraState.Create`
+
+Per the spec's "Components and APIs" section. These mirror the existing `GetHelpful` / `GetHarmful` view-rebuild pattern (AuraState.lua:248-310): check `view.dirty`, rebuild if needed, cache entries in `_helpfulClassifiedById` for reuse across rebuilds.
+
+- [ ] **Step 1: Locate the insertion point**
+
+Run: look at `Core/AuraState.lua` — find the end of `function AuraState:GetHarmful(filter)` (ends with `end` around line 310), and the start of `function F.AuraState.Create(owner)` (around line 312). The two new methods go between them.
+
+- [ ] **Step 2: Insert both read methods**
+
+Edit `Core/AuraState.lua` — find this transition:
+
+```lua
+	return view.list
+end
+
+function F.AuraState.Create(owner)
+```
+
+Replace with:
+
+```lua
+	return view.list
+end
+
+--- Array of wrapper entries for all helpful auras on the instance's unit.
+--- @return table   -- array of { aura = AuraData, flags = { isHelpful, ... } }
+function AuraState:GetHelpfulClassified()
+	local view = self._helpfulClassifiedView
+	if(not view.dirty) then
+		return view.list
+	end
+
+	view.dirty = false
+	wipe(view.list)
+
+	if(not self._unit) then
+		return view.list
+	end
+
+	for id, aura in next, self._helpfulById do
+		local entry = self._helpfulClassifiedById[id]
+		if(not entry) then
+			entry = classify(self._unit, aura, true)
+			self._helpfulClassifiedById[id] = entry
+		end
+		view.list[#view.list + 1] = entry
+	end
+
+	return view.list
+end
+
+--- Array of wrapper entries for all harmful auras on the instance's unit.
+--- @return table   -- array of { aura = AuraData, flags = { isHelpful, ... } }
+function AuraState:GetHarmfulClassified()
+	local view = self._harmfulClassifiedView
+	if(not view.dirty) then
+		return view.list
+	end
+
+	view.dirty = false
+	wipe(view.list)
+
+	if(not self._unit) then
+		return view.list
+	end
+
+	for id, aura in next, self._harmfulById do
+		local entry = self._harmfulClassifiedById[id]
+		if(not entry) then
+			entry = classify(self._unit, aura, false)
+			self._harmfulClassifiedById[id] = entry
+		end
+		view.list[#view.list + 1] = entry
+	end
+
+	return view.list
+end
+
+function F.AuraState.Create(owner)
+```
+
+- [ ] **Step 3: `/reload` and verify no errors**
+
+Run: `/reload`. Expected: no errors. Methods are defined but no caller exists yet.
+
+- [ ] **Step 4: Smoke-test via scratch print (optional sanity check)**
+
+In WoW chat, run:
+
+```
+/run local s = FramedAddon.AuraState.Create('test'); s:FullRefresh('player'); local list = s:GetHelpfulClassified(); print('helpful count:', #list); for _, e in next, list do print(e.aura.auraInstanceID, e.flags.isHelpful, e.flags.isRaid) end
+```
+
+Expected: prints your current helpful auras on `player`, with `isHelpful=true` for each. Caveat: without invalidation wiring (Tasks 5-6), this only works on a fresh throwaway state — don't reuse the scratch `s` across aura changes.
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+git add Core/AuraState.lua
+git commit -m "$(cat <<'EOF'
+feat(aurastate): add GetHelpfulClassified / GetHarmfulClassified
+
+A1 (#136) read methods. Mirrors the existing GetHelpful / GetHarmful
+view-rebuild pattern — check view.dirty, rebuild from _helpfulById
+with classify() on cache miss, reuse entries across generations when
+not invalidated. No element consumes these yet.
+EOF
+)"
+git push origin working-testing
+```
+
+---
+
+## Task 4: Add `GetClassifiedByInstanceID`
+
+**Files:**
+- Modify: `Core/AuraState.lua` — append after `GetHarmfulClassified`
+
+Per the spec's "Components and APIs" section. Single-entry accessor for the planned B3 Buffs per-indicator resolution path. Falls through helpful → harmful stores; lazy-classifies on cache miss.
+
+- [ ] **Step 1: Insert `GetClassifiedByInstanceID` method**
+
+Edit `Core/AuraState.lua` — find the end of `GetHarmfulClassified` (just added in Task 3) followed by `function F.AuraState.Create(owner)`. Insert between them:
+
+```lua
+	return view.list
+end
+
+--- Wrapper entry for a single aura instance ID, or nil.
+--- Planned primary consumer: B3 Buffs (#139) per-indicator spellID resolution.
+--- @param instanceID number
+--- @return table|nil   -- { aura, flags } or nil if not tracked on this unit
+function AuraState:GetClassifiedByInstanceID(instanceID)
+	if(not instanceID or not self._unit) then
+		return nil
+	end
+
+	local entry = self._helpfulClassifiedById[instanceID]
+	if(entry) then
+		return entry
+	end
+	entry = self._harmfulClassifiedById[instanceID]
+	if(entry) then
+		return entry
+	end
+
+	-- Cache miss — look up in the raw stores and classify lazily.
+	local aura = self._helpfulById[instanceID]
+	if(aura) then
+		entry = classify(self._unit, aura, true)
+		self._helpfulClassifiedById[instanceID] = entry
+		return entry
+	end
+	aura = self._harmfulById[instanceID]
+	if(aura) then
+		entry = classify(self._unit, aura, false)
+		self._harmfulClassifiedById[instanceID] = entry
+		return entry
+	end
+
+	return nil
+end
+
+function F.AuraState.Create(owner)
+```
+
+- [ ] **Step 2: `/reload` and verify no errors**
+
+Run: `/reload`. Expected: no errors. Method defined, no caller.
+
+- [ ] **Step 3: Commit and push**
+
+```bash
+git add Core/AuraState.lua
+git commit -m "$(cat <<'EOF'
+feat(aurastate): add GetClassifiedByInstanceID
+
+A1 (#136) single-entry accessor. Falls through helpful → harmful
+classified stores; lazy-classifies on cache miss. Shipped for B3 Buffs
+(#139) per-indicator resolution and possible B6 StatusText (#142)
+delta-payload processing; no caller in A1 itself.
+EOF
+)"
+git push origin working-testing
+```
+
+---
+
+## Task 5: Add classified-store invalidation methods
+
+**Files:**
+- Modify: `Core/AuraState.lua` — insert after existing `MarkHarmfulDirty` (ends at line 76)
+
+Per the spec's "UNIT_AURA write path" section. Four methods parallel to `InvalidateHelpfulMatch` / `MarkHelpfulDirty` / `InvalidateHarmfulMatch` / `MarkHarmfulDirty`.
+
+- [ ] **Step 1: Locate insertion point**
+
+Run: look at `Core/AuraState.lua` — find the end of `function AuraState:MarkHarmfulDirty()` block (ends around line 76), followed by `function AuraState:EnsureHelpfulView(filter)`.
+
+- [ ] **Step 2: Insert four invalidation methods**
+
+Edit `Core/AuraState.lua` — find:
+
+```lua
+function AuraState:MarkHarmfulDirty()
+	for _, view in next, self._harmfulViews do
+		view.dirty = true
+	end
+end
+
+function AuraState:EnsureHelpfulView(filter)
+```
+
+Replace with:
+
+```lua
+function AuraState:MarkHarmfulDirty()
+	for _, view in next, self._harmfulViews do
+		view.dirty = true
+	end
+end
+
+function AuraState:InvalidateHelpfulClassified(auraInstanceID)
+	self._helpfulClassifiedById[auraInstanceID] = nil
+end
+
+function AuraState:InvalidateHarmfulClassified(auraInstanceID)
+	self._harmfulClassifiedById[auraInstanceID] = nil
+end
+
+function AuraState:MarkHelpfulClassifiedDirty()
+	self._helpfulClassifiedView.dirty = true
+end
+
+function AuraState:MarkHarmfulClassifiedDirty()
+	self._harmfulClassifiedView.dirty = true
+end
+
+function AuraState:EnsureHelpfulView(filter)
+```
+
+- [ ] **Step 3: `/reload` and verify no errors**
+
+Run: `/reload`. Expected: no errors. Methods defined, write path still uses only legacy invalidation.
+
+- [ ] **Step 4: Commit and push**
+
+```bash
+git add Core/AuraState.lua
+git commit -m "$(cat <<'EOF'
+feat(aurastate): add classified invalidation methods
+
+A1 (#136) invalidation API. Four methods mirror the existing
+Invalidate*Match / Mark*Dirty pair — separate per-ID invalidation
+from view-dirty marking so ApplyUpdateInfo can batch dirty-marks.
+Not yet called from the write path.
+EOF
+)"
+git push origin working-testing
+```
+
+---
+
+## Task 6: Wire invalidation into `FullRefresh` and `ApplyUpdateInfo`
+
+**Files:**
+- Modify: `Core/AuraState.lua` — `FullRefresh` (lines 120-130) and `ApplyUpdateInfo` (lines 185-246)
+
+This is the task that makes the classified stores actually correct under aura mutations. Ten insertion points total.
+
+- [ ] **Step 1: Update `FullRefresh` to wipe classified stores and mark views dirty**
+
+Edit `Core/AuraState.lua` — find the header of `FullRefresh`:
+
+```lua
+function AuraState:FullRefresh(unit)
+	self._unit = unit
+	self._initialized = true
+	self._gen = F.AuraCache.GetGeneration(unit)
+	wipe(self._helpfulById)
+	wipe(self._harmfulById)
+	self:ResetHelpfulMatches()
+	self:ResetHarmfulMatches()
+	self:MarkHelpfulDirty()
+	self:MarkHarmfulDirty()
+```
+
+Replace with:
+
+```lua
+function AuraState:FullRefresh(unit)
+	self._unit = unit
+	self._initialized = true
+	self._gen = F.AuraCache.GetGeneration(unit)
+	wipe(self._helpfulById)
+	wipe(self._harmfulById)
+	wipe(self._helpfulClassifiedById)
+	wipe(self._harmfulClassifiedById)
+	self:ResetHelpfulMatches()
+	self:ResetHarmfulMatches()
+	self:MarkHelpfulDirty()
+	self:MarkHarmfulDirty()
+	self:MarkHelpfulClassifiedDirty()
+	self:MarkHarmfulClassifiedDirty()
+```
+
+- [ ] **Step 2: Add classified-invalidate calls to the `addedAuras` loop**
+
+Find in `ApplyUpdateInfo`:
+
+```lua
+	if(updateInfo.addedAuras) then
+		for _, aura in next, updateInfo.addedAuras do
+			if(aura and aura.auraInstanceID and isHelpfulAura(unit, aura)) then
+				self._helpfulById[aura.auraInstanceID] = aura
+				self:InvalidateHelpfulMatch(aura.auraInstanceID)
+				helpfulChanged = true
+			end
+			if(aura and aura.auraInstanceID and isHarmfulAura(unit, aura)) then
+				self._harmfulById[aura.auraInstanceID] = aura
+				self:InvalidateHarmfulMatch(aura.auraInstanceID)
+				harmfulChanged = true
+			end
+		end
+	end
+```
+
+Replace with:
+
+```lua
+	if(updateInfo.addedAuras) then
+		for _, aura in next, updateInfo.addedAuras do
+			if(aura and aura.auraInstanceID and isHelpfulAura(unit, aura)) then
+				self._helpfulById[aura.auraInstanceID] = aura
+				self:InvalidateHelpfulMatch(aura.auraInstanceID)
+				self:InvalidateHelpfulClassified(aura.auraInstanceID)
+				helpfulChanged = true
+			end
+			if(aura and aura.auraInstanceID and isHarmfulAura(unit, aura)) then
+				self._harmfulById[aura.auraInstanceID] = aura
+				self:InvalidateHarmfulMatch(aura.auraInstanceID)
+				self:InvalidateHarmfulClassified(aura.auraInstanceID)
+				harmfulChanged = true
+			end
+		end
+	end
+```
+
+- [ ] **Step 3: Add classified-invalidate calls to the `updatedAuraInstanceIDs` loop**
+
+Find:
+
+```lua
+	if(updateInfo.updatedAuraInstanceIDs and GetAuraDataByAuraInstanceID) then
+		for _, auraInstanceID in next, updateInfo.updatedAuraInstanceIDs do
+			local aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+			if(aura and aura.auraInstanceID and isHelpfulAura(unit, aura)) then
+				self._helpfulById[auraInstanceID] = aura
+				self:InvalidateHelpfulMatch(auraInstanceID)
+				helpfulChanged = true
+			elseif(self._helpfulById[auraInstanceID]) then
+				self._helpfulById[auraInstanceID] = nil
+				self:InvalidateHelpfulMatch(auraInstanceID)
+				helpfulChanged = true
+			end
+
+			if(aura and aura.auraInstanceID and isHarmfulAura(unit, aura)) then
+				self._harmfulById[auraInstanceID] = aura
+				self:InvalidateHarmfulMatch(auraInstanceID)
+				harmfulChanged = true
+			elseif(self._harmfulById[auraInstanceID]) then
+				self._harmfulById[auraInstanceID] = nil
+				self:InvalidateHarmfulMatch(auraInstanceID)
+				harmfulChanged = true
+			end
+		end
+	end
+```
+
+Replace with:
+
+```lua
+	if(updateInfo.updatedAuraInstanceIDs and GetAuraDataByAuraInstanceID) then
+		for _, auraInstanceID in next, updateInfo.updatedAuraInstanceIDs do
+			local aura = GetAuraDataByAuraInstanceID(unit, auraInstanceID)
+			if(aura and aura.auraInstanceID and isHelpfulAura(unit, aura)) then
+				self._helpfulById[auraInstanceID] = aura
+				self:InvalidateHelpfulMatch(auraInstanceID)
+				self:InvalidateHelpfulClassified(auraInstanceID)
+				helpfulChanged = true
+			elseif(self._helpfulById[auraInstanceID]) then
+				self._helpfulById[auraInstanceID] = nil
+				self:InvalidateHelpfulMatch(auraInstanceID)
+				self:InvalidateHelpfulClassified(auraInstanceID)
+				helpfulChanged = true
+			end
+
+			if(aura and aura.auraInstanceID and isHarmfulAura(unit, aura)) then
+				self._harmfulById[auraInstanceID] = aura
+				self:InvalidateHarmfulMatch(auraInstanceID)
+				self:InvalidateHarmfulClassified(auraInstanceID)
+				harmfulChanged = true
+			elseif(self._harmfulById[auraInstanceID]) then
+				self._harmfulById[auraInstanceID] = nil
+				self:InvalidateHarmfulMatch(auraInstanceID)
+				self:InvalidateHarmfulClassified(auraInstanceID)
+				harmfulChanged = true
+			end
+		end
+	end
+```
+
+- [ ] **Step 4: Add classified-invalidate calls to the `removedAuraInstanceIDs` loop**
+
+Find:
+
+```lua
+	if(updateInfo.removedAuraInstanceIDs) then
+		for _, auraInstanceID in next, updateInfo.removedAuraInstanceIDs do
+			if(self._helpfulById[auraInstanceID]) then
+				self._helpfulById[auraInstanceID] = nil
+				self:InvalidateHelpfulMatch(auraInstanceID)
+				helpfulChanged = true
+			end
+			if(self._harmfulById[auraInstanceID]) then
+				self._harmfulById[auraInstanceID] = nil
+				self:InvalidateHarmfulMatch(auraInstanceID)
+				harmfulChanged = true
+			end
+		end
+	end
+```
+
+Replace with:
+
+```lua
+	if(updateInfo.removedAuraInstanceIDs) then
+		for _, auraInstanceID in next, updateInfo.removedAuraInstanceIDs do
+			if(self._helpfulById[auraInstanceID]) then
+				self._helpfulById[auraInstanceID] = nil
+				self:InvalidateHelpfulMatch(auraInstanceID)
+				self:InvalidateHelpfulClassified(auraInstanceID)
+				helpfulChanged = true
+			end
+			if(self._harmfulById[auraInstanceID]) then
+				self._harmfulById[auraInstanceID] = nil
+				self:InvalidateHarmfulMatch(auraInstanceID)
+				self:InvalidateHarmfulClassified(auraInstanceID)
+				harmfulChanged = true
+			end
+		end
+	end
+```
+
+- [ ] **Step 5: Add classified dirty-mark at the end of `ApplyUpdateInfo`**
+
+Find the tail of `ApplyUpdateInfo`:
+
+```lua
+	if(helpfulChanged) then
+		self:MarkHelpfulDirty()
+	end
+	if(harmfulChanged) then
+		self:MarkHarmfulDirty()
+	end
+end
+```
+
+Replace with:
+
+```lua
+	if(helpfulChanged) then
+		self:MarkHelpfulDirty()
+		self:MarkHelpfulClassifiedDirty()
+	end
+	if(harmfulChanged) then
+		self:MarkHarmfulDirty()
+		self:MarkHarmfulClassifiedDirty()
+	end
+end
+```
+
+- [ ] **Step 6: `/reload` and verify classified stores stay correct under aura mutations**
+
+Run: `/reload`. Expected: no errors. Cast a self-buff (e.g., as Paladin, Blessing of the Seasons; as any class, eat/drink to trigger Food). In the chat, run:
+
+```
+/run local pf = FramedAddon.Units.Player.frame; local s = pf and pf.FramedAuraState; if s then print('helpful count:', #s:GetHelpfulClassified()) else print('no aurastate') end
+```
+
+Expected: prints the number of helpful auras on player; count updates correctly as you add/remove buffs (re-run the command after each mutation). No errors, no stale counts.
+
+- [ ] **Step 7: Commit and push**
+
+```bash
+git add Core/AuraState.lua
+git commit -m "$(cat <<'EOF'
+feat(aurastate): wire classified invalidation into write path
+
+A1 (#136) core wiring. FullRefresh wipes classified stores and marks
+both views dirty. ApplyUpdateInfo invalidates per-ID classified
+entries in addedAuras/updatedAuraInstanceIDs/removedAuraInstanceIDs
+branches and marks views dirty when helpfulChanged/harmfulChanged.
+Classified reads now return fresh data on every UNIT_AURA mutation.
+EOF
+)"
+git push origin working-testing
+```
+
+---
+
+## Task 7: Add `/framed aurastate <unit>` debug slash
+
+**Files:**
+- Modify: `Core/AuraState.lua` — append `F.AuraState.PrintDebug` at bottom of file
+- Modify: `Init.lua:421` — new `elseif(cmd == 'aurastate')` case before help block
+- Modify: `Init.lua:422-431` — add help line in the `help` case
+
+Per the spec's "Debug slash: `/framed aurastate <unit>`" section.
+
+- [ ] **Step 1: Append `PrintDebug` function to `Core/AuraState.lua`**
+
+Edit `Core/AuraState.lua` — the file currently ends at line 327 with `end` closing `F.AuraState.Create`. Append below that:
+
+```lua
+
+-- =================================================================
+-- Debug: /framed aurastate <unit>
+-- =================================================================
+
+local function classifyFlagsString(flags)
+	local parts = {}
+	if(flags.isPlayerCast)        then parts[#parts + 1] = 'player-cast'        end
+	if(flags.isExternalDefensive) then parts[#parts + 1] = 'external-defensive' end
+	if(flags.isBigDefensive)      then parts[#parts + 1] = 'big-defensive'      end
+	if(flags.isImportant)         then parts[#parts + 1] = 'important'          end
+	if(flags.isRaid)              then parts[#parts + 1] = 'raid'               end
+	if(flags.isBossAura)          then parts[#parts + 1] = 'boss'               end
+	if(flags.isFromPlayerOrPet)   then parts[#parts + 1] = 'from-player'        end
+	return table.concat(parts, ', ')
+end
+
+local function printEntry(entry)
+	local aura = entry.aura
+	local name = (F.IsValueNonSecret and F.IsValueNonSecret(aura.name)) and aura.name or '(secret)'
+	local flags = classifyFlagsString(entry.flags)
+	local dispel = aura.dispelName and ('  [dispel: ' .. aura.dispelName .. ']') or ''
+	print(('    [%d]  %-22s [%s]%s'):format(aura.auraInstanceID, name, flags, dispel))
+end
+
+function F.AuraState.PrintDebug(unit)
+	unit = (unit and unit ~= '') and unit or 'target'
+	if(not UnitExists(unit)) then
+		print('|cff00ccff[Framed/aurastate]|r unit "' .. unit .. '" does not exist')
+		return
+	end
+
+	local state = F.AuraState.Create('slash')
+	state:FullRefresh(unit)
+
+	local gen = F.AuraCache.GetGeneration(unit)
+	print(('|cff00ccff[Framed/aurastate]|r %s  (gen %d)'):format(unit, gen))
+
+	local helpful = state:GetHelpfulClassified()
+	print(('  HELPFUL (%d):'):format(#helpful))
+	for _, entry in next, helpful do
+		printEntry(entry)
+	end
+
+	local harmful = state:GetHarmfulClassified()
+	print(('  HARMFUL (%d):'):format(#harmful))
+	for _, entry in next, harmful do
+		printEntry(entry)
+	end
+end
+```
+
+- [ ] **Step 2: Add `aurastate` case to the `/framed` dispatcher**
+
+Edit `Init.lua` — find around line 414-421:
+
+```lua
+	elseif(cmd == 'testimport') then
+		local encoded, err = generateSyntheticImportString()
+		if(not encoded) then
+			print('|cff00ccff Framed|r testimport failed: ' .. (err or 'unknown error'))
+			return
+		end
+		showTestImportPopup(encoded)
+	elseif(cmd == 'help') then
+```
+
+Replace with:
+
+```lua
+	elseif(cmd == 'testimport') then
+		local encoded, err = generateSyntheticImportString()
+		if(not encoded) then
+			print('|cff00ccff Framed|r testimport failed: ' .. (err or 'unknown error'))
+			return
+		end
+		showTestImportPopup(encoded)
+	elseif(cmd == 'aurastate') then
+		F.AuraState.PrintDebug(arg1)
+	elseif(cmd == 'help') then
+```
+
+- [ ] **Step 3: Add help line to the `help` block**
+
+Edit `Init.lua` — find the tail of the help block around lines 430-431:
+
+```lua
+		print('  /framed debugicons — Debug indicator element state')
+		print('  /framed testimport — Generate a synthetic-diff import string for testing backfill')
+	else
+```
+
+Replace with:
+
+```lua
+		print('  /framed debugicons — Debug indicator element state')
+		print('  /framed testimport — Generate a synthetic-diff import string for testing backfill')
+		print('  /framed aurastate [unit] — Print classified aura state for unit (default: target)')
+	else
+```
+
+- [ ] **Step 4: `/reload` and verify slash works**
+
+Run: `/reload`. Then:
+
+1. `/framed help` → expected: lists the new `aurastate` line.
+2. `/framed aurastate` (no args) → expected: prints `[Framed/aurastate] target  (gen N)` followed by HELPFUL and HARMFUL sections for your current target (or an "does not exist" message if no target).
+3. `/framed aurastate player` → expected: prints player's own auras, HELPFUL includes any active buffs (Food, Drinking, self-buffs).
+4. `/framed aurastate bogusunit` → expected: `unit "bogusunit" does not exist` message, no errors.
+5. `/framed aurastate party2target` → expected: runs cleanly; HELPFUL/HARMFUL counts likely 0 because `isCompoundUnit` short-circuits `FullRefresh`.
+
+- [ ] **Step 5: Commit and push**
+
+```bash
+git add Core/AuraState.lua Init.lua
+git commit -m "$(cat <<'EOF'
+feat(aurastate): add /framed aurastate <unit> debug slash
+
+A1 (#136) observable surface. Prints classified helpful + harmful
+entries with active flag slugs and dispel type. Uses
+F.IsValueNonSecret for aura names — secret names print as "(secret)".
+Throwaway AuraState instance per call; no shared state with frame
+AuraStates.
+EOF
+)"
+git push origin working-testing
+```
+
+---
+
+## Task 8: Live smoke test + PR
+
+**Files:** none. This task is manual verification against the spec's A1 acceptance checklist, followed by opening the PR.
+
+No code changes in this task. If any verification fails, the failing piece becomes a bugfix commit before PR.
+
+- [ ] **Step 1: Run the correctness checklist per spec section "A1 acceptance"**
+
+For each scenario below, run `/framed aurastate <unit>` and confirm the flags match. Cross-check visually with the relevant element (Externals/Defensives) to confirm classification matches what elements expect:
+
+| Scenario | Expected flags on the aura entry |
+|----------|----------------------------------|
+| Empty target | Empty HELPFUL and HARMFUL lists, `gen ≥ 1` |
+| Power Word: Shield on you (any source) | `isExternalDefensive`, `isImportant` |
+| Power Word: Shield cast by you on yourself | Above + `isPlayerCast` |
+| Ironbark on you | `isExternalDefensive`, `isBigDefensive`, `isFromPlayerOrPet` (if druid is in party) |
+| Blessing of Protection on you by another paladin | `isExternalDefensive`, `isImportant`, `isPlayerCast=false` |
+| Self Devotion Aura | `isHelpful`, `isRaid`, `isPlayerCast` |
+| Boss DoT on you | `isHarmful`, `isBossAura` |
+| Dispellable magic debuff from arena opponent | `isHarmful`, `isImportant`, `[dispel: Magic]` appended |
+| `/reload` during combat | Same classifications pre vs. post-reload; gen counter restarts but first read classifies correctly |
+
+- [ ] **Step 2: Run the non-regression checklist**
+
+- Every existing element (Externals, Defensives, Buffs, Debuffs, MissingBuffs, StatusText) renders identically to pre-A1 — no visual changes.
+- `/framed events` shows UNIT_AURA registered once, no duplicates.
+- No Lua errors in a 10-minute session including: target dummy rotation + 5-man heroic dungeon. Watch the BugSack / default error frame carefully.
+
+- [ ] **Step 3: Verify encounter-boundary behavior (if available during session)**
+
+If a raid boss encounter is accessible during the test window:
+
+1. Engage the boss (triggers `ENCOUNTER_START` at `Core/AuraCache.lua:73-79`).
+2. Run `/framed aurastate player`.
+3. Confirm: the aura instance IDs are fresh (not stale from pre-pull), flags match expected.
+4. On `ENCOUNTER_END` (boss kill or wipe), run again — still correct.
+
+If no raid access this session, note it as "encounter-boundary verification deferred to next raid night" in the PR description. `Core/AuraCache.lua:73-79` already handles the bump per `project memory`; the risk is just live confirmation.
+
+- [ ] **Step 4: Profiler snapshot — A1 overhead check**
+
+In game:
+
+```
+/console scriptProfile 1
+/reload
+```
+
+Run around normally for ~60 seconds in a target-dummy or low-churn scenario, then:
+
+```
+/dump GetAddOnCPUUsage('Framed')
+```
+
+Compare against the baseline of `~0.448ms` from `project_framed` memory. Expected: within ~5% of baseline. Higher is acceptable for A1 (classify runs on first-reader-per-generation for each aura, but no element reads the classified API yet — overhead should be near zero). If significantly higher, investigate classify hotspots but not a hard block for PR.
+
+- [ ] **Step 5: Open PR from `working-testing` to `main`**
+
+```bash
+gh pr create --base main --head working-testing --title "feat(aurastate): classification layer (A1 / #136)" --body "$(cat <<'EOF'
+## Summary
+
+Foundation for the UNIT_AURA fan-out rearchitecture (parent #115).
+
+- New per-instance classified stores on `AuraState` (`_helpfulClassifiedById`, `_harmfulClassifiedById`, plus views)
+- Module-local `classify(unit, aura, isHelpful)` helper — 5 structural passthroughs + 4 C-probe flags
+- Three read methods: `GetHelpfulClassified`, `GetHarmfulClassified`, `GetClassifiedByInstanceID`
+- Four invalidation methods wired into `FullRefresh` + `ApplyUpdateInfo`
+- New `/framed aurastate <unit>` debug slash for live verification
+
+Behavior-neutral for all current elements — they keep consuming `GetHelpful(filter)` / `GetHarmful(filter)`. The B-series (#137-#142) migrates individual elements to read flags directly.
+
+Spec: `docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md`
+
+## Test plan
+
+- [x] `/framed aurastate target` — correctness checklist (9 scenarios)
+- [x] Non-regression: every existing aura element renders identically
+- [x] No Lua errors in 10-minute combat session (dummy + 5-man)
+- [ ] Encounter-boundary verification (raid boss ENCOUNTER_START / ENCOUNTER_END) — [deferred to next raid night if not tested this session]
+- [x] Profiler: A1 overhead within 5% of 0.448ms baseline
+
+Closes #136.
+EOF
+)"
+```
+
+- [ ] **Step 6: Link issue + close**
+
+After PR merges to main and the 24-48h live-use window passes without reports, close issue #136 with a comment citing the PR. A1 is live; next up is B6 (#142 StatusText).
+
+---
+
+## Self-Review
+
+Ran after drafting the plan.
+
+**Spec coverage** — each spec requirement mapped:
+
+- "Module-local `classify(unit, aura, isHelpful)`" → Task 2 ✓
+- "Per-instance state additions in `F.AuraState.Create`" → Task 1 ✓
+- "New instance methods: `GetHelpfulClassified`, `GetHarmfulClassified`, `GetClassifiedByInstanceID`" → Tasks 3, 4 ✓
+- "New invalidation methods (4)" → Task 5 ✓
+- "Write-path additions in `FullRefresh`, `ApplyUpdateInfo`" → Task 6 ✓
+- "New `/framed aurastate` case in slash dispatcher" → Task 7 ✓
+- "Debug slash output format" → Task 7 ✓
+- A1 acceptance checklist (9 scenarios) → Task 8 Step 1 ✓
+- Non-regression checklist → Task 8 Step 2 ✓
+- Encounter boundary verification → Task 8 Step 3 ✓
+- Rollback safety (A1 alone is rollback-safe) → Implicit via per-task commits ✓
+
+**Placeholder scan** — no "TBD", "TODO", "similar to Task N" shortcuts. Every code block is copy-pasteable.
+
+**Type consistency** — `classify()` returns `{ aura, flags }` with 9 flag keys (5 Tier 1 + 4 Tier 2). `GetHelpfulClassified` / `GetHarmfulClassified` / `GetClassifiedByInstanceID` all return this shape (or nil for the ID accessor's miss case). `isFromPlayerOrPlayerPet` on `AuraData` maps to `isFromPlayerOrPet` on `flags` (deliberate rename — shorter, matches common WoW addon convention). `flags.isBigDefensive` is always `false` for harmful entries (spec invariant). Signatures in Tasks 3-7 match Task 2's definition.
+
+---
+
+## B-series and C1 plans
+
+**Not included in this plan.** Each B-issue (B1 through B6) and C1 will get its own plan, written when the issue is picked up. This matches the spec's per-element gate model — the plan for B1 Externals depends on observations from A1's live behavior (actual classify() cost, whether flag-table churn is visible on profile, whether the spec's expected flag combinations match what `IsAuraFilteredOutByInstanceID` actually returns in edge cases). Locking in B-plans before A1 ships would risk re-writing them all after A1 lands.
+
+Next plan to write (after A1 merges): `2026-04-21-b6-statustext-migration.md` — the smallest B-issue, used as smoke test for the classified-flag read pattern.

--- a/docs/superpowers/specs/2026-04-21-multi-target-copy-design.md
+++ b/docs/superpowers/specs/2026-04-21-multi-target-copy-design.md
@@ -1,0 +1,117 @@
+# Multi-Target Copy Design Spec
+
+**Date:** 2026-04-21
+**Status:** Draft — awaiting user review
+
+## Summary
+
+Extend Framed's settings copy operations from single-target to multi-target at two scopes — aura panel and frame — while leaving the existing preset-level copy (`Copy Settings From`) untouched. Both scopes share one reusable checklist picker and one shared fan-out write helper. This reduces the multi-hour setup cost of tuning `(preset × frame × aura-panel)` combinations by letting users propagate a tuned source to N peers in one action.
+
+## Motivation
+
+Settings in Framed form a three-level tree: **Preset → Frame → Aura panel**. Every leaf is a unique `(preset, frame, configKey)` tuple. Users report the combinatorics cause "hundreds of hours" of setup when building out multiple presets (Raid, M+, Arena, Solo, Party) each with 6–9 frames each with ~10 aura panels.
+
+Today's copy surface is uneven:
+
+- **Aura panel:** `Copy To` header button with a **single-target** dropdown, same-preset only. See `Settings/Framework.lua:206` and `Settings/MainFrame.lua:272`.
+- **Frame:** no copy mechanism.
+- **Preset:** `Copy Settings From` dropdown in `Settings/Panels/FramePresets.lua:134` calling `F.PresetManager.CopySettings(source, target)`. One source → active preset.
+
+The missing pieces, in order of pain:
+
+1. **Multi-target fan-out at the aura panel level.** Single-target means users click Copy To N times to propagate one aura filter across frames or presets.
+2. **No frame-scope copy at all.** Users cannot say "make my Focus frame look like my Target frame" without touching every settings card individually.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Direction | Push (`Copy To…`) | Matches existing aura-panel pattern; research (Figma Publish, Premiere Paste Attributes) confirms push + checklist is the dominant multi-target pattern |
+| Picker shape | Flat grouped checklist, not tree | Matches Framed's shallow config depth; tree would be overkill at this scale |
+| Destructive-overwrite UX | Single modal with count — "Overwrite N targets?" — only when ≥1 target differs from source | Diff preview is high-cost and rarely pays off below Figma scale; preset revert already exists as undo |
+| Button naming | `Copy To…` (with ellipsis) | Standard "opens a picker" affordance |
+| Placement | Panel header button only (no right-click menu in v1) | Header-button wins on discoverability; WeakAuras' sub-tab burial is a known anti-pattern |
+| Scope of v1 | Aura-panel + frame only; preset untouched | Preset-level copy already exists; no need to re-invent |
+| Sub-toggles | One: `Include aura panels` at frame scope | Premiere-style orthogonal sub-toggle; one is enough to avoid silent incoherence from hidden dependencies |
+| Inheritance / linked configs | Not in v1 | Industry precedent (WeakAuras added inheritance years after copy) shows copy is a legitimate end state; layering inheritance later does not require removing copy |
+| Multi-select edit mode | Not in v1 | See Future Considerations — significant write-path rework and indeterminate-state UX; 80% of value is captured by multi-target copy |
+| Excluded panels | CrowdControl and LossOfControl | These store config globally, not per-preset/per-frame (matches prior `2026-03-26-copy-to-dialog-design.md` exclusion) |
+
+## Scope
+
+### (A) Aura panel: upgrade existing `Copy To…`
+
+**Source:** the current aura panel on the current frame in the active preset — e.g., `Raid.Defensives` in preset "Raid".
+
+**Target set — grouped checklist:**
+
+- *Other frames in this preset* — all frames that exist in the active preset except the source frame; checkbox per frame.
+- *Same frame in other presets* — for each other preset, one entry if that preset contains a frame with the same key as the source; labeled `<frameName> (<presetName>)`.
+
+Users may check any combination across both groups. A "Select all in group" link-button per group is permitted.
+
+**Write:** for each checked target, overwrite `presets.<targetPreset>.auras.<targetFrame>.<configKey>` with the source payload.
+
+**Fires:** `CONFIG_CHANGED` per target, respecting the active-preset guard documented in `project_live_update_presets` (targets that are not in the active preset must not trigger live frame rebuilds).
+
+### (B) Frame: new `Copy Frame To…`
+
+**Source:** all settings for the current frame — every settings card's configKey plus every aura panel's configKey under that frame — in the active preset.
+
+**Trigger:** new header button in the frame's settings area (same visual slot convention as the aura-panel Copy To).
+
+**Target set — grouped checklist** (same shape as A, but targets are `(preset, frame)` pairs):
+
+- *Other frames in this preset* — frame keys in the active preset excluding the source.
+- *Same frame in other presets* — the source frame key as it exists in each other preset.
+
+**Sub-toggle:** `☑ Include aura panels` (default on). When off, the copy payload excludes all aura-panel configKeys under the frame; only frame-level appearance/layout/bar/text/highlight configs are propagated.
+
+**Write:** for each checked target, overwrite the frame's config subtree (respecting the sub-toggle). Aura panels within the frame are written individually so that per-panel `CONFIG_CHANGED` semantics match the single-panel case.
+
+### Shared infrastructure
+
+- **Reusable picker widget** — new `Widgets.CreateCopyToPicker(source, scope)`-style helper (exact API TBD by implementation plan). Takes a source descriptor and a scope (`'auraPanel'` or `'frame'`), resolves target groups, renders the grouped checklist, and returns the user's selection.
+- **Shared overwrite-confirm helper** — given source payload and selected targets, returns true/false based on whether any target already differs; if so, shows the "Overwrite N targets?" modal.
+- **Shared fan-out write helper** — given source tree + list of target coordinates + scope, writes each target atomically and fires the correct `CONFIG_CHANGED` events, with active-preset guards intact.
+
+All three are built once and consumed by both (A) and (B). Future scopes (e.g., multi-target preset copy, if ever added) can reuse them.
+
+## Out of Scope
+
+- **Preset-level multi-target copy.** `Copy Settings From` covers the seeding case; multi-target preset overwrite is rare and not prioritized.
+- **Inheritance / linked configs.** Whether to make auras inherit from `AuraDefaults`, or make frames inherit layout from a parent frame, is a separate design.
+- **Multi-select preset edit mode.** See Future Considerations.
+- **Diff preview inside the picker.** Overwrite-confirm shows a count only.
+- **Right-click / context menu placement.** Header button only in v1.
+- **CrowdControl and LossOfControl aura panels.** These store global config and have no per-frame payload; the `Copy To…` button stays hidden on those panels, matching the existing behavior documented in `2026-03-26-copy-to-dialog-design.md`.
+
+## Future Considerations
+
+### Inheritance / linked configs
+Long-game direction observed across Figma (variables/components), JetBrains (scheme inheritance), CSS cascade, and WeakAuras (group inheritance). Inheritance removes drift but introduces override-rule UX and "where did this value come from?" debugging. Framed's shallow tree and imperative user mental model make copy a legitimate end state; inheritance can be layered on later without replacing copy. `Presets/AuraDefaults.lua` is the likely starting point.
+
+### Multi-select preset edit mode
+Natural extension: select multiple presets at the top level and have every settings edit propagate to all selected presets simultaneously. This is a *continuous* fan-out rather than an *imperative* one, and the UX cost is substantial:
+
+- Every settings control (checkbox, slider, dropdown, color picker) needs **indeterminate-state rendering** for the case where selected presets disagree on a value.
+- The write pipeline and `CONFIG_CHANGED` handlers currently assume a single active preset (see `project_live_update_presets`). Multi-target writes require rework of the active-preset model.
+- Live preview / auto-switch semantics become ambiguous.
+
+Deferred until users have lived with multi-target copy for some time; the remaining pain after copy may be small enough that a lighter design (e.g., per-preset "Mirror to preset X" toggle) covers it.
+
+## Open Questions
+
+None blocking. Implementation plan should decide:
+
+- Exact widget API for the shared picker.
+- Whether `Select all in group` link-buttons are included in v1 or deferred.
+- Exact `CONFIG_CHANGED` fan-out shape for the frame-scope case (single `FRAME_COPIED` event vs. one event per written configKey). Leaning toward the latter so existing per-panel live-update handlers require no changes.
+
+## References
+
+- Existing single-target aura Copy To: `Settings/Framework.lua:206-267`, `Settings/MainFrame.lua:272-280`
+- Existing preset Copy Settings From: `Settings/Panels/FramePresets.lua:134-161`, `Presets/Manager.lua` (`CopySettings`)
+- Prior aura-panel copy spec: `docs/superpowers/specs/2026-03-26-copy-to-dialog-design.md`
+- Excluded-panel rationale: same prior spec, "Config Key Mapping" section
+- Active-preset guard for live updates: `project_live_update_presets` memory

--- a/docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md
+++ b/docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md
@@ -37,7 +37,7 @@ The fix: classify once on the shared per-frame AuraState, expose flags, let elem
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| Classification timing | Write-path (UNIT_AURA events), not lazy | Amortizes cost across all readers; read path stays allocation-free |
+| Classification timing | Write-path invalidate, read-path materialize (lazy) | First reader per generation pays classify cost; subsequent readers hit the cached wrapper; hidden frames / disabled elements pay zero |
 | Ship scope (A1) | Helpful + harmful together | Catches cross-element collisions up front; avoids two migrations |
 | Wrapper shape | `{ aura, flags }` per entry | `aura` stays a live ref; `flags` is a stable-shape boolean table |
 | Tier structure | 2 tiers (passthrough + C probe) | Originally 3 tiers; revised to drop `AuraIsBigDefensive` in favor of probe |
@@ -188,6 +188,8 @@ function AuraState:GetClassifiedByInstanceID(instanceID) end
 
 All three run through the existing `EnsureInitialized(self._unit)` generation gate — same semantics as `GetHelpful` / `GetHarmful`.
 
+`GetClassifiedByInstanceID` is the single-entry accessor for elements that hold a spellID-to-instanceID map or process `updateInfo.updatedAuraInstanceIDs` payloads directly. **Primary planned consumer: B3 Buffs (#139)** per-indicator resolution path — the migrated Buffs element resolves indicator-tracked spells to their current wrapper entry in O(1) rather than scanning the full classified array. **B6 StatusText (#142)** is a secondary candidate if its migrated Drinking/Food detection switches from array-scan to delta-payload processing. The API ships in A1 so B-series wiring exists when those migrations land; final call sites are fixed at B-series issue refinement.
+
 Unlike `GetHelpful(filter)` which takes a filter string, the classified APIs return all helpful/harmful auras with flags populated. Filter-like narrowing is done by the caller via flag reads: `if(entry.flags.isExternalDefensive)`.
 
 ### Internal state
@@ -236,6 +238,8 @@ end
 ```
 
 The existing `IsAuraFilteredOutByInstanceID` local at AuraState.lua:9 is reused — no re-capture.
+
+`classify()` is called exclusively from the view-rebuild path (`GetHelpfulClassified` / `GetHarmfulClassified`). It is never invoked from `FullRefresh` or `ApplyUpdateInfo` — those only nil invalidated entries and mark views dirty. This keeps the write path cheap and defers classify cost to first-reader-per-generation.
 
 ### Element consumption pattern (post-migration)
 
@@ -294,6 +298,7 @@ AuraState: target  (gen 47)
 - `entry.aura` is always a non-nil `AuraData` reference.
 - `entry.flags` is always a non-nil table with **all 9 flag keys present and boolean**.
 - Consumers may rely on `if(entry.flags.isX) then` without defensive nil-checks.
+- Array order from `GetHelpfulClassified` / `GetHarmfulClassified` is **undefined** — underlying store is a hash keyed by `auraInstanceID`, iterated with `next`. Matches existing `GetHelpful` / `GetHarmful` semantics. Callers that need stable render order must sort after fetch.
 
 If classification produces a wrapper entry violating these invariants, that's an AuraState bug — not something elements paper over.
 
@@ -530,6 +535,7 @@ C1 is the closing verification pass. Deliverable: a documented report (no code c
    - Target dummy solo (minimal churn).
    - 5-man M+ dungeon (moderate churn).
    - Raid boss encounter (peak churn).
+   - **Reproducibility:** specific dungeon/boss/affix combos are named in the C1 GitHub issue body at execution time and reused verbatim across S0/S1/S2. Comparing 0.448ms on one boss to 0.22ms on a different boss is noise, not signal.
 3. **Metrics per snapshot per scenario:**
    - `GetAddOnCPUUsage('Framed')` delta over window.
    - UNIT_AURA handler cost per event (profiler or `debugprofilestop`).
@@ -550,10 +556,12 @@ Cell (0.231ms) and Dander (0.075ms) are context only, not gates. Closing the gap
 Each B-issue is its own commit behind main, enabling single-commit revert without touching siblings:
 
 1. `git revert` the B-issue's commit.
-2. A1 + unmigrated B-issues stay in place (flags keep being computed without a reader — no harm).
+2. A1 + other B-issues stay in place; reverted element falls back to its pre-migration path against the legacy `_helpfulById` / `_harmfulById` stores.
 3. Patch-level version bump per `feedback_release_workflow`.
 
 A1 itself is rollback-safe: new APIs + debug slash only. Reverting A1 is a non-event unless a B-issue already consumes it, which the per-element gate should prevent.
+
+**Mid-migration stability invariant.** Migrated and unmigrated elements coexist on the same AuraState instance without interference. Legacy stores (`_helpfulById`, `_harmfulById`, `_helpfulMatches`, `_harmfulMatches`) remain populated throughout and after the B-series. Unmigrated elements continue reading via `GetHelpful(filter)` / `GetHarmful(filter)`; migrated elements read via classified APIs. Both paths see identical underlying `AuraData` references and the same UNIT_AURA invalidations via the generation-bump mechanism. The B-series can pause at any element boundary without destabilizing the addon.
 
 ### Explicitly deferred
 

--- a/docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md
+++ b/docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md
@@ -1,0 +1,660 @@
+# UNIT_AURA Fan-Out Rearchitecture Design Spec
+
+**Date:** 2026-04-21
+**Issue:** #115 (parent); #136 (A1), #137-#142 (B1-B6), #143 (C1)
+**Status:** Approved
+
+## Summary
+
+Move per-aura classification work (external-defensive, important, player-cast, big-defensive) out of individual aura elements and into a shared AuraState classification layer. Each element migrates from making its own `C_UnitAuras.IsAuraFilteredOutByInstanceID` probes to reading pre-computed boolean flags off a wrapper entry. Shares the cost of classification across every consumer of the same `(unit, aura)` pair.
+
+Today's aura elements fall into two classes:
+
+- **Classification-heavy** (Externals, Defensives) — call `IsAuraFilteredOutByInstanceID` directly in their Update paths, up to 5 probes per aura per UNIT_AURA in Externals.
+- **Spell-set-driven** (Buffs, Debuffs, MissingBuffs) — don't do classification themselves, but would benefit from pre-computed flags to simplify `castBy='me'` decisions and dispel-color handling.
+- **Text/status** (StatusText) — registers its own UNIT_AURA handler for Drinking/Food detection; consolidation reduces total UNIT_AURA fan-out count.
+
+After this rearchitecture: four probes per aura per classification write, shared across all elements on the same frame (via the existing per-frame `self.FramedAuraState` instance). Target: ≈50% reduction from baseline.
+
+## Motivation
+
+Framed's baseline profile (from combat telemetry in the `project_framed` memory):
+
+- Framed: **0.448ms avg** per frame
+- Cell: 0.231ms
+- Dander: 0.075ms
+
+The dominant cost in Framed is `IsAuraFilteredOutByInstanceID` chains in Externals (up to 5 probes per aura per UNIT_AURA) and Defensives, plus parallel work across elements on the same frame reading different filters of the same aura set. Existing caching addresses adjacent layers but not classification:
+
+- `AuraCache` dedupes raw `GetUnitAuras` calls across elements (per-(unit, filter) generation-gated).
+- `AuraState._helpfulMatches[filter][auraInstanceID]` memoizes filter-probe results per instance, per filter — but each filter is a separate cache, and the memoization is cleared on every aura change.
+
+Neither layer materializes classification flags for the element to read cheaply. Elements still chain multiple probes per aura.
+
+The fix: classify once on the shared per-frame AuraState, expose flags, let elements read them directly.
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Classification timing | Write-path (UNIT_AURA events), not lazy | Amortizes cost across all readers; read path stays allocation-free |
+| Ship scope (A1) | Helpful + harmful together | Catches cross-element collisions up front; avoids two migrations |
+| Wrapper shape | `{ aura, flags }` per entry | `aura` stays a live ref; `flags` is a stable-shape boolean table |
+| Tier structure | 2 tiers (passthrough + C probe) | Originally 3 tiers; revised to drop `AuraIsBigDefensive` in favor of probe |
+| Update-path behavior | Always re-classify | Correctness > microperf at UNIT_AURA rate |
+| B-series pacing | Per-element gate | Each element migrates independently; smoke test + merge between |
+| B-series order | B6 → B1 → B2 → B4 → B5 → B3 | Simplest first (smoke); Buffs last (size + #113 retirement) |
+| Buffs castBy model | `flags.isPlayerCast` exclusively | Retires #113 over-match workaround silently |
+| Debug surface | `/framed aurastate <unit>` slash | Permanent shipping feature; matches `/framed events` / `/framed config` pattern |
+| Flag-table pooling | Deferred (unpooled in A1) | Prior attempt caused cross-addon taint; conservative retry is a separate issue |
+| Spec structure | Single comprehensive spec | A1 + B1-B6 + C1 share enough design surface to document once |
+
+## Prior Work and Dependencies
+
+### #123 (aura instance ID re-randomization) is stale
+
+Parent issue #115 is tagged as blocked by #123 ("verify 12.0.5 aura instance ID re-randomization handling"). Investigation during brainstorming confirmed #123's code-side fix is already implemented: `Core/AuraCache.lua:73-79` bumps the generation counter for every tracked unit on `ENCOUNTER_START` and `ENCOUNTER_END`. The comment at that site explicitly documents the 12.0.5 re-randomization behavior.
+
+What remains for #123 is live verification on a real boss encounter, not code work. Since A1 shares the same invalidation surface (generation bump → classified store invalidation), A1 will inherently exercise the ENCOUNTER_START path during A1's own smoke-testing phase.
+
+**Action before A1 starts:** downgrade #123's "blocker" tag. Either close with comment "code-side implemented at AuraCache.lua:73-79; live verification will happen during A1 smoke-testing", or keep open but remove the `blocks #136` relationship.
+
+### Dander Frames inspiration (no code copied)
+
+Dander's low CPU footprint (0.075ms) is observed to come from classification sharing. The architectural pattern is public behavior visible via profiler + code reading; no code is copied. Dander is ARR-licensed and off-limits for direct reference per `feedback_licensing_references`. This spec independently derives the classification layer from Framed's existing AuraCache + AuraState infrastructure.
+
+## Architecture
+
+### The structural shift
+
+AuraState is a per-frame class (`Core/AuraState.lua`), created idempotently by the first element on each frame to run Setup:
+
+```lua
+if(not self.FramedAuraState and F.AuraState) then
+    self.FramedAuraState = F.AuraState.Create(self)
+end
+```
+
+All elements on the same frame share that one instance. A1 extends this shared instance with a classification layer.
+
+**Before:**
+
+```
+UNIT_AURA -> Externals.Update
+            -> for each helpful aura:
+                 probe EXTERNAL_DEFENSIVE, IMPORTANT, BIG_DEFENSIVE, RAID, PLAYER (up to 5 probes)
+          -> Defensives.Update
+            -> for each helpful aura:
+                 probe BIG_DEFENSIVE, PLAYER (2 probes)
+          -> Debuffs.Update, MissingBuffs.Update, ...
+            -> spellID-based work
+```
+
+**After:**
+
+```
+UNIT_AURA -> shared AuraState classifies each aura once
+              probe EXTERNAL_DEFENSIVE, IMPORTANT, PLAYER, BIG_DEFENSIVE (4 probes)
+          -> Externals.Update
+            -> for each classified entry: read entry.flags.*  (free lookups)
+          -> Defensives.Update
+            -> for each classified entry: read entry.flags.*  (free lookups)
+          -> Debuffs, MissingBuffs, ... -> read flags where useful
+```
+
+### Post-A1 store shape
+
+Two new per-instance dictionaries on `AuraState`, parallel to the existing `self._helpfulById` / `self._harmfulById`:
+
+```lua
+self._helpfulClassifiedById[instanceID] = {
+    aura  = <AuraData ref>,   -- never copied, never mutated
+    flags = {                 -- always all 9 keys, always boolean
+        isHelpful           = bool,
+        isHarmful           = bool,
+        isRaid              = bool,
+        isBossAura          = bool,
+        isFromPlayerOrPet   = bool,
+        isExternalDefensive = bool,
+        isImportant         = bool,
+        isPlayerCast        = bool,
+        isBigDefensive      = bool,
+    },
+}
+```
+
+`isBigDefensive` is always `false` for harmful auras (the `HELPFUL|BIG_DEFENSIVE` filter has no harmful analog). The flag is present on every wrapper for shape stability.
+
+Existing `self._helpfulById` / `self._harmfulById` stores stay untouched during the migration. Each B-issue migrates one element's read path; writes to both stores happen in parallel. After B6 ships, a follow-up collapses the two stores.
+
+### Flag lifecycle tiers
+
+| Tier | Flags | Source | Secret-safe |
+|------|-------|--------|-------------|
+| 1 (passthrough) | `isHelpful`, `isHarmful`, `isRaid`, `isBossAura`, `isFromPlayerOrPet` | `AuraData` structural booleans | Always |
+| 2 (C probe) | `isExternalDefensive`, `isImportant`, `isPlayerCast`, `isBigDefensive` | `C_UnitAuras.IsAuraFilteredOutByInstanceID(unit, id, filter)` | Always (C-level API) |
+
+**Originally proposed a third tier** (spellID-keyed cache for `isBigDefensive` via `C_UnitAuras.AuraIsBigDefensive`). Dropped because (a) `spellId` is typically secret in combat, and `AuraIsBigDefensive` is not documented to accept secret scalars; (b) the probe alternative is already proven by current Externals.lua. Two tiers keeps single-path and avoids feature-detection branching.
+
+### Filter strings used
+
+All four are present in `/tmp/wow-ui-source/Interface/AddOns/Blizzard_FrameXMLUtil/AuraUtil.lua:158-174` and used by Framed today:
+
+- `HELPFUL|EXTERNAL_DEFENSIVE` → `flags.isExternalDefensive`
+- `HELPFUL|IMPORTANT` / `HARMFUL|IMPORTANT` → `flags.isImportant`
+- `HELPFUL|PLAYER` / `HARMFUL|PLAYER` → `flags.isPlayerCast`
+- `HELPFUL|BIG_DEFENSIVE` → `flags.isBigDefensive` (helpful only — no harmful variant applies)
+
+### Integration with existing invalidation
+
+AuraCache's generation counter is the single invalidation signal. A1 introduces zero new event registrations. Every invalidation path that works today for `GetHelpful` / `GetHarmful` works identically for the classified APIs:
+
+- UNIT_AURA: generation bumps on affected unit.
+- Unit token reassignment (PLAYER_TARGET_CHANGED, PLAYER_FOCUS_CHANGED, UNIT_TARGET, GROUP_ROSTER_UPDATE, ARENA_OPPONENT_UPDATE, INSTANCE_ENCOUNTER_ENGAGE_UNIT, NAME_PLATE_UNIT_ADDED/REMOVED): generation bumps on the token.
+- ENCOUNTER_START / ENCOUNTER_END (12.0.5 ID re-randomization): generation bumps on every tracked unit.
+
+AuraState's existing `ensureFresh(unit)` gate catches all three categories.
+
+### Non-goals for A1
+
+- No pooling of `flags` tables. (Deferred issue.)
+- No collapse of `_helpfulById` + `_helpfulClassifiedById`. (Follow-up after B6.)
+- No removal of `_helpfulMatches` filter memoization — some filters (e.g., `RAID_IN_COMBAT`) stay in use via `GetHelpful(filter)` post-B6.
+- No changes to existing `GetHelpful(filter)` / `GetHarmful(filter)` shape or behavior.
+- No mutation of `AuraData` references.
+- No new event registrations.
+
+## Components and APIs
+
+### Public API additions — AuraState instance methods
+
+Match the existing `GetHelpful(filter)` / `GetHarmful(filter)` method shape (colon-call, no unit parameter — unit is stored on the instance):
+
+```lua
+--- Array of wrapper entries for all helpful auras on the instance's unit.
+--- @return table   -- array of { aura, flags }
+function AuraState:GetHelpfulClassified() end
+
+--- Array of wrapper entries for all harmful auras on the instance's unit.
+--- @return table   -- array of { aura, flags }
+function AuraState:GetHarmfulClassified() end
+
+--- Wrapper entry for a single aura instance ID, or nil.
+--- Useful for elements handling UNIT_AURA delta payloads directly.
+--- @param instanceID number
+--- @return table|nil   -- { aura, flags } or nil
+function AuraState:GetClassifiedByInstanceID(instanceID) end
+```
+
+All three run through the existing `EnsureInitialized(self._unit)` generation gate — same semantics as `GetHelpful` / `GetHarmful`.
+
+Unlike `GetHelpful(filter)` which takes a filter string, the classified APIs return all helpful/harmful auras with flags populated. Filter-like narrowing is done by the caller via flag reads: `if(entry.flags.isExternalDefensive)`.
+
+### Internal state
+
+Added to the `AuraState` instance table in `F.AuraState.Create`:
+
+```lua
+self._helpfulClassifiedById = {}    -- [instanceID] = entry
+self._harmfulClassifiedById = {}    -- [instanceID] = entry
+self._helpfulClassifiedView = { dirty = true, list = {} }
+self._harmfulClassifiedView = { dirty = true, list = {} }
+```
+
+The `{ dirty, list }` view shape mirrors the existing `_helpfulViews[filter]` / `_harmfulViews[filter]` pattern in AuraState.lua:78-109 — rebuild-on-read with a dirty flag toggled on write. Classified has no filter dimension, so it's a single view instead of a per-filter table.
+
+### Classification function
+
+Module-local helper in `Core/AuraState.lua`, called from the instance's `GetHelpfulClassified` / `GetHarmfulClassified` view-rebuild path:
+
+```lua
+local function classify(unit, aura, isHelpful)
+    local id = aura.auraInstanceID
+    local prefix = isHelpful and 'HELPFUL' or 'HARMFUL'
+
+    -- Tier 1: structural passthrough (always safe, never secret)
+    local flags = {
+        isHelpful         = aura.isHelpful or false,
+        isHarmful         = aura.isHarmful or false,
+        isRaid            = aura.isRaid or false,
+        isBossAura        = aura.isBossAura or false,
+        isFromPlayerOrPet = aura.isFromPlayerOrPlayerPet or false,
+    }
+
+    -- Tier 2: instance-ID filter probes.
+    -- NOTE: explicit `== false` (not `not ...`). IsAuraFilteredOutByInstanceID
+    -- returns nil for invalid state; `not nil == true` would promote every aura.
+    flags.isExternalDefensive = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|EXTERNAL_DEFENSIVE') == false
+    flags.isImportant         = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|IMPORTANT')          == false
+    flags.isPlayerCast        = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|PLAYER')             == false
+    flags.isBigDefensive      = isHelpful
+                                and IsAuraFilteredOutByInstanceID(unit, id, 'HELPFUL|BIG_DEFENSIVE') == false
+                                or false
+
+    return { aura = aura, flags = flags }
+end
+```
+
+The existing `IsAuraFilteredOutByInstanceID` local at AuraState.lua:9 is reused — no re-capture.
+
+### Element consumption pattern (post-migration)
+
+```lua
+-- Before (today, Externals.lua:42):
+local rawAuras = auraState and auraState:GetHelpful('HELPFUL')
+    or F.AuraCache.GetUnitAuras(unit, 'HELPFUL')
+for _, aura in next, rawAuras do
+    local isExt = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+        unit, aura.auraInstanceID, 'HELPFUL|EXTERNAL_DEFENSIVE')
+    if(isExt) then
+        ...
+    end
+end
+
+-- After (B1 migration):
+local classified = auraState and auraState:GetHelpfulClassified() or nil
+if(classified) then
+    for _, entry in next, classified do
+        if(entry.flags.isExternalDefensive) then
+            local aura = entry.aura
+            ...
+        end
+    end
+end
+```
+
+Per-aura C API probe count for Externals: **up to 5 → 0**. All five filter probes (EXTERNAL_DEFENSIVE, IMPORTANT, BIG_DEFENSIVE, RAID, PLAYER) at Externals.lua:51/59/62/76/79/97 become flag reads; the cost moves into the shared `classify()` step, which runs once per aura per generation on the per-frame AuraState instance.
+
+Elements without a shared AuraState (e.g., a theoretical frame with zero aura elements) would fall back to `F.AuraCache.GetUnitAuras` exactly like today. Since every aura-tracking frame has at least one element that creates AuraState via the idempotent Setup guard, the `classified = nil` branch is vestigial — preserved only to match the existing element-level `auraState and ... or fallback` pattern.
+
+### Debug slash: `/framed aurastate <unit>`
+
+New case in the existing `/framed` dispatcher in `Init.lua`. Unit defaults to `target` if omitted.
+
+Output format:
+
+```
+AuraState: target  (gen 47)
+  HELPFUL (3):
+    [4521]  Rallying Cry          [player-cast, raid]
+    [4877]  Pain Suppression      [external-defensive, important]
+    [4921]  Ironbark              [external-defensive, big-defensive]
+  HARMFUL (2):
+    [5102]  Fel Flame             [boss, important]
+    [5144]  (secret)              [dispel: magic]
+```
+
+- Columns: `[instanceID]  <name or "(secret)">  [comma-separated active flags]`
+- Flag names use kebab-case slugs matching the camelCase key (`isExternalDefensive` → `external-defensive`).
+- Appends `[dispel: <name>]` when `entry.aura.dispelName` is non-nil.
+- Permanent shipping feature. Low enough cost to run in live combat.
+
+### Wrapper entry invariants
+
+- `entry.aura` is always a non-nil `AuraData` reference.
+- `entry.flags` is always a non-nil table with **all 9 flag keys present and boolean**.
+- Consumers may rely on `if(entry.flags.isX) then` without defensive nil-checks.
+
+If classification produces a wrapper entry violating these invariants, that's an AuraState bug — not something elements paper over.
+
+## Data Flow and Lifecycle
+
+### UNIT_AURA write path
+
+Every aura mutation event flows through `AuraState:FullRefresh(unit)` or `AuraState:ApplyUpdateInfo(unit, updateInfo)`. A1 adds classified-store invalidation alongside the existing filter-match invalidation:
+
+| Trigger | Existing behavior | New classified store behavior |
+|---------|-------------------|-------------------------------|
+| `FullRefresh` | Wipes `self._helpfulById` + repopulates; `ResetHelpfulMatches` | Wipes `self._helpfulClassifiedById`; marks `_helpfulClassifiedView` dirty |
+| Added aura | Inserts into `self._helpfulById[id]`; `InvalidateHelpfulMatch(id)` | `self._helpfulClassifiedById[id] = nil` (force re-classify on next read); marks view dirty |
+| Updated aura | Replaces entry in `self._helpfulById[id]`; `InvalidateHelpfulMatch(id)` | `self._helpfulClassifiedById[id] = nil`; marks view dirty |
+| Removed aura | `nil`s entry in `self._helpfulById[id]`; `InvalidateHelpfulMatch(id)` | `nil`s entry in `self._helpfulClassifiedById[id]`; marks view dirty |
+
+Classification is populated lazily on first `GetHelpfulClassified()` read per generation. The view-rebuild walks `self._helpfulById`, reuses any still-valid entries in `self._helpfulClassifiedById`, and calls `classify()` for entries that are missing or invalidated.
+
+**Helpful and harmful are symmetric.** Everything above applies identically to the harmful side via `_harmfulById` / `_harmfulClassifiedById` / `_harmfulClassifiedView`.
+
+New instance methods for consistency with the existing invalidation methods:
+
+- `AuraState:InvalidateHelpfulClassified(auraInstanceID)` — removes ID from `_helpfulClassifiedById`, marks classified view dirty.
+- `AuraState:InvalidateHarmfulClassified(auraInstanceID)` — parallel for harmful.
+- `AuraState:MarkHelpfulClassifiedDirty()` / `AuraState:MarkHarmfulClassifiedDirty()` — mirror the existing `MarkHelpfulDirty` / `MarkHarmfulDirty` pattern.
+
+Called from the same points as `InvalidateHelpfulMatch` / `InvalidateHarmfulMatch` (AuraState.lua:189, 205, 209, 215, 219, 229, 234).
+
+### Update-path re-classification rationale
+
+Update events (`updateInfo.updatedAuraInstanceIDs`) invalidate the classified entry for each affected ID and let the next read re-classify. No in-place delta-check on which flag might have flipped. Three reasons:
+
+1. An aura can change category mid-life as the game propagates classifications asynchronously.
+2. UNIT_AURA fires at human-reaction frequency, not render frequency. Four C probes per updated aura is cheap.
+3. Invalidation is a single code path symmetric with the existing `InvalidateHelpfulMatch` pattern. Delta-checking introduces branches that would need testing in edge cases.
+
+Cold start and re-classification pay for a full aura only on first read of that generation. If no element calls `GetHelpfulClassified()` in a given generation (e.g., frame hidden, all aura elements disabled), classify runs zero times for that generation — lazy materialization is a net win over eager write-path population.
+
+### Encounter boundaries
+
+`ENCOUNTER_START` / `ENCOUNTER_END` bump every tracked unit's generation via the existing AuraCache handler. The next read of any classified API sees generation mismatch → `FullRefresh` → fresh scan with post-randomization instanceIDs → new `classify` calls → correct flags.
+
+### Cold start
+
+First-ever `GetHelpfulClassified()` call on a fresh AuraState instance:
+
+1. `AuraCache.GetGeneration(self._unit)` → 0 (never bumped for this unit).
+2. `EnsureInitialized(self._unit)` at AuraState.lua:151 sees `self._initialized == false` → runs `FullRefresh`.
+3. `FullRefresh` populates `self._helpfulById` and marks classified view dirty (new behavior).
+4. View-rebuild walks `self._helpfulById`, calls `classify()` for each aura, populates `self._helpfulClassifiedById` + `_helpfulClassifiedView.list`.
+5. Returns populated list.
+
+No cold-start branch leaks to callers.
+
+### Lifecycle diagram
+
+```
+   UNIT_AURA event
+        |
+        v
+   AuraCache.bump(unit)                           <-- existing
+        |  generation[unit]++
+        v
+   oUF dispatches to elements' Update
+        |
+        v
+   AuraState:ApplyUpdateInfo(unit, updateInfo)    <-- existing + new branches
+     -> update self._helpfulById / _harmfulById   <-- existing
+     -> nil classified entries for changed IDs    <-- new
+     -> mark classified views dirty               <-- new
+        |
+        v
+   [element calls auraState:GetHelpfulClassified()]
+        |
+        v
+   view.dirty?
+       |          \
+       no          yes
+       |            \
+       v             v
+   return list   walk self._helpfulById:
+                   for each aura:
+                     cached = self._helpfulClassifiedById[id]
+                     if not cached: classify()       <-- 4x probes, cache result
+                     append to view.list
+                   view.dirty = false
+                   return view.list
+```
+
+## Error Handling and Secret-Value Interactions
+
+### Secret-value invariants
+
+A1 is single-path. The same `classify()` runs for every aura regardless of which fields are secret. No `F.IsValueNonSecret()` branches anywhere in the classification layer.
+
+Why this works cleanly:
+
+- **Tier 1 passthrough:** structural booleans on `AuraData` (`isHelpful`, `isHarmful`, `isRaid`, `isBossAura`, `isFromPlayerOrPlayerPet`) are never secret, regardless of whether other fields on the same AuraData are secret.
+- **Tier 2 probes:** `IsAuraFilteredOutByInstanceID` is explicitly secret-safe per the CLAUDE.md "Secret Values" section.
+- **`entry.aura`** is a live ref — it carries whatever secret-ness the aura has. Downstream consumers handle via existing `F.IsValueNonSecret()` + secret-safe C-level rendering, exactly as they do today against raw `GetHelpful` results.
+
+The classification layer sits strictly upstream of any secret-value read. The "never split secret/non-secret paths" CLAUDE.md rule is upheld.
+
+### C API return normalization
+
+`IsAuraFilteredOutByInstanceID(unit, id, filter)` returns:
+
+- `true` → aura does NOT match the filter.
+- `false` → aura matches the filter.
+- `nil` → invalid unit, unknown instanceID, or unrecognized filter.
+
+Every Tier 2 flag uses `filtered == false` normalization:
+
+```lua
+flags.isExternalDefensive = C_UnitAuras.IsAuraFilteredOutByInstanceID(...) == false
+```
+
+**Not `not filtered`.** Since `not nil == true`, the naive form would silently promote every aura to match every filter. This is the single most important implementation detail in A1. An inline comment at the probe call site calls out this distinction.
+
+### Stale-ID degradation
+
+If an element retains an `entry` across a generation bump (shouldn't happen — contract is "re-fetch every frame"):
+
+- `entry.aura` is still a live table; fields still read cleanly.
+- `entry.flags` still holds booleans — stale but doesn't throw.
+- Likely the aura has been removed; `entry.aura.expirationTime` reads as past → element's existing expiration handling hides it.
+
+A1 does not add new defensive code for this. The contract matches existing `GetHelpful`: call fresh every UNIT_AURA.
+
+### Invalid or compound unit tokens
+
+For an AuraState instance on a frame whose unit is `raid50` in a 5-man, or a compound token like `party2target` (rejected by `C_UnitAuras.GetAuraSlots`):
+
+- `isCompoundUnit(unit)` guard at AuraState.lua:14 short-circuits `FullRefresh` for compound tokens — empty stores returned.
+- For invalid-but-simple tokens like `raid50`, `GetAuraSlots` returns empty results — empty stores.
+- Either way, `GetHelpfulClassified()` returns an empty list. No error, no warning.
+
+Identical to existing `GetHelpful('HELPFUL')` behavior for the same tokens.
+
+### No pcall
+
+Per CLAUDE.md "No pcall" rule, zero pcall in the classification layer. If a C API call throws, that's a Blizzard bug worth surfacing. No feature-detection guards for the four filter strings in scope — all four are present on live.
+
+### Flag-table GC pressure
+
+Unpooled in A1. Churn is ~2-4 KB/sec during active combat (~120 tables/min at steady state). Tolerable; visible on profile graphs but not catastrophic. Pooling deferred as a follow-up issue — prior attempt caused cross-addon taint (`feedback_table_pooling` memory), so a conservative retry design is out of scope here.
+
+## Testing Strategy
+
+### Philosophy
+
+Framed has no automated test harness; verification is live in-game. This matches all comparable WoW addons and is the standard per `feedback_coding_standards`. The per-element gate from the B-series is the test harness — each migration isolates its own regression surface.
+
+### A1 (#136) acceptance
+
+A1 does not change element behavior. Verification is correctness of classification + absence of regression in existing elements.
+
+**Correctness checklist (via `/framed aurastate <unit>`):**
+
+Each scenario below must also cross-check against the current element behavior — e.g., an aura marked `isExternalDefensive=true` by the new classifier must also be shown by the pre-A1 `Externals` element when that aura is on-screen. This cross-check is what confirms the classification matches what elements expect.
+
+| Scenario | Expected flags |
+|----------|----------------|
+| Empty unit | Empty lists, gen ≥ 1 |
+| Power Word: Shield cast on you (any source) | `isExternalDefensive=true`, `isImportant=true` |
+| Power Word: Shield cast by you on yourself | Above + `isPlayerCast=true` |
+| Ironbark cast on you | `isExternalDefensive=true`, `isBigDefensive=true`, `isFromPlayerOrPet=true` (if druid is in party) |
+| Blessing of Protection cast on you by another paladin | `isExternalDefensive=true`, `isImportant=true`, `isPlayerCast=false` |
+| Self-cast Devotion Aura | `isHelpful=true`, `isRaid=true`, `isPlayerCast=true` |
+| Boss DoT on you | `isHarmful=true`, `isBossAura=true` |
+| Dispellable magic debuff (from arena opponent) | `isHarmful=true`, `isImportant=true`, `entry.aura.dispelName == 'Magic'` |
+| `/reload` during combat | Same classifications as pre-reload; gen restarts at 0 for the instance, first read classifies fresh |
+
+**Non-regression checklist:**
+
+- Every existing element renders identically (Externals, Defensives, Buffs, Debuffs, MissingBuffs, StatusText).
+- `/framed events` shows UNIT_AURA registered, no duplicates.
+- No Lua errors during a 10-minute target-dummy + 5-man heroic session.
+- Profiler: `F.AuraState` per-frame cost delta < 5% over baseline. If higher, investigate `classify()` hot spots but not a hard block (B-series gains dwarf A1 overhead).
+
+**Encounter boundary verification:**
+
+Enter a raid boss encounter mid-auras. On `ENCOUNTER_START`, generation bumps (existing behavior at AuraCache.lua:73-79). Next `/framed aurastate <unit>` call shows re-classified state with fresh instanceIDs and no stale flags.
+
+### B-series acceptance (generic template)
+
+Each of #137-#142 follows:
+
+1. **Pre-migration snapshot.** Screenshot the element in 3-4 representative scenarios.
+2. **Migrate** to read `entry.flags.*` or the classified slice instead of element-side probes / separate `GetHelpful(filter)` calls.
+3. **Post-migration smoke.** Same scenarios, same screenshots. Diff visually.
+4. **Error capture.** No new Lua errors in 10-minute combat session.
+5. **Profiler snapshot.** Element's per-frame cost drops (big drop for #137/B1 and #138/B2; incidental-to-zero for others).
+6. **Commit + push to `working-testing`.** Merge to main after 24-48h live use without reports.
+
+**Per-element scope summary (from each issue body):**
+
+| Issue | Element | Migration focus | Must-test scenarios |
+|-------|---------|-----------------|---------------------|
+| #142 B6 (first) | `Elements/Status/StatusText.lua` | Event-handler consolidation: consume classified helpful slice for Drinking/Food detection | Drinking food buff appears with correct text/color/timer; no regression in summon-pending, disconnect, AFK, dead, ghost states |
+| #137 B1 | `Elements/Auras/Externals.lua` | Replace 5-probe classification chain with flag reads | Self PWS; external Ironbark; external BoP; IMPORTANT-only non-defensive helpful (still appears); RAID fallback for secret-spellID auras in combat (still hides Rejuvenation out of combat) |
+| #138 B2 | `Elements/Auras/Defensives.lua` | Single BIG_DEFENSIVE probe becomes `flags.isBigDefensive` read | Self Divine Shield; Ice Block; Cooldown Aggressive; player-cast border color distinction preserved |
+| #140 B4 | `Elements/Auras/Debuffs.lua` | Consume classified harmful slice (A1 already includes harmful per Q1) | Dispel-type colorization; boss/role debuff priority; `castBy` filter for harmful |
+| #141 B5 | `Elements/Auras/MissingBuffs.lua` | Consistency migration (spellID-driven, no classification needed) | Missing raid buff surfaces; cast it + confirm it clears |
+| #139 B3 (last) | `Elements/Auras/Buffs.lua` | `castBy='me'` uses `flags.isPlayerCast` (retires #113 over-match fallback); preserve `computeBuffFilter` and per-indicator spellID lookups | `castBy='me'` / `'others'` / `'all'` in combat + out of combat, with indicators with/without spell lists; no regression on border colors, stacks, ordering |
+
+### B3 Buffs: #113 retirement
+
+Brainstorming decision: B3 uses `flags.isPlayerCast` (populated by the `HELPFUL|PLAYER` probe — per AuraUtil.lua:158-174, "combine with Player & Helpful to return self-cast HoTs") for `castBy` discrimination. This is a definitive C-API answer and simpler than the #139 issue description's two-branch (`sourceUnit` non-secret → use `sourceUnit`; secret → fall back to `isFromPlayerOrPet`) approach.
+
+- **Today (with #113):** if `sourceUnit` is secret, the fallback treats the aura as cast-by-self when user configured `castBy='me'`. World buffs like Rallying Cry occasionally show in the wrong slot during combat.
+- **After B3:** `isPlayerCast` is a definitive answer regardless of sourceUnit secrecy. Rallying Cry you didn't cast classifies as `isPlayerCast=false`. `castBy='me'` shows only genuinely player-cast auras.
+
+**Action when B3 is planned:** update issue #139's "Preserve exactly" list to reflect `isPlayerCast` as the castBy mechanism; the two-branch fallback is superseded by this spec.
+
+Preserved from the original #139 scope (unchanged):
+
+- `computeBuffFilter` at Buffs.lua:71 — widens to `HELPFUL` when any indicator has a spell list, else `HELPFUL|RAID_IN_COMBAT`. This is an orthogonal filter for input scoping, not a castBy decision.
+- Per-indicator spell list matching — spellID-driven, independent of classification.
+
+No CHANGELOG call-out for the behavior change. Single-user audience, no migration friction.
+
+### C1 (#143) benchmark + visual regression
+
+C1 is the closing verification pass. Deliverable: a documented report (no code changes).
+
+**Protocol:**
+
+1. **Three profiler snapshots under identical conditions:**
+   - S0: pre-A1 baseline (from memory: 0.448ms avg).
+   - S1: post-A1, pre-B-series (classification writing, no element reading flags yet).
+   - S2: post-B6 (all elements migrated).
+2. **Three scenarios, 60 seconds each:**
+   - Target dummy solo (minimal churn).
+   - 5-man M+ dungeon (moderate churn).
+   - Raid boss encounter (peak churn).
+3. **Metrics per snapshot per scenario:**
+   - `GetAddOnCPUUsage('Framed')` delta over window.
+   - UNIT_AURA handler cost per event (profiler or `debugprofilestop`).
+   - GC pressure (`collectgarbage('count')` delta over window).
+4. **Visual regression set:** screenshots of 8-12 representative element states, pre-A1 vs post-B6. Archived in the C1 GitHub issue as attachments.
+
+**Success bar:**
+
+- **S2 ≤ 0.22ms (≈50% reduction from S0 0.448ms baseline)** on the raid scenario.
+- Measurable improvement on M+ scenario.
+- Target dummy may be flat — classification has fixed overhead, low-churn case is the weakest for a sharing optimization.
+- No visual regression in any screenshot pair.
+
+Cell (0.231ms) and Dander (0.075ms) are context only, not gates. Closing the gap toward Dander is aspirational future work.
+
+### Rollback strategy
+
+Each B-issue is its own commit behind main, enabling single-commit revert without touching siblings:
+
+1. `git revert` the B-issue's commit.
+2. A1 + unmigrated B-issues stay in place (flags keep being computed without a reader — no harm).
+3. Patch-level version bump per `feedback_release_workflow`.
+
+A1 itself is rollback-safe: new APIs + debug slash only. Reverting A1 is a non-event unless a B-issue already consumes it, which the per-element gate should prevent.
+
+### Explicitly deferred
+
+- Automated Lua unit tests (no harness exists today).
+- CI integration (`auto-tag.yml` + `release.yml` unchanged).
+- Visual regression automation (screenshot diffing is research scope).
+- Cross-locale testing (only English verified; other locales use same code path).
+
+## Dependencies and Sequencing
+
+### Issue graph
+
+```
+[#123 stale --> close]
+
+A1 (#136 AuraState classify)
+  |
+  v
+B6 (#142 StatusText) [smoke-test migration]
+  |
+  v
+B1 (#137 Externals)
+  |
+  v
+B2 (#138 Defensives)
+  |
+  v
+B4 (#140 Debuffs)
+  |
+  v
+B5 (#141 MissingBuffs)
+  |
+  v
+B3 (#139 Buffs) [#113 retirement]
+  |
+  v
+C1 (#143 Benchmark + VR)
+```
+
+### Locked execution order
+
+1. **Pre-work:** Close #123 as already-implemented.
+2. **A1 #136** — AuraState classification + debug slash.
+3. **B6 #142** — StatusText (smallest element; validates `entry.flags.*` pattern).
+4. **B1 #137** — Externals (highest C-API savings).
+5. **B2 #138** — Defensives (shares logic with Externals).
+6. **B4 #140** — Debuffs (independent of healing-oriented elements).
+7. **B5 #141** — MissingBuffs (complements Buffs, lighter).
+8. **B3 #139** — Buffs (largest; widest user-visible surface; #113 retirement).
+9. **C1 #143** — Benchmark + visual regression.
+
+### Branch and release discipline
+
+- All work on `working-testing` per `project_framed_worktree`.
+- Each issue = one PR from `working-testing` → `main`.
+- Commit + push after every task per `feedback_commit_after_task`.
+- Patch-level bump (0.x.Y) per `feedback_versioning`.
+- Version bump commit touches only TOC + CHANGELOG + About card per `feedback_release_workflow`.
+- Display name "Moodibs" per `feedback_author_name`.
+
+### Post-C1 follow-ups (out of scope)
+
+File as new GitHub issues when A1 ships:
+
+- **Flag-table pooling revisit** — conservative retry with bool-typed, wipe-on-release, internal-only pool.
+- **Store consolidation** — collapse `_helpfulById` + `_helpfulClassifiedById` into single classified store. Requires verifying no remaining caller needs raw AuraData without the flag wrapper.
+- **Partial `_helpfulMatches` cleanup** — the four filters that move to flags (`EXTERNAL_DEFENSIVE`, `IMPORTANT`, `PLAYER`, `BIG_DEFENSIVE`) can be stripped from the per-filter memoization path. Filters that stay in use post-B6 (e.g., `RAID_IN_COMBAT` for Buffs' `computeBuffFilter`, `RAID` for Debuffs' raid-filtered path) keep their memoization.
+- **Cache coverage gap analysis** — document structural reasons Framed can't easily match Dander's 0.075ms.
+
+## Files Touched
+
+### A1 (#136)
+
+- `Core/AuraState.lua`:
+  - Module-local `classify(unit, aura, isHelpful)` helper.
+  - Per-instance state additions in `F.AuraState.Create` (`_helpfulClassifiedById`, `_harmfulClassifiedById`, `_helpfulClassifiedView`, `_harmfulClassifiedView`).
+  - New instance methods: `GetHelpfulClassified`, `GetHarmfulClassified`, `GetClassifiedByInstanceID`.
+  - New invalidation methods: `InvalidateHelpfulClassified`, `InvalidateHarmfulClassified`, `MarkHelpfulClassifiedDirty`, `MarkHarmfulClassifiedDirty`.
+  - Write-path additions in `FullRefresh`, `ApplyUpdateInfo` (wipe classified store / invalidate per-ID entries alongside existing filter-match invalidation).
+- `Init.lua` — new `/framed aurastate` case in slash dispatcher.
+
+### B-series (#137 - #142)
+
+Each migrates one element's read path:
+
+- `Elements/Status/StatusText.lua` (B6 #142) — event-handler consolidation
+- `Elements/Auras/Externals.lua` (B1 #137) — probe chain → flag reads
+- `Elements/Auras/Defensives.lua` (B2 #138) — single-probe → flag read
+- `Elements/Auras/Debuffs.lua` (B4 #140) — consume classified harmful slice
+- `Elements/Auras/MissingBuffs.lua` (B5 #141) — consistency migration
+- `Elements/Auras/Buffs.lua` (B3 #139) — castBy via `isPlayerCast`
+
+### C1 (#143)
+
+No code changes. Report attached to the GitHub issue.
+
+## References
+
+- Parent issue: #115
+- Sub-issues: #136, #137, #138, #139, #140, #141, #142, #143
+- Stale dependency to close: #123
+- Prior art in-repo: `Core/AuraCache.lua` (Aura Cache Design spec, 2026-04-10), `Core/AuraState.lua`
+- Source of truth for filter strings: `/tmp/wow-ui-source/Interface/AddOns/Blizzard_FrameXMLUtil/AuraUtil.lua:158-174`
+- Source of truth for AuraData fields: `/tmp/wow-ui-source/Interface/AddOns/Blizzard_APIDocumentationGenerated/UnitAuraDocumentation.lua`


### PR DESCRIPTION
## Summary
- **A1 AuraState classification infrastructure** (#115) — per-frame shared classified store with `GetHelpfulClassified` / `GetHarmfulClassified` / `GetClassifiedByInstanceID` API. Write-path invalidation wired through `FullRefresh` / `ApplyUpdateInfo`. No element consumer migrated yet; B1-B6 follow in subsequent releases.
- **12.0.5 hotfix** — `C_UnitAuras.AddPrivateAuraAnchor` args now require `isContainer` in 12.0.5; missing field was throwing `bad argument #2 to '?'` on every unit frame spawn.
- **`/framed aurastate [unit]` debug slash** — dumps classification flag breakdown per aura on the target unit. Lets classification correctness be verified as B-series consumer migrations land.
- **Multi-target copy design spec** — doc-only, future work.
- Version bump to `v0.8.14-alpha`

## Commits
- `70b4f36` docs(spec): add UNIT_AURA fan-out rearchitecture design
- `12eb241` docs(spec): refine UNIT_AURA fan-out spec after self-review
- `20515ba` docs(plan): add A1 AuraState classification implementation plan
- `fb322fe` feat(aurastate): add classified store fields
- `72cb4c9` feat(aurastate): add classify() helper
- `2abeb9a` feat(aurastate): add GetHelpfulClassified / GetHarmfulClassified
- `71d1ea3` feat(aurastate): add GetClassifiedByInstanceID
- `6c56dbf` feat(aurastate): add classified invalidation methods
- `28216ef` feat(aurastate): wire classified invalidation into write path
- `9cf4f91` feat(aurastate): add /framed aurastate debug slash
- `a161b93` Add multi-target copy design spec
- `2032508` fix(12.0.5): pass required isContainer field to AddPrivateAuraAnchor
- `cf73b14` Bump to v0.8.14-alpha

## Test plan
QA completed on the `working-testing` → `working` leg (#145). Promotion only.

## Post-merge
- [ ] Confirm `auto-tag.yml` creates `v0.8.14-alpha` tag
- [ ] Confirm `release.yml` publishes to CurseForge and posts to Discord

## Follow-ups
- #118 — delta path unreachable (gen check forces FullRefresh on every UNIT_AURA). Diagnosis documented; separate PR cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)