### PR TITLE
B5 MissingBuffs + gate TargetedSpells/CastTracker (#141, #148)

### DIFF
--- a/Elements/Auras/MissingBuffs.lua
+++ b/Elements/Auras/MissingBuffs.lua
@@ -103,14 +103,17 @@ local function ensureCached(spellId)
 end
 
 --- Check whether a buff matching targetSpellId exists in the pre-fetched
---- aura list. Avoids any table creation — just iterates the API result
---- and compares spellId/name directly.
---- @param rawAuras table  Result of C_UnitAuras.GetUnitAuras(unit, 'HELPFUL')
+--- aura list. Accepts either AuraState classified entries ({ aura, flags })
+--- or raw auraData objects — the fallback path still feeds raw auras when
+--- AuraState is unavailable. `item.aura or item` keeps both shapes working
+--- without a call-site branch.
+--- @param auras table  Classified entries or raw auraData objects
 --- @param targetSpellId number
 --- @return boolean
-local function auraListHasBuff(rawAuras, targetSpellId)
+local function auraListHasBuff(auras, targetSpellId)
 	local targetName = ensureCached(targetSpellId)
-	for _, auraData in next, rawAuras do
+	for _, item in next, auras do
+		local auraData = item.aura or item
 		local sid = auraData.spellId
 		if(F.IsValueNonSecret(sid) and sid == targetSpellId) then return true end
 		if(targetName) then
@@ -192,7 +195,8 @@ local function Update(self, event, unit, updateInfo)
 			auraState:EnsureInitialized(unit)
 		end
 	end
-	local rawAuras = auraState and auraState:GetHelpful('HELPFUL') or C_UnitAuras.GetUnitAuras(unit, 'HELPFUL')
+	local auras = auraState and auraState:GetHelpfulClassified()
+		or C_UnitAuras.GetUnitAuras(unit, 'HELPFUL')
 
 	for _, spellId in next, BUFF_ORDER do
 		local providingClass = RAID_BUFFS[spellId]
@@ -203,7 +207,7 @@ local function Update(self, event, unit, updateInfo)
 		if(isNpc and providingClass ~= playerClass) then
 			slot.bi:Hide()
 			if(slot.glow:IsActive()) then slot.glow:Stop() end
-		elseif(providingClass and groupClasses[providingClass] and not auraListHasBuff(rawAuras, spellId)) then
+		elseif(providingClass and groupClasses[providingClass] and not auraListHasBuff(auras, spellId)) then
 			-- Missing buff from a class in the group — show and reposition
 			slot.bi.icon:SetTexture(iconCache[spellId])
 			slot.bi:ClearAllPoints()

--- a/Init.lua
+++ b/Init.lua
@@ -38,10 +38,10 @@ eventFrame:SetScript('OnEvent', function(self, event, arg1)
 		-- Start auto-switching (detects content type and activates preset)
 		F.AutoSwitch.Check()
 
-		-- Enable cast tracker for targeted spells
-		if(F.CastTracker) then
-			F.CastTracker:Enable()
-		end
+		-- Cast tracker is gated off alongside TargetedSpells
+		-- (see Units/StyleBuilder.lua TARGETED_SPELLS_ENABLED).
+		-- Re-enable here if the feature is restored.
+		-- if(F.CastTracker) then F.CastTracker:Enable() end
 
 		-- Minimap icon via LibDataBroker + LibDBIcon
 		local LDB = LibStub('LibDataBroker-1.1')

--- a/Units/StyleBuilder.lua
+++ b/Units/StyleBuilder.lua
@@ -380,8 +380,12 @@ function F.StyleBuilder.Apply(self, unit, config, unitType)
 		F.Elements.MissingBuffs.Setup(self, missingBuffsConfig)
 	end
 
+	-- TargetedSpells runtime-gated off — Blizzard 12.0.x secret-tainting
+	-- leaves cast source/target unreliable. Config keys left in place so
+	-- SavedVariables remain stable until a full removal PR lands.
+	local TARGETED_SPELLS_ENABLED = false
 	local targetedSpellsConfig = F.StyleBuilder.GetAuraConfig(unitType, 'targetedSpells')
-	if(targetedSpellsConfig and targetedSpellsConfig.enabled and F.Elements.TargetedSpells) then
+	if(TARGETED_SPELLS_ENABLED and targetedSpellsConfig and targetedSpellsConfig.enabled and F.Elements.TargetedSpells) then
 		F.Elements.TargetedSpells.Setup(self, targetedSpellsConfig)
 	end
 

--- a/docs/superpowers/plans/2026-04-22-b5-missingbuffs-classified.md
+++ b/docs/superpowers/plans/2026-04-22-b5-missingbuffs-classified.md
@@ -1,0 +1,151 @@
+# B5 — MissingBuffs Classified Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch `Elements/Auras/MissingBuffs.lua` from `AuraState:GetHelpful('HELPFUL')` to `AuraState:GetHelpfulClassified()` so every helpful-side B-series element consumes the same slice.
+
+**Architecture:** MissingBuffs is spellID set-membership, not classification filtering — it reads `auraData.spellId` and `auraData.name`, never any flag. The migration peels the `aura` field out of each classified entry inside `auraListHasBuff`. No flag use, no behavior change.
+
+**Tech Stack:** WoW 12.0.x Lua, embedded oUF, Framed AuraState.
+
+**Part of:** #115 UNIT_AURA fan-out rearchitecture, closes #141.
+
+---
+
+## Task 1: Migrate MissingBuffs.lua to classified path
+
+**Files:**
+- Modify: `Elements/Auras/MissingBuffs.lua:111-122` (auraListHasBuff helper)
+- Modify: `Elements/Auras/MissingBuffs.lua:195` (auraState read)
+
+- [ ] **Step 1: Rewrite `auraListHasBuff` to accept classified entries**
+
+The helper currently iterates auraData objects directly. Switch the loop to read `entry.aura`. Keep the name-fallback logic for secret-spellId cases.
+
+Current (lines 111-122):
+
+```lua
+local function auraListHasBuff(rawAuras, targetSpellId)
+	local targetName = ensureCached(targetSpellId)
+	for _, auraData in next, rawAuras do
+		local sid = auraData.spellId
+		if(F.IsValueNonSecret(sid) and sid == targetSpellId) then return true end
+		if(targetName) then
+			local n = auraData.name
+			if(F.IsValueNonSecret(n) and n == targetName) then return true end
+		end
+	end
+	return false
+end
+```
+
+Replace with:
+
+```lua
+-- Scan classified entries for a matching buff. Accepts either
+-- classified entries ({ aura, flags }) or raw aura objects — the
+-- fallback path still feeds raw auras when AuraState is unavailable.
+local function auraListHasBuff(auras, targetSpellId)
+	local targetName = ensureCached(targetSpellId)
+	for _, item in next, auras do
+		local auraData = item.aura or item
+		local sid = auraData.spellId
+		if(F.IsValueNonSecret(sid) and sid == targetSpellId) then return true end
+		if(targetName) then
+			local n = auraData.name
+			if(F.IsValueNonSecret(n) and n == targetName) then return true end
+		end
+	end
+	return false
+end
+```
+
+The `item.aura or item` form keeps the fallback path (which passes raw auras from `C_UnitAuras.GetUnitAuras`) working without branching at the call site.
+
+- [ ] **Step 2: Swap the auraState read**
+
+Current (line 195):
+
+```lua
+local rawAuras = auraState and auraState:GetHelpful('HELPFUL') or C_UnitAuras.GetUnitAuras(unit, 'HELPFUL')
+```
+
+Replace with:
+
+```lua
+local auras = auraState and auraState:GetHelpfulClassified()
+	or C_UnitAuras.GetUnitAuras(unit, 'HELPFUL')
+```
+
+Rename `rawAuras` → `auras` at the call site on line 206:
+
+```lua
+elseif(providingClass and groupClasses[providingClass] and not auraListHasBuff(auras, spellId)) then
+```
+
+- [ ] **Step 3: Verify no other consumers of `rawAuras`**
+
+Run: `grep -n rawAuras Elements/Auras/MissingBuffs.lua`
+
+Expected: no matches (the only reference outside the Update function was in the `auraListHasBuff` signature, which we already updated).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Elements/Auras/MissingBuffs.lua
+git commit -m "refactor(MissingBuffs): migrate to classified aura path (#141)"
+git push
+```
+
+---
+
+## Task 2: LFR smoke test
+
+- [ ] **Step 1: `/reload` in-game**
+
+Verify no errors on load.
+
+- [ ] **Step 2: Verify missing-buff detection**
+
+In a group (party or LFR) where multiple buff-providing classes are present:
+- Missing icons for classes present in group should glow/appear.
+- Apply the buff (e.g. Arcane Intellect) → icon should disappear next UNIT_AURA.
+- Remove the buff → icon should reappear.
+
+- [ ] **Step 3: Verify hidden-state cases**
+
+- Dead/ghost unit → all slots hidden.
+- Pet unit → all slots hidden.
+- NPC follower unit (delve): only own-class buff icon should be visible; other classes hidden (pre-existing NPC-secret-aura behavior).
+
+- [ ] **Step 4: Report back**
+
+User confirms smoke passes before opening PR.
+
+---
+
+## Task 3: Open PR
+
+- [ ] **Step 1: Open working-testing → working PR**
+
+```bash
+gh pr create --base working --head working-testing \
+  --title "B5 — migrate MissingBuffs to AuraState classified API (#141)" \
+  --body "..."
+```
+
+PR body should cover:
+- One-line migration (swap `GetHelpful('HELPFUL')` → `GetHelpfulClassified()`, peel `entry.aura` in helper).
+- No behavior change. Fallback path unchanged.
+- Closes #141.
+- Test plan reflects Task 2 steps.
+
+---
+
+## Self-review checklist
+
+- [x] Every spec step has actual code, not placeholder text.
+- [x] `item.aura or item` form preserves the fallback path (C_UnitAuras raw auras) without call-site branching.
+- [x] No flag reads (MissingBuffs never consumed classification flags — the classified view is used purely for slice consistency).
+- [x] No other call sites reference `rawAuras` or the old helper signature.
+- [x] Task ordering: migration → user-run smoke → PR, matching B1/B2/B3/B4 pattern.


### PR DESCRIPTION
## Summary

Two related changes on `working-testing`:

### B5 — MissingBuffs classified migration (#141)

Migrates `Elements/Auras/MissingBuffs.lua` from `GetHelpful('HELPFUL')` to `GetHelpfulClassified()`, matching the B-series pattern (B1 Externals / B2 Defensives / B3 Buffs / B4 Debuffs).

- `auraListHasBuff()` handles both shapes (classified `entry = { aura, flags }` wrappers and raw auras) via the `item.aura or item` dual-shape dispatch trick.
- Update site falls back to `C_UnitAuras.GetUnitAuras(unit, 'HELPFUL')` when `auraState` is unavailable.
- No behavioral change for real players. Pre-existing NPC-follower-in-combat limitation documented (#157).

### Gate TargetedSpells + CastTracker off (#148)

Blizzard 12.0.x secret-tainting leaves cast source/target unreliable, so both features are disabled at source:

- `Units/StyleBuilder.lua` — `TARGETED_SPELLS_ENABLED = false` gate wraps the `F.Elements.TargetedSpells.Setup` call. Config keys preserved so SavedVariables stay stable until a full removal PR lands.
- `Init.lua` — `F.CastTracker:Enable()` commented out at `PLAYER_LOGIN`.

Chose runtime gates over full removal to keep config/SavedVariables stable and make re-enable trivial if the API situation changes.

### Memory diagnostic findings (#155)

Diagnostic work during this branch identified Framed's aura fan-out as 80–93% of the LFR allocation yoyo (details posted on #155). Disabling CastTracker recovers ~6.6 MB/30s of that. Remaining fix plan (pool classify() wrappers, reduce FullRefresh frequency, avoid varargs pack) tracked on #155.

## Test plan

- [x] B5: LFR real-player raid smoke test passed
- [x] B5: bisect confirmed NPC-follower limitation pre-dates B5 (#157)
- [x] Gate: TargetedSpells element no longer registered on any unit
- [x] Gate: CastTracker OnEvent no longer firing (verified via MemDiag before gate landed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)