### PR TITLE
B2 — migrate Defensives to AuraState classified API (#138)

### DIFF
--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -9,7 +9,11 @@ local GetAuraDataByAuraInstanceID = C_UnitAuras and C_UnitAuras.GetAuraDataByAur
 local IsAuraFilteredOutByInstanceID = C_UnitAuras and C_UnitAuras.IsAuraFilteredOutByInstanceID
 
 -- Classify a single aura into a wrapper entry { aura, flags }.
--- Tier 1 flags are structural passthroughs from AuraData (never secret).
+-- Tier 1 flags are structural AuraData booleans. Per Blizzard's 12.0.x
+-- changes, isHelpful / isHarmful / isRaid / isNameplateOnly /
+-- isFromPlayerOrPlayerPet are non-secret. isBossAura remains secret on
+-- encounter auras and must be guarded with F.IsValueNonSecret to avoid
+-- tainted boolean tests.
 -- Tier 2 flags use C_UnitAuras filter probes (secret-safe C API).
 local function classify(unit, aura, isHelpful)
 	local id = aura.auraInstanceID
@@ -19,7 +23,7 @@ local function classify(unit, aura, isHelpful)
 		isHelpful         = aura.isHelpful         or false,
 		isHarmful         = aura.isHarmful         or false,
 		isRaid            = aura.isRaid            or false,
-		isBossAura        = aura.isBossAura        or false,
+		isBossAura        = F.IsValueNonSecret(aura.isBossAura) and aura.isBossAura or false,
 		isFromPlayerOrPet = aura.isFromPlayerOrPlayerPet or false,
 	}
 

--- a/Elements/Auras/Defensives.lua
+++ b/Elements/Auras/Defensives.lua
@@ -6,6 +6,57 @@ F.Elements = F.Elements or {}
 F.Elements.Defensives = {}
 
 -- ============================================================
+-- renderEntry — acquire / position / paint a single BorderIcon slot
+-- ============================================================
+
+local function renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+	anchorPoint, anchorX, anchorY, playerColor, otherColor,
+	unit, id, auraData, isPlayerCast)
+
+	if(not pool[displayed]) then
+		pool[displayed] = F.Indicators.BorderIcon.Create(self, iconSize, {
+			showCooldown = true,
+			showStacks   = cfg.showStacks ~= false,
+			showDuration = cfg.showDuration ~= false,
+			frameLevel   = cfg.frameLevel,
+			stackFont    = cfg.stackFont,
+			durationFont = cfg.durationFont,
+		})
+	end
+
+	local bi = pool[displayed]
+	bi:ClearAllPoints()
+	bi:SetSize(iconSize)
+
+	local offset = (displayed - 1) * (iconSize + 2)
+	if(orientation == 'RIGHT') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX + offset, anchorY)
+	elseif(orientation == 'LEFT') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX - offset, anchorY)
+	elseif(orientation == 'DOWN') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY - offset)
+	elseif(orientation == 'UP') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY + offset)
+	end
+
+	local borderColor = isPlayerCast and playerColor or otherColor
+	if(bi.SetBorderColor) then
+		bi:SetBorderColor(borderColor[1], borderColor[2], borderColor[3])
+	end
+
+	bi:SetAura(
+		unit, id,
+		auraData.spellId,
+		auraData.icon,
+		auraData.duration,
+		auraData.expirationTime,
+		auraData.applications,
+		nil
+	)
+	bi:Show()
+end
+
+-- ============================================================
 -- Update — single-pass filter + display (zero intermediate tables)
 -- ============================================================
 
@@ -28,9 +79,6 @@ local function Update(self, event, unit, updateInfo)
 	local anchorX        = anchor[4]
 	local anchorY        = anchor[5]
 
-	-- BIG_DEFENSIVE is a classification filter, not a query filter —
-	-- GetUnitAuras does not support it. Fetch all helpful auras, then
-	-- classify each one via IsAuraFilteredOutByInstanceID.
 	local auraState = self.FramedAuraState
 	if(auraState) then
 		if(event == 'UNIT_AURA') then
@@ -39,85 +87,80 @@ local function Update(self, event, unit, updateInfo)
 			auraState:EnsureInitialized(unit)
 		end
 	end
-	local rawAuras = auraState and auraState:GetHelpful('HELPFUL') or F.AuraCache.GetUnitAuras(unit, 'HELPFUL')
+
+	local classified = auraState and auraState:GetHelpfulClassified()
+	local rawAuras   = (not classified) and F.AuraCache.GetUnitAuras(unit, 'HELPFUL') or nil
 
 	local displayed = 0
-	for _, auraData in next, rawAuras do
-		if(displayed >= maxDisplayed) then break end
 
-		local id = auraData.auraInstanceID -- NeverSecret
+	if(classified) then
+		for _, entry in next, classified do
+			if(displayed >= maxDisplayed) then break end
 
-		-- Step 1: BIG_DEFENSIVE (primary classification)
-		-- Exclude EXTERNAL_DEFENSIVE — those belong in the Externals element.
-		local show = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
-			unit, id, 'HELPFUL|BIG_DEFENSIVE')
-		if(show) then
-			local isExtDef = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
-				unit, id, 'HELPFUL|EXTERNAL_DEFENSIVE')
-			if(isExtDef) then show = false end
-		end
+			local auraData = entry.aura
+			local flags    = entry.flags
+			local id       = auraData.auraInstanceID
 
-		-- Skip long-duration buffs (flasks, food, racials) that aren't
-		-- real defensives. duration == 0 means permanent.
-		if(show) then
-			local dur = auraData.duration
-			if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
-				show = false
+			-- Primary classification: BIG_DEFENSIVE, excluding EXTERNAL_DEFENSIVE
+			-- (those belong in the Externals element).
+			local show = flags.isBigDefensive and not flags.isExternalDefensive
+
+			-- Skip long-duration buffs (flasks, food, racials) that aren't real
+			-- defensives. duration == 0 means permanent.
+			if(show) then
+				local dur = auraData.duration
+				if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
+					show = false
+				end
+			end
+
+			if(show) then
+				local isPlayerCast = flags.isPlayerCast
+
+				if(not ((visibilityMode == 'player' and not isPlayerCast)
+					or (visibilityMode == 'others' and isPlayerCast))) then
+					displayed = displayed + 1
+					renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+						anchorPoint, anchorX, anchorY, playerColor, otherColor,
+						unit, id, auraData, isPlayerCast)
+				end
 			end
 		end
+	else
+		-- Fallback: no AuraState on this frame. Vestigial in practice — every
+		-- aura-tracking frame creates AuraState via the idempotent Setup guard —
+		-- preserved to match the element-level pattern used across Auras/.
+		for _, auraData in next, rawAuras do
+			if(displayed >= maxDisplayed) then break end
 
-		if(show) then
-			-- Determine if player-cast via |PLAYER filter (avoids secret sourceUnit)
-			local isPlayerCast = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
-				unit, id, 'HELPFUL|PLAYER')
+			local id = auraData.auraInstanceID
 
-			-- Apply visibility mode filter
-			if(not ((visibilityMode == 'player' and not isPlayerCast)
-				or (visibilityMode == 'others' and isPlayerCast))) then
-				-- Display directly — no intermediate table
-				displayed = displayed + 1
+			local show = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+				unit, id, 'HELPFUL|BIG_DEFENSIVE')
+			if(show) then
+				local isExtDef = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+					unit, id, 'HELPFUL|EXTERNAL_DEFENSIVE')
+				if(isExtDef) then show = false end
+			end
 
-				if(not pool[displayed]) then
-					pool[displayed] = F.Indicators.BorderIcon.Create(self, iconSize, {
-						showCooldown = true,
-						showStacks   = cfg.showStacks ~= false,
-						showDuration = cfg.showDuration ~= false,
-						frameLevel   = cfg.frameLevel,
-						stackFont    = cfg.stackFont,
-						durationFont = cfg.durationFont,
-					})
+			if(show) then
+				local dur = auraData.duration
+				if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
+					show = false
 				end
+			end
 
-				local bi = pool[displayed]
-				bi:ClearAllPoints()
-				bi:SetSize(iconSize)
+			if(show) then
+				local isPlayerCast = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+					unit, id, 'HELPFUL|PLAYER')
 
-				local offset = (displayed - 1) * (iconSize + 2)
-				if(orientation == 'RIGHT') then
-					bi:SetPoint(anchorPoint, self, anchorPoint, anchorX + offset, anchorY)
-				elseif(orientation == 'LEFT') then
-					bi:SetPoint(anchorPoint, self, anchorPoint, anchorX - offset, anchorY)
-				elseif(orientation == 'DOWN') then
-					bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY - offset)
-				elseif(orientation == 'UP') then
-					bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY + offset)
+				if(not ((visibilityMode == 'player' and not isPlayerCast)
+					or (visibilityMode == 'others' and isPlayerCast))) then
+					displayed = displayed + 1
+					renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+						anchorPoint, anchorX, anchorY, playerColor, otherColor,
+						unit, id, auraData, isPlayerCast)
 				end
-
-				local borderColor = isPlayerCast and playerColor or otherColor
-				if(bi.SetBorderColor) then
-					bi:SetBorderColor(borderColor[1], borderColor[2], borderColor[3])
-				end
-
-				bi:SetAura(
-					unit, id,
-					auraData.spellId,
-					auraData.icon,
-					auraData.duration,
-					auraData.expirationTime,
-					auraData.applications,
-					nil
-				)
-				bi:Show()
 			end
 		end
 	end

--- a/docs/superpowers/plans/2026-04-21-b2-defensives-classified.md
+++ b/docs/superpowers/plans/2026-04-21-b2-defensives-classified.md
@@ -1,0 +1,468 @@
+# B2 Defensives Classified-API Migration Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `Elements/Auras/Defensives.lua` from inline `IsAuraFilteredOutByInstanceID` probes to flag reads on AuraState's classified store. Smoke-test migration for the B-series.
+
+**Architecture:** Replace three C-API probes per aura (BIG_DEFENSIVE, EXTERNAL_DEFENSIVE, PLAYER) with field reads on `entry.flags.*` from `auraState:GetHelpfulClassified()`. Preserve the no-AuraState fallback path for frames that don't create one (vestigial, matches existing element-level convention).
+
+**Tech Stack:** Lua 5.1, oUF, Framed's `F.AuraState` classified API (shipped in A1 / v0.8.14-alpha).
+
+---
+
+## Context and References
+
+- **Spec:** `docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md`
+- **A1 implementation:** `Core/AuraState.lua` — `classify()` at line 14, `GetHelpfulClassified()` at line 375
+- **Current Defensives probes:** `Elements/Auras/Defensives.lua:52-56` (BIG_DEFENSIVE + EXTERNAL_DEFENSIVE), line 71 (PLAYER)
+- **Issue:** #138 (B2 Defensives)
+- **Parent:** #115 (UNIT_AURA fan-out rearchitecture)
+
+## Scope note — three probes, not one
+
+The spec's per-element table says "Single BIG_DEFENSIVE probe becomes `flags.isBigDefensive` read + `flags.isPlayerCast` for border-color distinction." The actual code has three probes: BIG_DEFENSIVE (line 52), EXTERNAL_DEFENSIVE exclusion (line 55), and PLAYER (line 71). All three map to existing flags in A1's `classify()`. The migration covers all three.
+
+## Fallback path
+
+When `self.FramedAuraState` is nil (no aura element on the frame has created one), the existing fallback at line 42 uses `F.AuraCache.GetUnitAuras` and raw AuraData. Keep that path using the original probe logic — the spec at line 272 calls this branch "vestigial but preserved to match the existing element-level `auraState and ... or fallback` pattern." Do not touch it.
+
+---
+
+## File Structure
+
+- **Modify:** `Elements/Auras/Defensives.lua` — replace the inner loop of `Update` with a two-path pattern: classified iteration when AuraState exists, raw-AuraData iteration (current code) when it doesn't.
+
+No new files. No changes to `Core/AuraState.lua`.
+
+---
+
+## Task 1: Migrate Defensives.lua Update to classified API
+
+**Files:**
+- Modify: `Elements/Auras/Defensives.lua:44-123` (the main `for _, auraData in next, rawAuras do` loop)
+
+- [ ] **Step 1: Verify current probe positions with Grep**
+
+Run: `Grep -n "IsAuraFilteredOutByInstanceID" Elements/Auras/Defensives.lua`
+Expected output:
+```
+52:		local show = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+55:			local isExtDef = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+71:			local isPlayerCast = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+```
+
+If positions differ, re-read the file before editing.
+
+- [ ] **Step 2: Restructure the fetch + iterate block**
+
+Replace lines 34-42 and the `for _, auraData in next, rawAuras do` loop (line 45) through `end` of that loop (line 123) with two-path iteration. Concretely:
+
+Replace this block (lines 31-45):
+```lua
+	-- BIG_DEFENSIVE is a classification filter, not a query filter —
+	-- GetUnitAuras does not support it. Fetch all helpful auras, then
+	-- classify each one via IsAuraFilteredOutByInstanceID.
+	local auraState = self.FramedAuraState
+	if(auraState) then
+		if(event == 'UNIT_AURA') then
+			auraState:ApplyUpdateInfo(unit, updateInfo)
+		else
+			auraState:EnsureInitialized(unit)
+		end
+	end
+	local rawAuras = auraState and auraState:GetHelpful('HELPFUL') or F.AuraCache.GetUnitAuras(unit, 'HELPFUL')
+
+	local displayed = 0
+	for _, auraData in next, rawAuras do
+```
+
+With:
+```lua
+	local auraState = self.FramedAuraState
+	if(auraState) then
+		if(event == 'UNIT_AURA') then
+			auraState:ApplyUpdateInfo(unit, updateInfo)
+		else
+			auraState:EnsureInitialized(unit)
+		end
+	end
+
+	local classified = auraState and auraState:GetHelpfulClassified()
+	local rawAuras   = (not classified) and F.AuraCache.GetUnitAuras(unit, 'HELPFUL') or nil
+
+	local displayed = 0
+
+	if(classified) then
+		for _, entry in next, classified do
+			if(displayed >= maxDisplayed) then break end
+
+			local auraData = entry.aura
+			local flags    = entry.flags
+			local id       = auraData.auraInstanceID
+
+			-- Primary classification: BIG_DEFENSIVE, excluding EXTERNAL_DEFENSIVE
+			-- (those belong in the Externals element).
+			local show = flags.isBigDefensive and not flags.isExternalDefensive
+
+			-- Skip long-duration buffs (flasks, food, racials) that aren't real
+			-- defensives. duration == 0 means permanent.
+			if(show) then
+				local dur = auraData.duration
+				if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
+					show = false
+				end
+			end
+
+			if(show) then
+				local isPlayerCast = flags.isPlayerCast
+
+				if(not ((visibilityMode == 'player' and not isPlayerCast)
+					or (visibilityMode == 'others' and isPlayerCast))) then
+					displayed = displayed + 1
+					renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+						anchorPoint, anchorX, anchorY, playerColor, otherColor,
+						unit, id, auraData, isPlayerCast)
+				end
+			end
+		end
+	else
+		for _, auraData in next, rawAuras do
+			if(displayed >= maxDisplayed) then break end
+
+			local id = auraData.auraInstanceID
+
+			local show = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+				unit, id, 'HELPFUL|BIG_DEFENSIVE')
+			if(show) then
+				local isExtDef = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+					unit, id, 'HELPFUL|EXTERNAL_DEFENSIVE')
+				if(isExtDef) then show = false end
+			end
+
+			if(show) then
+				local dur = auraData.duration
+				if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
+					show = false
+				end
+			end
+
+			if(show) then
+				local isPlayerCast = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+					unit, id, 'HELPFUL|PLAYER')
+
+				if(not ((visibilityMode == 'player' and not isPlayerCast)
+					or (visibilityMode == 'others' and isPlayerCast))) then
+					displayed = displayed + 1
+					renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+						anchorPoint, anchorX, anchorY, playerColor, otherColor,
+						unit, id, auraData, isPlayerCast)
+				end
+			end
+		end
+	end
+
+	for idx = displayed + 1, #pool do
+		pool[idx]:Clear()
+	end
+end
+```
+
+And delete the original monolithic loop body (the big `if(show) then ... bi:Show()` render block that was lines 77-121 in the original) — moved into `renderEntry` below.
+
+- [ ] **Step 3: Extract the BorderIcon render into a local `renderEntry` helper**
+
+Add this module-local function between the `local oUF = F.oUF` block and the `Update` function (so before line 12):
+
+```lua
+-- ============================================================
+-- renderEntry — acquire / position / paint a single BorderIcon slot
+-- ============================================================
+
+local function renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+	anchorPoint, anchorX, anchorY, playerColor, otherColor,
+	unit, id, auraData, isPlayerCast)
+
+	if(not pool[displayed]) then
+		pool[displayed] = F.Indicators.BorderIcon.Create(self, iconSize, {
+			showCooldown = true,
+			showStacks   = cfg.showStacks ~= false,
+			showDuration = cfg.showDuration ~= false,
+			frameLevel   = cfg.frameLevel,
+			stackFont    = cfg.stackFont,
+			durationFont = cfg.durationFont,
+		})
+	end
+
+	local bi = pool[displayed]
+	bi:ClearAllPoints()
+	bi:SetSize(iconSize)
+
+	local offset = (displayed - 1) * (iconSize + 2)
+	if(orientation == 'RIGHT') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX + offset, anchorY)
+	elseif(orientation == 'LEFT') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX - offset, anchorY)
+	elseif(orientation == 'DOWN') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY - offset)
+	elseif(orientation == 'UP') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY + offset)
+	end
+
+	local borderColor = isPlayerCast and playerColor or otherColor
+	if(bi.SetBorderColor) then
+		bi:SetBorderColor(borderColor[1], borderColor[2], borderColor[3])
+	end
+
+	bi:SetAura(
+		unit, id,
+		auraData.spellId,
+		auraData.icon,
+		auraData.duration,
+		auraData.expirationTime,
+		auraData.applications,
+		nil
+	)
+	bi:Show()
+end
+```
+
+- [ ] **Step 4: Verify the file is syntactically valid**
+
+Run: `Bash luac -p Elements/Auras/Defensives.lua` (if luac is installed locally) OR visually scan the file structure: every `function … end`, every `if … then … end`, every `for … do … end` pair closes cleanly.
+
+If local `luac` not available, check by `Read`-ing the final file and visually verify indentation and structure.
+
+- [ ] **Step 5: Grep for any orphaned probe calls**
+
+Run: `Grep -n "IsAuraFilteredOutByInstanceID" Elements/Auras/Defensives.lua`
+Expected: only the three probes inside the `else` (no-AuraState fallback) block — roughly 3 matches. If zero, the fallback got inadvertently removed; revisit. If >3, the happy path still has probes; revisit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Elements/Auras/Defensives.lua
+git commit -m "$(cat <<'EOF'
+feat(defensives): migrate to AuraState classified API (B2 #138)
+
+Replace 3 IsAuraFilteredOutByInstanceID probes per aura
+(BIG_DEFENSIVE, EXTERNAL_DEFENSIVE, PLAYER) with flag reads on
+entry.flags.* from auraState:GetHelpfulClassified().
+
+The no-AuraState fallback path keeps its original probe logic —
+per spec, this branch is vestigial but preserved for consistency
+with the element-level pattern used across Auras/.
+
+Render slot acquisition/positioning/painting factored into a
+local renderEntry helper so both paths share it without copy-paste.
+
+Part of #115 UNIT_AURA fan-out rearchitecture.
+EOF
+)"
+```
+
+---
+
+## Task 2: Live smoke test
+
+Framed has no automated test harness; verification is in-game per `feedback_coding_standards` and the spec's "Testing Strategy" section.
+
+**Files:** None.
+
+- [ ] **Step 1: /reload in WoW**
+
+The addon folder is a symlink (per `feedback_wow_sync`), so the edited Defensives.lua is already live. `/reload` to pick it up.
+
+- [ ] **Step 2: Verify with `/framed aurastate player`**
+
+Cast Power Word: Shield on yourself (or similar self-buff), then run `/framed aurastate player`. Confirm the printed flags include `external-defensive` and `important` for PWS. This confirms the classified API is populated before Defensives reads it.
+
+- [ ] **Step 3: Self-defensive test — Divine Shield / Ice Block / Cloak / Shield Wall**
+
+Cast a personal defensive (class-appropriate):
+- Paladin: Divine Shield
+- Mage: Ice Block
+- Rogue: Cloak of Shadows
+- Warrior: Shield Wall
+
+**Expected:** Defensive BorderIcon appears on your player frame with green (player-cast) border color. Position matches the configured anchor. Duration text displays. Icon clears when the aura expires.
+
+**If regression:** revert Task 1's commit, re-examine the flag mapping.
+
+- [ ] **Step 4: External-defensive exclusion**
+
+Have a healer cast Power Word: Shield on you (or use a target dummy + offer PWS yourself). **Expected:** PWS does NOT appear in Defensives — it's classified as `isExternalDefensive` and excluded. It should appear in Externals instead.
+
+If PWS appears in Defensives: the `not flags.isExternalDefensive` exclusion didn't fire. Check Step 2's `/framed aurastate player` output to confirm `external-defensive` is in the flag list.
+
+- [ ] **Step 5: Visibility mode test**
+
+Open Framed Settings → Defensives panel. Toggle `visibilityMode` through `all` / `player` / `others` and confirm:
+- `all`: all BIG_DEFENSIVE auras render
+- `player`: only player-cast renders (green border)
+- `others`: only other-cast renders (yellow border)
+
+- [ ] **Step 6: Border color distinction**
+
+If you have a target dummy setup, stand a second character near your main's view. Have it apply a big defensive to you (if any class can externally apply something that's classified as BIG_DEFENSIVE and NOT EXTERNAL_DEFENSIVE — rare, but test whatever applies). Otherwise confirm via the self-cast path that the green (player) border shows correctly.
+
+- [ ] **Step 7: Long-duration skip**
+
+Confirm flasks / food buffs / racial buffs (all duration 0 or >= 600s) do NOT appear. This exercises the `dur == 0 or dur >= 600` filter after the flag check.
+
+- [ ] **Step 8: Combat churn — 5-man or target dummy burst**
+
+Run a dungeon pull or a 60s target-dummy rotation with all personal cooldowns active. Watch for:
+- No Lua errors in `/etrace` or BugSack
+- Icons appear/disappear cleanly with cooldown usage
+- No visual flicker or orphaned icons after auras drop
+
+- [ ] **Step 9: Report findings**
+
+Post a brief summary back to the user confirming:
+- Which personal defensives were tested
+- Border color distinction worked
+- External-defensive exclusion worked
+- No regressions observed in a combat session
+
+If any step reveals a regression, STOP, do not proceed to Task 3, and consult the user.
+
+---
+
+## Task 3: Release cut
+
+**Files:**
+- Modify: `CHANGELOG.md` (new v0.8.15-alpha block)
+- Modify: `Framed.toc:5` (version bump)
+- Modify: `Settings/Cards/About.lua` (regenerated by sync-changelog.lua)
+
+Per `feedback_release_workflow`: fix commit first (Task 1), bump commit second (this task) touches only CHANGELOG / TOC / About.
+
+- [ ] **Step 1: Add v0.8.15-alpha block to CHANGELOG.md**
+
+Open `CHANGELOG.md` and insert between `[Unreleased]` and `v0.8.14-alpha`:
+
+```markdown
+## v0.8.15-alpha
+
+- **B2 Defensives migrated to classified API** (#115, #138) — `Elements/Auras/Defensives.lua` now reads `entry.flags.*` from `auraState:GetHelpfulClassified()` instead of issuing 3 `IsAuraFilteredOutByInstanceID` probes per aura per UNIT_AURA. First consumer of A1's classification infrastructure. Behavior unchanged — same defensives render, same player/other border distinction, same long-duration skip.
+```
+
+- [ ] **Step 2: Run sync-changelog.lua**
+
+```bash
+./tools/sync-changelog.lua
+```
+
+This regenerates the `-- BEGIN/END GENERATED CHANGELOG` block in `Settings/Cards/About.lua` with the new entries (most-recent-2 kept).
+
+- [ ] **Step 3: Bump Framed.toc version**
+
+Edit `Framed.toc` line 5:
+```
+## Version: 0.8.14-alpha
+```
+to:
+```
+## Version: 0.8.15-alpha
+```
+
+- [ ] **Step 4: Verify the bump commit's diff is scoped correctly**
+
+Run: `Bash git status && git diff --stat`
+Expected three files changed: `CHANGELOG.md`, `Framed.toc`, `Settings/Cards/About.lua`. Nothing else.
+
+If other files appear, stash them before committing the bump — the release-workflow memory requires the bump commit to be narrow.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md Framed.toc Settings/Cards/About.lua
+git commit -m "Bump to v0.8.15-alpha"
+```
+
+- [ ] **Step 6: Push**
+
+```bash
+git push origin working-testing
+```
+
+---
+
+## Task 4: Create PRs (working-testing → working, then working → main)
+
+Follows the same two-stage promotion pattern used for v0.8.14-alpha (PRs #145 + #146). Per `project_framed_worktree`: working-testing → working for dev promotion; working → main triggers release automation.
+
+**Files:** None.
+
+- [ ] **Step 1: Create working-testing → working PR**
+
+```bash
+gh pr create --base working --head working-testing \
+  --title "v0.8.15-alpha — B2 Defensives classified-API migration" \
+  --body "$(cat <<'EOF'
+## Summary
+- **B2 Defensives migrated to classified API** (#115, #138) — first element consumer of A1's classification layer. Replaces 3 `IsAuraFilteredOutByInstanceID` probes per aura (BIG_DEFENSIVE, EXTERNAL_DEFENSIVE, PLAYER) with flag reads.
+- Behavior unchanged; smoke-test migration validates the `entry.flags.*` pattern for the rest of the B-series.
+- Version bump 0.8.14-alpha → 0.8.15-alpha.
+
+## Test plan
+- [x] Self-cast personal defensive (Divine Shield / Ice Block / etc.) renders with green border
+- [x] PWS (external-defensive) does NOT appear in Defensives (appears in Externals)
+- [x] Visibility mode all / player / others each filter correctly
+- [x] Long-duration skip (flasks / food / racials) preserved
+- [x] Combat session with cooldowns — no Lua errors, no orphaned icons
+
+## Follow-ups
+- B1 Externals (#137) next in the series
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for working-testing → working PR to be reviewed and merged**
+
+STOP here. Hand back to the user for merge. Once merged, continue to Step 3.
+
+- [ ] **Step 3: Create working → main promotion PR**
+
+Run after the working-testing PR is merged:
+
+```bash
+gh pr create --base main --head working \
+  --title "Promote v0.8.15-alpha to main" \
+  --body "$(cat <<'EOF'
+## Summary
+- **B2 Defensives migrated to classified API** (#115, #138) — first element consumer of A1's classification layer; 3 probes per aura replaced with flag reads. Behavior unchanged.
+- Version bump 0.8.14-alpha → 0.8.15-alpha.
+
+## Test plan
+QA completed on the `working-testing` → `working` leg (previous PR). Promotion only.
+
+## Post-merge
+- [ ] Confirm `auto-tag.yml` creates `v0.8.15-alpha` tag
+- [ ] Confirm `release.yml` publishes to CurseForge and posts to Discord
+
+## Follow-ups
+- B1 Externals (#137) next in the series
+- #118 gen-check defect — remains blocked until all B-series elements ship
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Hand back to user**
+
+Report both PR URLs. The user owns the merge; auto-tag + release automation fire on the main merge.
+
+---
+
+## Rollback strategy
+
+Per the spec's "Rollback strategy" section (line 556):
+1. `git revert` the Task 1 commit (and the bump in Task 3 if already landed).
+2. AuraState's classification layer stays in place; Defensives reverts to its pre-B2 probe path against `_helpfulById`.
+3. Other B-issues (none shipped yet) unaffected.
+
+A1's API surface is append-only — reverting B2 does not require touching `Core/AuraState.lua`.

--- a/docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md
+++ b/docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md
@@ -131,8 +131,11 @@ Existing `self._helpfulById` / `self._harmfulById` stores stay untouched during 
 
 | Tier | Flags | Source | Secret-safe |
 |------|-------|--------|-------------|
-| 1 (passthrough) | `isHelpful`, `isHarmful`, `isRaid`, `isBossAura`, `isFromPlayerOrPet` | `AuraData` structural booleans | Always |
+| 1a (passthrough) | `isHelpful`, `isHarmful`, `isRaid`, `isFromPlayerOrPet` | `AuraData` structural booleans | Always — de-secret'd by Blizzard in 12.0.x |
+| 1b (guarded passthrough) | `isBossAura` | `AuraData` boolean via `F.IsValueNonSecret()` guard | Graceful degrade — secret resolves to `false` |
 | 2 (C probe) | `isExternalDefensive`, `isImportant`, `isPlayerCast`, `isBigDefensive` | `C_UnitAuras.IsAuraFilteredOutByInstanceID(unit, id, filter)` | Always (C-level API) |
+
+**Why `isBossAura` needs the guard:** per Blizzard's 12.0.x API changes, `isHelpful` / `isHarmful` / `isRaid` / `isNameplateOnly` / `isFromPlayerOrPlayerPet` are no longer secret on aura data tables. `isBossAura` remains secret on encounter auras — a bare `or false` on a secret boolean taints the enclosing function. The guard is the minimum defensive read.
 
 **Originally proposed a third tier** (spellID-keyed cache for `isBigDefensive` via `C_UnitAuras.AuraIsBigDefensive`). Dropped because (a) `spellId` is typically secret in combat, and `AuraIsBigDefensive` is not documented to accept secret scalars; (b) the probe alternative is already proven by current Externals.lua. Two tiers keeps single-path and avoids feature-detection branching.
 
@@ -214,13 +217,16 @@ local function classify(unit, aura, isHelpful)
     local id = aura.auraInstanceID
     local prefix = isHelpful and 'HELPFUL' or 'HARMFUL'
 
-    -- Tier 1: structural passthrough (always safe, never secret)
+    -- Tier 1a: derived from caller's filter (never reads a secret field).
+    -- Tier 1b: AuraData booleans guarded with F.IsValueNonSecret — these
+    -- fields can be secret per-aura (e.g. isBossAura on encounter auras),
+    -- so a bare `or false` would taint the classify call. Secret -> false.
     local flags = {
-        isHelpful         = aura.isHelpful or false,
-        isHarmful         = aura.isHarmful or false,
-        isRaid            = aura.isRaid or false,
-        isBossAura        = aura.isBossAura or false,
-        isFromPlayerOrPet = aura.isFromPlayerOrPlayerPet or false,
+        isHelpful         = isHelpful,
+        isHarmful         = not isHelpful,
+        isRaid            = F.IsValueNonSecret(aura.isRaid)                 and aura.isRaid                 or false,
+        isBossAura        = F.IsValueNonSecret(aura.isBossAura)             and aura.isBossAura             or false,
+        isFromPlayerOrPet = F.IsValueNonSecret(aura.isFromPlayerOrPlayerPet) and aura.isFromPlayerOrPlayerPet or false,
     }
 
     -- Tier 2: instance-ID filter probes.
@@ -392,15 +398,18 @@ No cold-start branch leaks to callers.
 
 ### Secret-value invariants
 
-A1 is single-path. The same `classify()` runs for every aura regardless of which fields are secret. No `F.IsValueNonSecret()` branches anywhere in the classification layer.
+A1 is single-path. The same `classify()` runs for every aura; `F.IsValueNonSecret()` appears on exactly one field read (`aura.isBossAura`). No conditional branches change *what* is classified based on secret-ness — the guard is a graceful-degrade wrapper on a single field read.
 
 Why this works cleanly:
 
-- **Tier 1 passthrough:** structural booleans on `AuraData` (`isHelpful`, `isHarmful`, `isRaid`, `isBossAura`, `isFromPlayerOrPlayerPet`) are never secret, regardless of whether other fields on the same AuraData are secret.
-- **Tier 2 probes:** `IsAuraFilteredOutByInstanceID` is explicitly secret-safe per the CLAUDE.md "Secret Values" section.
+- **Tier 1a (passthrough):** `isHelpful`, `isHarmful`, `isRaid`, `isFromPlayerOrPet` are no longer secret per [Patch 12.0.5 API changes](https://warcraft.wiki.gg/wiki/Patch_12.0.5/API_changes): *"The isHelpful, isHarmful, isRaid, isNameplateOnly, and isFromPlayerOrPlayerPet fields on AuraData are no longer secret."* Bare `aura.field or false` is safe.
+- **Tier 1b (guarded passthrough):** `isBossAura` remains secret on encounter auras. Read via `F.IsValueNonSecret(aura.isBossAura) and aura.isBossAura or false`. Secret values resolve to `false`. This is *graceful degradation*, not a split path: a boss-aura still renders; it just won't surface `flags.isBossAura=true` while its field is tainted. No Framed consumer currently reads this flag in a way that breaks on a `false` result.
+- **Tier 2 probes:** `IsAuraFilteredOutByInstanceID` is explicitly secret-safe per the CLAUDE.md "Secret Values" section — pass-through by C API.
 - **`entry.aura`** is a live ref — it carries whatever secret-ness the aura has. Downstream consumers handle via existing `F.IsValueNonSecret()` + secret-safe C-level rendering, exactly as they do today against raw `GetHelpful` results.
 
-The classification layer sits strictly upstream of any secret-value read. The "never split secret/non-secret paths" CLAUDE.md rule is upheld.
+**Why we can't skip the `isBossAura` guard:** empirically (AuraState crash 2026-04-21, error log locals) a single `AuraData` can carry `isHelpful=true` / `isRaid=false` (both non-secret per 12.0.5) alongside `isBossAura=<secret>`. A bare `or false` on the secret field taints the enclosing function. The guard is the minimum defensive read.
+
+The classification layer sits strictly upstream of any secret-value *comparison* or *arithmetic*. The "never split secret/non-secret paths" CLAUDE.md rule is upheld — there is one `classify()` path for every aura on every frame.
 
 ### C API return normalization
 

--- a/docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md
+++ b/docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md
@@ -1,7 +1,7 @@
 # UNIT_AURA Fan-Out Rearchitecture Design Spec
 
 **Date:** 2026-04-21
-**Issue:** #115 (parent); #136 (A1), #137-#142 (B1-B6), #143 (C1)
+**Issue:** #115 (parent); #136 (A1), #137-#141 (B1-B5), #143 (C1). #142 (B6 StatusText) dropped from scope — see below.
 **Status:** Approved
 
 ## Summary
@@ -12,7 +12,7 @@ Today's aura elements fall into two classes:
 
 - **Classification-heavy** (Externals, Defensives) — call `IsAuraFilteredOutByInstanceID` directly in their Update paths, up to 5 probes per aura per UNIT_AURA in Externals.
 - **Spell-set-driven** (Buffs, Debuffs, MissingBuffs) — don't do classification themselves, but would benefit from pre-computed flags to simplify `castBy='me'` decisions and dispel-color handling.
-- **Text/status** (StatusText) — registers its own UNIT_AURA handler for Drinking/Food detection; consolidation reduces total UNIT_AURA fan-out count.
+- ~~**Text/status** (StatusText) — registers its own UNIT_AURA handler for Drinking/Food detection.~~ Out of scope: StatusText's aura scan is spellID-name-based (no flag reads) and short-circuits via `InCombatLockdown()` before running, so it contributes zero cost to the combat window this work targets. See "Non-goals for A1" and the B6 drop rationale below.
 
 After this rearchitecture: four probes per aura per classification write, shared across all elements on the same frame (via the existing per-frame `self.FramedAuraState` instance). Target: ≈50% reduction from baseline.
 
@@ -43,11 +43,11 @@ The fix: classify once on the shared per-frame AuraState, expose flags, let elem
 | Tier structure | 2 tiers (passthrough + C probe) | Originally 3 tiers; revised to drop `AuraIsBigDefensive` in favor of probe |
 | Update-path behavior | Always re-classify | Correctness > microperf at UNIT_AURA rate |
 | B-series pacing | Per-element gate | Each element migrates independently; smoke test + merge between |
-| B-series order | B6 → B1 → B2 → B4 → B5 → B3 | Simplest first (smoke); Buffs last (size + #113 retirement) |
+| B-series order | B2 → B1 → B4 → B5 → B3 | B2 is simplest flag consumer (smoke-test); Buffs last (size + #113 retirement). B6 StatusText dropped — see below. |
 | Buffs castBy model | `flags.isPlayerCast` exclusively | Retires #113 over-match workaround silently |
 | Debug surface | `/framed aurastate <unit>` slash | Permanent shipping feature; matches `/framed events` / `/framed config` pattern |
 | Flag-table pooling | Deferred (unpooled in A1) | Prior attempt caused cross-addon taint; conservative retry is a separate issue |
-| Spec structure | Single comprehensive spec | A1 + B1-B6 + C1 share enough design surface to document once |
+| Spec structure | Single comprehensive spec | A1 + B1-B5 + C1 share enough design surface to document once |
 
 ## Prior Work and Dependencies
 
@@ -125,7 +125,7 @@ self._helpfulClassifiedById[instanceID] = {
 
 `isBigDefensive` is always `false` for harmful auras (the `HELPFUL|BIG_DEFENSIVE` filter has no harmful analog). The flag is present on every wrapper for shape stability.
 
-Existing `self._helpfulById` / `self._harmfulById` stores stay untouched during the migration. Each B-issue migrates one element's read path; writes to both stores happen in parallel. After B6 ships, a follow-up collapses the two stores.
+Existing `self._helpfulById` / `self._harmfulById` stores stay untouched during the migration. Each B-issue migrates one element's read path; writes to both stores happen in parallel. After the B-series ships, a follow-up collapses the two stores.
 
 ### Flag lifecycle tiers
 
@@ -158,8 +158,8 @@ AuraState's existing `ensureFresh(unit)` gate catches all three categories.
 ### Non-goals for A1
 
 - No pooling of `flags` tables. (Deferred issue.)
-- No collapse of `_helpfulById` + `_helpfulClassifiedById`. (Follow-up after B6.)
-- No removal of `_helpfulMatches` filter memoization — some filters (e.g., `RAID_IN_COMBAT`) stay in use via `GetHelpful(filter)` post-B6.
+- No collapse of `_helpfulById` + `_helpfulClassifiedById`. (Follow-up after the B-series.)
+- No removal of `_helpfulMatches` filter memoization — some filters (e.g., `RAID_IN_COMBAT`) stay in use via `GetHelpful(filter)` post-B-series.
 - No changes to existing `GetHelpful(filter)` / `GetHarmful(filter)` shape or behavior.
 - No mutation of `AuraData` references.
 - No new event registrations.
@@ -188,7 +188,7 @@ function AuraState:GetClassifiedByInstanceID(instanceID) end
 
 All three run through the existing `EnsureInitialized(self._unit)` generation gate — same semantics as `GetHelpful` / `GetHarmful`.
 
-`GetClassifiedByInstanceID` is the single-entry accessor for elements that hold a spellID-to-instanceID map or process `updateInfo.updatedAuraInstanceIDs` payloads directly. **Primary planned consumer: B3 Buffs (#139)** per-indicator resolution path — the migrated Buffs element resolves indicator-tracked spells to their current wrapper entry in O(1) rather than scanning the full classified array. **B6 StatusText (#142)** is a secondary candidate if its migrated Drinking/Food detection switches from array-scan to delta-payload processing. The API ships in A1 so B-series wiring exists when those migrations land; final call sites are fixed at B-series issue refinement.
+`GetClassifiedByInstanceID` is the single-entry accessor for elements that hold a spellID-to-instanceID map or process `updateInfo.updatedAuraInstanceIDs` payloads directly. **Primary planned consumer: B3 Buffs (#139)** per-indicator resolution path — the migrated Buffs element resolves indicator-tracked spells to their current wrapper entry in O(1) rather than scanning the full classified array. The API ships in A1 so B-series wiring exists when that migration lands; final call sites are fixed at B-series issue refinement.
 
 Unlike `GetHelpful(filter)` which takes a filter string, the classified APIs return all helpful/harmful auras with flags populated. Filter-like narrowing is done by the caller via flag reads: `if(entry.flags.isExternalDefensive)`.
 
@@ -485,7 +485,7 @@ Enter a raid boss encounter mid-auras. On `ENCOUNTER_START`, generation bumps (e
 
 ### B-series acceptance (generic template)
 
-Each of #137-#142 follows:
+Each of #137-#141 follows:
 
 1. **Pre-migration snapshot.** Screenshot the element in 3-4 representative scenarios.
 2. **Migrate** to read `entry.flags.*` or the classified slice instead of element-side probes / separate `GetHelpful(filter)` calls.
@@ -498,12 +498,13 @@ Each of #137-#142 follows:
 
 | Issue | Element | Migration focus | Must-test scenarios |
 |-------|---------|-----------------|---------------------|
-| #142 B6 (first) | `Elements/Status/StatusText.lua` | Event-handler consolidation: consume classified helpful slice for Drinking/Food detection | Drinking food buff appears with correct text/color/timer; no regression in summon-pending, disconnect, AFK, dead, ghost states |
+| #138 B2 (first) | `Elements/Auras/Defensives.lua` | Single BIG_DEFENSIVE probe becomes `flags.isBigDefensive` read + `flags.isPlayerCast` for border-color distinction | Self Divine Shield; Ice Block; Cooldown Aggressive; player-cast border color distinction preserved |
 | #137 B1 | `Elements/Auras/Externals.lua` | Replace 5-probe classification chain with flag reads | Self PWS; external Ironbark; external BoP; IMPORTANT-only non-defensive helpful (still appears); RAID fallback for secret-spellID auras in combat (still hides Rejuvenation out of combat) |
-| #138 B2 | `Elements/Auras/Defensives.lua` | Single BIG_DEFENSIVE probe becomes `flags.isBigDefensive` read | Self Divine Shield; Ice Block; Cooldown Aggressive; player-cast border color distinction preserved |
 | #140 B4 | `Elements/Auras/Debuffs.lua` | Consume classified harmful slice (A1 already includes harmful per Q1) | Dispel-type colorization; boss/role debuff priority; `castBy` filter for harmful |
 | #141 B5 | `Elements/Auras/MissingBuffs.lua` | Consistency migration (spellID-driven, no classification needed) | Missing raid buff surfaces; cast it + confirm it clears |
 | #139 B3 (last) | `Elements/Auras/Buffs.lua` | `castBy='me'` uses `flags.isPlayerCast` (retires #113 over-match fallback); preserve `computeBuffFilter` and per-indicator spellID lookups | `castBy='me'` / `'others'` / `'all'` in combat + out of combat, with indicators with/without spell lists; no regression on border colors, stacks, ordering |
+
+**B6 #142 StatusText dropped from scope.** StatusText registers UNIT_AURA for Drinking/Food detection, but its `checkDrinking` scan short-circuits on `InCombatLockdown()` (StatusText.lua:76) before touching auras. The combat window this work targets is exactly when StatusText doesn't run. Separately, its scan is spellID-name-based (matches `aura.name` against the Food & Drink spell list) — it reads zero of the 9 classification flags, so routing it through `GetHelpfulClassified()` would make it pay the classify() cost for data it discards. Migration to `GetHelpful('HELPFUL')` (existing API) is a valid standalone cleanup but doesn't belong in the classification series. #142 closed as not-needed.
 
 ### B3 Buffs: #113 retirement
 
@@ -530,7 +531,7 @@ C1 is the closing verification pass. Deliverable: a documented report (no code c
 1. **Three profiler snapshots under identical conditions:**
    - S0: pre-A1 baseline (from memory: 0.448ms avg).
    - S1: post-A1, pre-B-series (classification writing, no element reading flags yet).
-   - S2: post-B6 (all elements migrated).
+   - S2: post-B3 (all in-scope elements migrated; B3 Buffs is the last B-issue).
 2. **Three scenarios, 60 seconds each:**
    - Target dummy solo (minimal churn).
    - 5-man M+ dungeon (moderate churn).
@@ -540,7 +541,7 @@ C1 is the closing verification pass. Deliverable: a documented report (no code c
    - `GetAddOnCPUUsage('Framed')` delta over window.
    - UNIT_AURA handler cost per event (profiler or `debugprofilestop`).
    - GC pressure (`collectgarbage('count')` delta over window).
-4. **Visual regression set:** screenshots of 8-12 representative element states, pre-A1 vs post-B6. Archived in the C1 GitHub issue as attachments.
+4. **Visual regression set:** screenshots of 8-12 representative element states, pre-A1 vs post-B3. Archived in the C1 GitHub issue as attachments.
 
 **Success bar:**
 
@@ -576,17 +577,15 @@ A1 itself is rollback-safe: new APIs + debug slash only. Reverting A1 is a non-e
 
 ```
 [#123 stale --> close]
+[#142 B6 StatusText dropped from scope]
 
 A1 (#136 AuraState classify)
   |
   v
-B6 (#142 StatusText) [smoke-test migration]
+B2 (#138 Defensives) [smoke-test migration — smallest flag consumer]
   |
   v
 B1 (#137 Externals)
-  |
-  v
-B2 (#138 Defensives)
   |
   v
 B4 (#140 Debuffs)
@@ -603,15 +602,14 @@ C1 (#143 Benchmark + VR)
 
 ### Locked execution order
 
-1. **Pre-work:** Close #123 as already-implemented.
+1. **Pre-work:** Close #123 as already-implemented; close #142 B6 as out-of-scope (StatusText combat-gated, reads no flags).
 2. **A1 #136** — AuraState classification + debug slash.
-3. **B6 #142** — StatusText (smallest element; validates `entry.flags.*` pattern).
+3. **B2 #138** — Defensives (smallest flag consumer; validates `entry.flags.*` pattern as smoke-test).
 4. **B1 #137** — Externals (highest C-API savings).
-5. **B2 #138** — Defensives (shares logic with Externals).
-6. **B4 #140** — Debuffs (independent of healing-oriented elements).
-7. **B5 #141** — MissingBuffs (complements Buffs, lighter).
-8. **B3 #139** — Buffs (largest; widest user-visible surface; #113 retirement).
-9. **C1 #143** — Benchmark + visual regression.
+5. **B4 #140** — Debuffs (independent of healing-oriented elements).
+6. **B5 #141** — MissingBuffs (complements Buffs, lighter).
+7. **B3 #139** — Buffs (largest; widest user-visible surface; #113 retirement).
+8. **C1 #143** — Benchmark + visual regression.
 
 ### Branch and release discipline
 
@@ -628,7 +626,7 @@ File as new GitHub issues when A1 ships:
 
 - **Flag-table pooling revisit** — conservative retry with bool-typed, wipe-on-release, internal-only pool.
 - **Store consolidation** — collapse `_helpfulById` + `_helpfulClassifiedById` into single classified store. Requires verifying no remaining caller needs raw AuraData without the flag wrapper.
-- **Partial `_helpfulMatches` cleanup** — the four filters that move to flags (`EXTERNAL_DEFENSIVE`, `IMPORTANT`, `PLAYER`, `BIG_DEFENSIVE`) can be stripped from the per-filter memoization path. Filters that stay in use post-B6 (e.g., `RAID_IN_COMBAT` for Buffs' `computeBuffFilter`, `RAID` for Debuffs' raid-filtered path) keep their memoization.
+- **Partial `_helpfulMatches` cleanup** — the four filters that move to flags (`EXTERNAL_DEFENSIVE`, `IMPORTANT`, `PLAYER`, `BIG_DEFENSIVE`) can be stripped from the per-filter memoization path. Filters that stay in use post-B-series (e.g., `RAID_IN_COMBAT` for Buffs' `computeBuffFilter`, `RAID` for Debuffs' raid-filtered path) keep their memoization.
 - **Cache coverage gap analysis** — document structural reasons Framed can't easily match Dander's 0.075ms.
 
 ## Files Touched
@@ -643,16 +641,17 @@ File as new GitHub issues when A1 ships:
   - Write-path additions in `FullRefresh`, `ApplyUpdateInfo` (wipe classified store / invalidate per-ID entries alongside existing filter-match invalidation).
 - `Init.lua` — new `/framed aurastate` case in slash dispatcher.
 
-### B-series (#137 - #142)
+### B-series (#137 - #141)
 
 Each migrates one element's read path:
 
-- `Elements/Status/StatusText.lua` (B6 #142) — event-handler consolidation
+- `Elements/Auras/Defensives.lua` (B2 #138) — single-probe → flag read (smoke-test)
 - `Elements/Auras/Externals.lua` (B1 #137) — probe chain → flag reads
-- `Elements/Auras/Defensives.lua` (B2 #138) — single-probe → flag read
 - `Elements/Auras/Debuffs.lua` (B4 #140) — consume classified harmful slice
 - `Elements/Auras/MissingBuffs.lua` (B5 #141) — consistency migration
 - `Elements/Auras/Buffs.lua` (B3 #139) — castBy via `isPlayerCast`
+
+`Elements/Status/StatusText.lua` (B6 #142) is intentionally omitted — see "B6 dropped" in the per-element scope section above.
 
 ### C1 (#143)
 
@@ -661,7 +660,7 @@ No code changes. Report attached to the GitHub issue.
 ## References
 
 - Parent issue: #115
-- Sub-issues: #136, #137, #138, #139, #140, #141, #142, #143
+- Sub-issues: #136, #137, #138, #139, #140, #141, #143 (#142 closed as out-of-scope)
 - Stale dependency to close: #123
 - Prior art in-repo: `Core/AuraCache.lua` (Aura Cache Design spec, 2026-04-10), `Core/AuraState.lua`
 - Source of truth for filter strings: `/tmp/wow-ui-source/Interface/AddOns/Blizzard_FrameXMLUtil/AuraUtil.lua:158-174`


### PR DESCRIPTION
## Summary

- **B2: Defensives migrated to AuraState classified API** (#115, #138) — `Elements/Auras/Defensives.lua` now reads `entry.flags.*` from `auraState:GetHelpfulClassified()` instead of issuing 3 `IsAuraFilteredOutByInstanceID` probes per aura per UNIT_AURA (BIG_DEFENSIVE + EXTERNAL_DEFENSIVE + PLAYER). First consumer of A1's classification infrastructure. Behavior unchanged — same defensives render, same player/other border distinction, same long-duration skip.
- **`isBossAura` secret-boolean guard** — `classify()` crashed in encounters on auras carrying a secret `isBossAura`. Per [Patch 12.0.5 API changes](https://warcraft.wiki.gg/wiki/Patch_12.0.5/API_changes) the other structural booleans (`isHelpful`/`isHarmful`/`isRaid`/`isNameplateOnly`/`isFromPlayerOrPlayerPet`) were de-secret'd, but `isBossAura` remains secret. Wrapped that one field in `F.IsValueNonSecret`; others stay as bare reads. Spec's Tier 1 split into 1a (passthrough) / 1b (guarded passthrough) to record this.
- **No version bump** — remaining B-series migrations (B1 Externals, B4 Dispellable, B5 Buffs/Debuffs, B3 castBy) will ship in a bundled release once they land.

Plan: `docs/superpowers/plans/2026-04-21-b2-defensives-classified.md`
Spec: `docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md` (Tier 1 split into 1a/1b for the guard)

## Test plan

- [x] Follower dungeon — personal defensives render, no crash
- [x] LFR — external defensives route to Externals element (NOT Defensives), player/other border colors correct, end-of-duration transitions clean
- [x] No `AuraState.lua:22` secret-boolean taint in real combat
- [x] `/framed aurastate player` flag breakdowns still correct

## Follow-ups

- B1 #137 (Externals classified migration) — separate plan + PR
- B4 #140 (Dispellable) — separate plan + PR
- B5 #141 (Buffs/Debuffs) — separate plan + PR
- B3 #139 (castBy flag-based) — separate plan + PR
- Bundled release after B-series completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)