### PR TITLE
Promote working-testing → main

### DIFF
--- a/Core/AuraCache.lua
+++ b/Core/AuraCache.lua
@@ -3,8 +3,16 @@ local F = Framed
 
 F.AuraCache = {}
 
--- Generation counter per unit — bumped on each UNIT_AURA event.
+-- Content generation — bumps on any UNIT_AURA for the unit. Used by
+-- GetUnitAuras() to invalidate filter-result caches when aura set changes.
 local generation = {}
+
+-- Identity generation — bumps only when the unit token may now point at
+-- a different entity (reassignment events) or when existing auraInstanceIDs
+-- are invalidated at encounter boundaries. Used by AuraState to decide
+-- whether a FullRefresh is needed vs. a delta apply.
+-- See issue #118: single-gen approach forced FullRefresh on every UNIT_AURA.
+local identityGeneration = {}
 
 -- Cache keyed by 'unit\0filter' — each entry is { gen = number, result = table }.
 -- Tables are reused across generations to avoid allocation.
@@ -13,10 +21,19 @@ local cache = {}
 -- Pre-computed key strings to avoid per-call string concatenation.
 local keyCache = {}
 
--- Bump generation for a single unit token.
+-- Bump content generation for a single unit token.
 local function bump(unit)
 	if(unit) then
 		generation[unit] = (generation[unit] or 0) + 1
+	end
+end
+
+-- Bump identity generation for a single unit token. Callers should pair
+-- this with bump(unit) when the content also changed (most reassignment
+-- events imply a content change too, since auraInstanceIDs are re-keyed).
+local function bumpIdentity(unit)
+	if(unit) then
+		identityGeneration[unit] = (identityGeneration[unit] or 0) + 1
 	end
 end
 
@@ -41,57 +58,86 @@ eventFrame:RegisterEvent('NAME_PLATE_UNIT_REMOVED')
 
 eventFrame:SetScript('OnEvent', function(_, event, arg1)
 	if(event == 'UNIT_AURA') then
+		-- Content-only: auras changed on the same entity. No identity bump —
+		-- AuraState should take its delta path, not FullRefresh.
 		bump(arg1)
 	elseif(event == 'PLAYER_TARGET_CHANGED') then
 		bump('target')
 		bump('targettarget')
+		bumpIdentity('target')
+		bumpIdentity('targettarget')
 	elseif(event == 'PLAYER_FOCUS_CHANGED') then
 		bump('focus')
 		bump('focustarget')
+		bumpIdentity('focus')
+		bumpIdentity('focustarget')
 	elseif(event == 'UNIT_TARGET') then
 		-- arg1 = unit whose target changed; the subunit token (e.g.,
 		-- 'targettarget' when arg1 == 'target') now points somewhere new.
 		if(arg1) then
 			bump(arg1 .. 'target')
+			bumpIdentity(arg1 .. 'target')
 		end
 	elseif(event == 'GROUP_ROSTER_UPDATE') then
 		for i = 1, 4 do
 			bump('party' .. i)
 			bump('partypet' .. i)
+			bumpIdentity('party' .. i)
+			bumpIdentity('partypet' .. i)
 		end
 		for i = 1, 40 do
 			bump('raid' .. i)
 			bump('raidpet' .. i)
+			bumpIdentity('raid' .. i)
+			bumpIdentity('raidpet' .. i)
 		end
 	elseif(event == 'ARENA_OPPONENT_UPDATE') then
 		for i = 1, 5 do
 			bump('arena' .. i)
 			bump('arenapet' .. i)
+			bumpIdentity('arena' .. i)
+			bumpIdentity('arenapet' .. i)
 		end
 	elseif(event == 'INSTANCE_ENCOUNTER_ENGAGE_UNIT') then
 		for i = 1, 8 do
 			bump('boss' .. i)
+			bumpIdentity('boss' .. i)
 		end
 	elseif(event == 'ENCOUNTER_START' or event == 'ENCOUNTER_END') then
 		-- 12.0.5 re-randomizes aura instance IDs on encounter boundaries.
-		-- Bump every tracked unit so the next read refreshes from the
-		-- game's aura list instead of trusting pre-boundary IDs.
+		-- Bump both content and identity on every tracked unit so the next
+		-- read refreshes from the game's aura list instead of trusting
+		-- pre-boundary IDs. GUID doesn't change here, so the identity bump
+		-- is the only signal AuraState has to discard its auraInstanceID
+		-- keyed caches.
 		for unit in next, generation do
 			bump(unit)
+			bumpIdentity(unit)
 		end
 	elseif(event == 'NAME_PLATE_UNIT_ADDED' or event == 'NAME_PLATE_UNIT_REMOVED') then
 		bump(arg1)
+		bumpIdentity(arg1)
 	end
 end)
 
---- Current generation counter for a unit token. Bumped whenever cached
---- data for that token may be stale (UNIT_AURA or token reassignment).
---- Consumers that hold their own cache can compare against this to
---- detect when they need to invalidate.
+--- Current content generation counter for a unit token. Bumped on every
+--- UNIT_AURA for that unit. Consumers caching filter results (e.g.
+--- GetUnitAuras below) compare against this to detect stale results.
 --- @param unit string
 --- @return number
 function F.AuraCache.GetGeneration(unit)
 	return generation[unit] or 0
+end
+
+--- Current identity generation counter for a unit token. Bumped only on
+--- reassignment events (token now points at a different entity) or on
+--- encounter boundaries (auraInstanceID re-randomization). Consumers that
+--- hold auraInstanceID-keyed state compare against this to decide whether
+--- to full-refresh vs. apply a delta. See #118.
+--- @param unit string
+--- @return number
+function F.AuraCache.GetIdentityGeneration(unit)
+	return identityGeneration[unit] or 0
 end
 
 --- Drop-in replacement for C_UnitAuras.GetUnitAuras(unit, filter).

--- a/Core/AuraCache.lua
+++ b/Core/AuraCache.lua
@@ -25,6 +25,8 @@ end
 -- don't fire UNIT_AURA on their own, but the unit token now points at a
 -- different entity — any cached data for that token is stale.
 local eventFrame = CreateFrame('Frame')
+-- Exposed for diagnostics (Core/MemDiag.lua hooks OnEvent here).
+F.AuraCache._eventFrame = eventFrame
 eventFrame:RegisterEvent('UNIT_AURA')
 eventFrame:RegisterEvent('PLAYER_TARGET_CHANGED')
 eventFrame:RegisterEvent('PLAYER_FOCUS_CHANGED')

--- a/Core/AuraCache.lua
+++ b/Core/AuraCache.lua
@@ -45,6 +45,7 @@ local eventFrame = CreateFrame('Frame')
 -- Exposed for diagnostics (Core/MemDiag.lua hooks OnEvent here).
 F.AuraCache._eventFrame = eventFrame
 eventFrame:RegisterEvent('UNIT_AURA')
+eventFrame:RegisterEvent('UNIT_PET')
 eventFrame:RegisterEvent('PLAYER_TARGET_CHANGED')
 eventFrame:RegisterEvent('PLAYER_FOCUS_CHANGED')
 eventFrame:RegisterEvent('UNIT_TARGET')
@@ -61,6 +62,24 @@ eventFrame:SetScript('OnEvent', function(_, event, arg1)
 		-- Content-only: auras changed on the same entity. No identity bump —
 		-- AuraState should take its delta path, not FullRefresh.
 		bump(arg1)
+	elseif(event == 'UNIT_PET') then
+		-- arg1 = owner unit; derive the corresponding pet token. UnitGUID
+		-- returns secret strings for pet tokens in combat, so we can't use
+		-- a GUID snapshot as a fallback — this event is the sole signal
+		-- that a pet token now points at a different entity.
+		local petUnit
+		if(arg1 == 'player') then
+			petUnit = 'pet'
+		elseif(arg1) then
+			local prefix, n = arg1:match('^(%a+)(%d+)$')
+			if(prefix == 'party' or prefix == 'raid' or prefix == 'arena') then
+				petUnit = prefix .. 'pet' .. n
+			end
+		end
+		if(petUnit) then
+			bump(petUnit)
+			bumpIdentity(petUnit)
+		end
 	elseif(event == 'PLAYER_TARGET_CHANGED') then
 		bump('target')
 		bump('targettarget')

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -76,6 +76,22 @@ local function releaseClassified(pool, entry)
 	pool[#pool + 1] = entry
 end
 
+-- Pack GetAuraSlots varargs into `tbl` without allocating a fresh pack table.
+-- Returns the count, which callers MUST use as the iteration bound (not #tbl).
+-- Position 1 holds the continuation token; real slot IDs start at index 2.
+-- The tail loop nils any residual entries from a prior call where the aura
+-- count was higher, keeping `tbl` a proper sequence across reuses.
+local function fillSlots(tbl, ...)
+	local n = select('#', ...)
+	for i = 1, n do
+		tbl[i] = select(i, ...)
+	end
+	for i = n + 1, #tbl do
+		tbl[i] = nil
+	end
+	return n
+end
+
 -- Compound unit tokens (e.g. 'party2target', 'playertarget', 'focustarget')
 -- are rejected by C_UnitAuras.GetAuraSlots. Pinned target-chain slots can
 -- produce these tokens — skip aura queries for them rather than erroring.
@@ -521,6 +537,7 @@ function F.AuraState.Create(owner)
 		_harmfulClassifiedById = {},
 		_harmfulClassifiedView = { dirty = true, list = {} },
 		_classifiedFreeList = {},
+		_slotsScratch = {},
 	}, AuraState)
 	F.AuraState._instances[inst] = true
 	return inst

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -242,7 +242,13 @@ end
 function AuraState:FullRefresh(unit)
 	self._unit = unit
 	self._initialized = true
-	self._gen = F.AuraCache.GetGeneration(unit)
+	self._gen = F.AuraCache.GetIdentityGeneration(unit)
+	-- GUID snapshot as second-line guardrail: catches identity changes
+	-- that bypass the enumerated reassignment events (UNIT_PET, vehicle
+	-- transitions, odd timing). UnitGUID returns nil for unloaded units,
+	-- which is a stable value — first real GUID post-load triggers one
+	-- legitimate FullRefresh. See #118.
+	self._guid = unit and UnitGUID(unit) or nil
 	wipe(self._helpfulById)
 	wipe(self._harmfulById)
 	self:ResetHelpfulMatches()
@@ -275,10 +281,14 @@ function AuraState:FullRefresh(unit)
 end
 
 function AuraState:EnsureInitialized(unit)
-	-- Compare generation from AuraCache, not the token string — the token
-	-- (e.g. 'target') stays identical on retarget even when it now points
-	-- at a different entity. AuraCache bumps generation on reassignment.
-	if(not self._initialized or self._unit ~= unit or self._gen ~= F.AuraCache.GetGeneration(unit)) then
+	-- Identity generation catches enumerated reassignment events and
+	-- encounter-boundary auraInstanceID re-randomization. GUID snapshot
+	-- catches any identity change not covered by an enumerated event.
+	-- Together: belt-and-suspenders against stale auraInstanceID-keyed state.
+	if(not self._initialized
+		or self._unit ~= unit
+		or self._gen  ~= F.AuraCache.GetIdentityGeneration(unit)
+		or self._guid ~= UnitGUID(unit)) then
 		self:FullRefresh(unit)
 	end
 end
@@ -295,7 +305,13 @@ function AuraState:ApplyUpdateInfo(unit, updateInfo)
 		return
 	end
 
-	if(not self._initialized or self._unit ~= unit or self._gen ~= F.AuraCache.GetGeneration(unit)) then
+	-- Identity-stale detection: same as EnsureInitialized. Without this,
+	-- a UNIT_AURA racing an un-dispatched reassignment would apply a delta
+	-- against _helpfulById keyed by auraInstanceIDs from a different entity.
+	if(not self._initialized
+		or self._unit ~= unit
+		or self._gen  ~= F.AuraCache.GetIdentityGeneration(unit)
+		or self._guid ~= UnitGUID(unit)) then
 		self._lastUpdateInfo = updateInfo
 		self._lastUpdateUnit = unit
 		self:FullRefresh(unit)
@@ -524,6 +540,7 @@ function F.AuraState.Create(owner)
 		_unit = nil,
 		_initialized = false,
 		_gen = 0,
+		_guid = nil,
 		_lastUpdateInfo = nil,
 		_lastUpdateUnit = nil,
 		_helpfulById = {},

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -9,7 +9,11 @@ local GetAuraDataByAuraInstanceID = C_UnitAuras and C_UnitAuras.GetAuraDataByAur
 local IsAuraFilteredOutByInstanceID = C_UnitAuras and C_UnitAuras.IsAuraFilteredOutByInstanceID
 
 -- Classify a single aura into a wrapper entry { aura, flags }.
--- Tier 1 flags are structural passthroughs from AuraData (never secret).
+-- Tier 1 flags are structural AuraData booleans. Per Blizzard's 12.0.x
+-- changes, isHelpful / isHarmful / isRaid / isNameplateOnly /
+-- isFromPlayerOrPlayerPet are non-secret. isBossAura remains secret on
+-- encounter auras and must be guarded with F.IsValueNonSecret to avoid
+-- tainted boolean tests.
 -- Tier 2 flags use C_UnitAuras filter probes (secret-safe C API).
 local function classify(unit, aura, isHelpful)
 	local id = aura.auraInstanceID
@@ -19,7 +23,7 @@ local function classify(unit, aura, isHelpful)
 		isHelpful         = aura.isHelpful         or false,
 		isHarmful         = aura.isHarmful         or false,
 		isRaid            = aura.isRaid            or false,
-		isBossAura        = aura.isBossAura        or false,
+		isBossAura        = F.IsValueNonSecret(aura.isBossAura) and aura.isBossAura or false,
 		isFromPlayerOrPet = aura.isFromPlayerOrPlayerPet or false,
 	}
 

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -11,6 +11,12 @@ local F = Framed
 
 F.AuraState = {}
 
+-- Weak-keyed registry so diagnostics (/framed memusage, /framed pools)
+-- can walk live instances without preventing GC of frames whose
+-- AuraState becomes unreferenced (e.g., preset hot-swap drops old
+-- oUF frames).
+F.AuraState._instances = setmetatable({}, { __mode = 'k' })
+
 local GetAuraSlots = C_UnitAuras and C_UnitAuras.GetAuraSlots
 local GetAuraDataBySlot = C_UnitAuras and C_UnitAuras.GetAuraDataBySlot
 local GetAuraDataByAuraInstanceID = C_UnitAuras and C_UnitAuras.GetAuraDataByAuraInstanceID
@@ -462,7 +468,7 @@ end
 F.AuraState._mt = AuraState
 
 function F.AuraState.Create(owner)
-	return setmetatable({
+	local inst = setmetatable({
 		_owner = owner,
 		_unit = nil,
 		_initialized = false,
@@ -479,5 +485,8 @@ function F.AuraState.Create(owner)
 		_harmfulMatches = {},
 		_harmfulClassifiedById = {},
 		_harmfulClassifiedView = { dirty = true, list = {} },
+		_classifiedFreeList = {},
 	}, AuraState)
+	F.AuraState._instances[inst] = true
+	return inst
 end

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -33,6 +33,12 @@ local function classify(unit, aura, isHelpful)
 	flags.isBigDefensive      = isHelpful
 	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HELPFUL|BIG_DEFENSIVE') == false
 	                            or false
+	flags.isRaidDispellable   = not isHelpful
+	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|RAID_PLAYER_DISPELLABLE') == false
+	                            or false
+	flags.isRaidInCombat      = not isHelpful
+	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|RAID_IN_COMBAT') == false
+	                            or false
 
 	return { aura = aura, flags = flags }
 end

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -243,12 +243,6 @@ function AuraState:FullRefresh(unit)
 	self._unit = unit
 	self._initialized = true
 	self._gen = F.AuraCache.GetIdentityGeneration(unit)
-	-- GUID snapshot as second-line guardrail: catches identity changes
-	-- that bypass the enumerated reassignment events (UNIT_PET, vehicle
-	-- transitions, odd timing). UnitGUID returns nil for unloaded units,
-	-- which is a stable value — first real GUID post-load triggers one
-	-- legitimate FullRefresh. See #118.
-	self._guid = unit and UnitGUID(unit) or nil
 	wipe(self._helpfulById)
 	wipe(self._harmfulById)
 	self:ResetHelpfulMatches()
@@ -281,14 +275,14 @@ function AuraState:FullRefresh(unit)
 end
 
 function AuraState:EnsureInitialized(unit)
-	-- Identity generation catches enumerated reassignment events and
-	-- encounter-boundary auraInstanceID re-randomization. GUID snapshot
-	-- catches any identity change not covered by an enumerated event.
-	-- Together: belt-and-suspenders against stale auraInstanceID-keyed state.
+	-- Identity generation catches enumerated reassignment events (incl.
+	-- UNIT_PET) and encounter-boundary auraInstanceID re-randomization.
+	-- Can't use UnitGUID as a belt here — it returns secret-value strings
+	-- on pet/nameplate tokens during tainted execution, which would taint
+	-- the comparison. Per CLAUDE.md, no secret/non-secret path splits.
 	if(not self._initialized
 		or self._unit ~= unit
-		or self._gen  ~= F.AuraCache.GetIdentityGeneration(unit)
-		or self._guid ~= UnitGUID(unit)) then
+		or self._gen  ~= F.AuraCache.GetIdentityGeneration(unit)) then
 		self:FullRefresh(unit)
 	end
 end
@@ -310,8 +304,7 @@ function AuraState:ApplyUpdateInfo(unit, updateInfo)
 	-- against _helpfulById keyed by auraInstanceIDs from a different entity.
 	if(not self._initialized
 		or self._unit ~= unit
-		or self._gen  ~= F.AuraCache.GetIdentityGeneration(unit)
-		or self._guid ~= UnitGUID(unit)) then
+		or self._gen  ~= F.AuraCache.GetIdentityGeneration(unit)) then
 		self._lastUpdateInfo = updateInfo
 		self._lastUpdateUnit = unit
 		self:FullRefresh(unit)
@@ -540,7 +533,6 @@ function F.AuraState.Create(owner)
 		_unit = nil,
 		_initialized = false,
 		_gen = 0,
-		_guid = nil,
 		_lastUpdateInfo = nil,
 		_lastUpdateUnit = nil,
 		_helpfulById = {},

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -36,9 +36,7 @@ local function classify(unit, aura, isHelpful)
 	flags.isRaidDispellable   = not isHelpful
 	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|RAID_PLAYER_DISPELLABLE') == false
 	                            or false
-	flags.isRaidInCombat      = not isHelpful
-	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|RAID_IN_COMBAT') == false
-	                            or false
+	flags.isRaidInCombat      = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|RAID_IN_COMBAT') == false
 
 	return { aura = aura, flags = flags }
 end

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -1,6 +1,14 @@
 local _, Framed = ...
 local F = Framed
 
+-- Classified entries ({ aura, flags } wrappers) are pooled per-instance.
+-- Consumers must not stash entry or entry.flags across UNIT_AURA — pool
+-- reuse silently refills the wrapper with a different aura, producing
+-- ghost-aura bugs that no guardrail in AuraState can catch.
+-- Audit completed 2026-04-22 (Externals / Defensives / Debuffs / Buffs /
+-- MissingBuffs): all consumers destructure fields inline within their
+-- iteration loops and do not persist entry references.
+
 F.AuraState = {}
 
 local GetAuraSlots = C_UnitAuras and C_UnitAuras.GetAuraSlots

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -450,6 +450,9 @@ function AuraState:GetClassifiedByInstanceID(auraInstanceID)
 	return nil
 end
 
+-- Exposed for diagnostics (e.g. Core/MemDiag.lua monkey-patches methods here).
+F.AuraState._mt = AuraState
+
 function F.AuraState.Create(owner)
 	return setmetatable({
 		_owner = owner,

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -265,9 +265,9 @@ function AuraState:FullRefresh(unit)
 		end
 	end
 
-	local harmfulResults = { GetAuraSlots(unit, 'HARMFUL') }
-	for i = 2, #harmfulResults do
-		local aura = GetAuraDataBySlot(unit, harmfulResults[i])
+	local nHarmful = fillSlots(self._slotsScratch, GetAuraSlots(unit, 'HARMFUL'))
+	for i = 2, nHarmful do
+		local aura = GetAuraDataBySlot(unit, self._slotsScratch[i])
 		if(aura and aura.auraInstanceID) then
 			self._harmfulById[aura.auraInstanceID] = aura
 		end

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -257,9 +257,9 @@ function AuraState:FullRefresh(unit)
 	if(not unit or not GetAuraSlots or not GetAuraDataBySlot) then return end
 	if(isCompoundUnit(unit)) then return end
 
-	local helpfulResults = { GetAuraSlots(unit, 'HELPFUL') }
-	for i = 2, #helpfulResults do
-		local aura = GetAuraDataBySlot(unit, helpfulResults[i])
+	local nHelpful = fillSlots(self._slotsScratch, GetAuraSlots(unit, 'HELPFUL'))
+	for i = 2, nHelpful do
+		local aura = GetAuraDataBySlot(unit, self._slotsScratch[i])
 		if(aura and aura.auraInstanceID) then
 			self._helpfulById[aura.auraInstanceID] = aura
 		end

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -22,24 +22,35 @@ local GetAuraDataBySlot = C_UnitAuras and C_UnitAuras.GetAuraDataBySlot
 local GetAuraDataByAuraInstanceID = C_UnitAuras and C_UnitAuras.GetAuraDataByAuraInstanceID
 local IsAuraFilteredOutByInstanceID = C_UnitAuras and C_UnitAuras.IsAuraFilteredOutByInstanceID
 
--- Classify a single aura into a wrapper entry { aura, flags }.
+-- Acquire a classified entry from the per-instance pool (or allocate
+-- fresh if the pool is empty) and fill its flag fields for `aura`.
+--
 -- Tier 1 flags are structural AuraData booleans. Per Blizzard's 12.0.x
 -- changes, isHelpful / isHarmful / isRaid / isNameplateOnly /
 -- isFromPlayerOrPlayerPet are non-secret. isBossAura remains secret on
 -- encounter auras and must be guarded with F.IsValueNonSecret to avoid
 -- tainted boolean tests.
 -- Tier 2 flags use C_UnitAuras filter probes (secret-safe C API).
-local function classify(unit, aura, isHelpful)
+local function acquireClassified(pool, unit, aura, isHelpful)
 	local id = aura.auraInstanceID
 	local prefix = isHelpful and 'HELPFUL' or 'HARMFUL'
 
-	local flags = {
-		isHelpful         = aura.isHelpful         or false,
-		isHarmful         = aura.isHarmful         or false,
-		isRaid            = aura.isRaid            or false,
-		isBossAura        = F.IsValueNonSecret(aura.isBossAura) and aura.isBossAura or false,
-		isFromPlayerOrPet = aura.isFromPlayerOrPlayerPet or false,
-	}
+	local entry = pool[#pool]
+	if(entry) then
+		pool[#pool] = nil
+		wipe(entry.flags)
+	else
+		entry = { flags = {} }
+	end
+
+	entry.aura = aura
+
+	local flags = entry.flags
+	flags.isHelpful         = aura.isHelpful         or false
+	flags.isHarmful         = aura.isHarmful         or false
+	flags.isRaid            = aura.isRaid            or false
+	flags.isBossAura        = F.IsValueNonSecret(aura.isBossAura) and aura.isBossAura or false
+	flags.isFromPlayerOrPet = aura.isFromPlayerOrPlayerPet or false
 
 	flags.isExternalDefensive = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|EXTERNAL_DEFENSIVE') == false
 	flags.isImportant         = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|IMPORTANT')          == false
@@ -52,7 +63,7 @@ local function classify(unit, aura, isHelpful)
 	                            or false
 	flags.isRaidInCombat      = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|RAID_IN_COMBAT') == false
 
-	return { aura = aura, flags = flags }
+	return entry
 end
 
 -- Compound unit tokens (e.g. 'party2target', 'playertarget', 'focustarget')
@@ -406,7 +417,7 @@ function AuraState:GetHelpfulClassified()
 	for id, aura in next, self._helpfulById do
 		local entry = self._helpfulClassifiedById[id]
 		if(not entry) then
-			entry = classify(self._unit, aura, true)
+			entry = acquireClassified(self._classifiedFreeList, self._unit, aura, true)
 			self._helpfulClassifiedById[id] = entry
 		end
 		view.list[#view.list + 1] = entry
@@ -427,7 +438,7 @@ function AuraState:GetHarmfulClassified()
 	for id, aura in next, self._harmfulById do
 		local entry = self._harmfulClassifiedById[id]
 		if(not entry) then
-			entry = classify(self._unit, aura, false)
+			entry = acquireClassified(self._classifiedFreeList, self._unit, aura, false)
 			self._harmfulClassifiedById[id] = entry
 		end
 		view.list[#view.list + 1] = entry
@@ -444,7 +455,7 @@ function AuraState:GetClassifiedByInstanceID(auraInstanceID)
 
 	local aura = self._helpfulById[auraInstanceID]
 	if(aura) then
-		entry = classify(self._unit, aura, true)
+		entry = acquireClassified(self._classifiedFreeList, self._unit, aura, true)
 		self._helpfulClassifiedById[auraInstanceID] = entry
 		return entry
 	end
@@ -456,7 +467,7 @@ function AuraState:GetClassifiedByInstanceID(auraInstanceID)
 
 	aura = self._harmfulById[auraInstanceID]
 	if(aura) then
-		entry = classify(self._unit, aura, false)
+		entry = acquireClassified(self._classifiedFreeList, self._unit, aura, false)
 		self._harmfulClassifiedById[auraInstanceID] = entry
 		return entry
 	end

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -66,6 +66,16 @@ local function acquireClassified(pool, unit, aura, isHelpful)
 	return entry
 end
 
+-- Return a classified entry to the pool. Nils the aura reference so
+-- the underlying AuraData can be GC'd even while the wrapper sits in
+-- the free list; flags contents are left stale until the next acquire
+-- wipes them (lazy — avoids paying wipe cost on entries that never
+-- get reused before session end).
+local function releaseClassified(pool, entry)
+	entry.aura = nil
+	pool[#pool + 1] = entry
+end
+
 -- Compound unit tokens (e.g. 'party2target', 'playertarget', 'focustarget')
 -- are rejected by C_UnitAuras.GetAuraSlots. Pinned target-chain slots can
 -- produce these tokens — skip aura queries for them rather than erroring.
@@ -134,19 +144,33 @@ function AuraState:MarkHarmfulDirty()
 end
 
 function AuraState:ResetHelpfulClassified()
+	for _, entry in next, self._helpfulClassifiedById do
+		releaseClassified(self._classifiedFreeList, entry)
+	end
 	wipe(self._helpfulClassifiedById)
 end
 
 function AuraState:ResetHarmfulClassified()
+	for _, entry in next, self._harmfulClassifiedById do
+		releaseClassified(self._classifiedFreeList, entry)
+	end
 	wipe(self._harmfulClassifiedById)
 end
 
 function AuraState:InvalidateHelpfulClassified(auraInstanceID)
-	self._helpfulClassifiedById[auraInstanceID] = nil
+	local entry = self._helpfulClassifiedById[auraInstanceID]
+	if(entry) then
+		releaseClassified(self._classifiedFreeList, entry)
+		self._helpfulClassifiedById[auraInstanceID] = nil
+	end
 end
 
 function AuraState:InvalidateHarmfulClassified(auraInstanceID)
-	self._harmfulClassifiedById[auraInstanceID] = nil
+	local entry = self._harmfulClassifiedById[auraInstanceID]
+	if(entry) then
+		releaseClassified(self._classifiedFreeList, entry)
+		self._harmfulClassifiedById[auraInstanceID] = nil
+	end
 end
 
 function AuraState:MarkHelpfulClassifiedDirty()

--- a/Core/MemDiag.lua
+++ b/Core/MemDiag.lua
@@ -1,0 +1,291 @@
+local _, Framed = ...
+local F = Framed
+
+-- Diagnostic tool: measure allocation churn in the aura fan-out hot paths.
+--
+-- Usage: F.MemDiag.Start(seconds)
+-- Stops GC for the window so any `collectgarbage('count')` rise is pure
+-- allocation (nothing gets freed), wraps each hot funnel to accumulate
+-- KB delta + call count, restores originals when the window ends, runs
+-- a full collect, and prints a sorted report.
+--
+-- Not for steady-state use — memory climbs for the duration by design.
+
+F.MemDiag = {
+	_active    = false,
+	_counters  = nil,
+	_originals = nil,
+}
+
+local MAX_SECONDS = 30
+
+local function ensureCounter(key)
+	local c = F.MemDiag._counters[key]
+	if(not c) then
+		c = { calls = 0, kb = 0 }
+		F.MemDiag._counters[key] = c
+	end
+	return c
+end
+
+--- Build a wrapper that records KB-delta + call count for `fn` under `key`.
+local function instrument(key, fn)
+	return function(...)
+		local before = collectgarbage('count')
+		local a, b, c, d, e, f = fn(...)
+		local c1 = ensureCounter(key)
+		c1.calls = c1.calls + 1
+		c1.kb    = c1.kb + (collectgarbage('count') - before)
+		return a, b, c, d, e, f
+	end
+end
+
+local function patchAuraCache()
+	local orig = F.AuraCache.GetUnitAuras
+	F.MemDiag._originals.GetUnitAuras = orig
+	F.AuraCache.GetUnitAuras = instrument('AuraCache.GetUnitAuras', orig)
+end
+
+local function patchAuraStateMethods()
+	local mt = F.AuraState._mt
+	if(not mt) then return end
+
+	local methods = {
+		'FullRefresh',
+		'ApplyUpdateInfo',
+		'GetHelpful',
+		'GetHarmful',
+		'GetHelpfulClassified',
+		'GetHarmfulClassified',
+	}
+
+	F.MemDiag._originals.methods = {}
+	for _, name in next, methods do
+		local orig = mt[name]
+		F.MemDiag._originals.methods[name] = orig
+		mt[name] = instrument('AuraState:' .. name, orig)
+	end
+end
+
+--- Hook every oUF unit frame's OnEvent handler so we can attribute the
+--- KB delta of each callback to the WoW event name that triggered it.
+--- oUF uses a single OnEvent per frame that dispatches internally to all
+--- registered element callbacks, so one hook per frame catches every
+--- element update cost under that event.
+local function patchOUFEvents()
+	local oUF = F.oUF
+	if(not oUF or not oUF.objects) then return end
+
+	F.MemDiag._originals.frameEvents = {}
+	for _, frame in next, oUF.objects do
+		local orig = frame:GetScript('OnEvent')
+		if(orig) then
+			F.MemDiag._originals.frameEvents[frame] = orig
+			frame:SetScript('OnEvent', function(self, event, ...)
+				local before = collectgarbage('count')
+				orig(self, event, ...)
+				local c = ensureCounter('event:' .. (event or '?'))
+				c.calls = c.calls + 1
+				c.kb    = c.kb + (collectgarbage('count') - before)
+			end)
+		end
+	end
+end
+
+--- Best-effort frame identifier for OnUpdate attribution.
+--- Prefers the explicit name, falls back to parent name + class hint.
+local function frameLabel(frame, depth)
+	local name = frame:GetName()
+	if(name) then return name end
+	local parent = frame:GetParent()
+	local parentName = parent and parent:GetName() or 'anon'
+	return parentName .. ':anon@d' .. depth
+end
+
+--- Walk a frame tree up to maxDepth levels and apply fn(frame, depth).
+--- Table-packing `{ frame:GetChildren() }` allocates, but this is one-shot
+--- setup — fine outside the measurement window proper (we snapshot before
+--- patching, so the walk's own allocations are not counted).
+local function walkFrames(frame, depth, maxDepth, fn)
+	fn(frame, depth)
+	if(depth >= maxDepth) then return end
+	local kids = { frame:GetChildren() }
+	for _, child in next, kids do
+		walkFrames(child, depth + 1, maxDepth, fn)
+	end
+end
+
+--- Hook OnUpdate scripts on all oUF frames and their descendants up to 3
+--- levels deep. Castbars, health bars, and similar per-frame animators
+--- typically live 1–2 levels below the unit frame.
+local function patchOnUpdates()
+	local oUF = F.oUF
+	if(not oUF or not oUF.objects) then return end
+
+	F.MemDiag._originals.onUpdates = {}
+	for _, root in next, oUF.objects do
+		walkFrames(root, 0, 3, function(frame, depth)
+			local orig = frame:GetScript('OnUpdate')
+			if(orig) then
+				local label = frameLabel(frame, depth)
+				F.MemDiag._originals.onUpdates[frame] = orig
+				frame:SetScript('OnUpdate', function(self, elapsed)
+					local before = collectgarbage('count')
+					orig(self, elapsed)
+					local c = ensureCounter('update:' .. label)
+					c.calls = c.calls + 1
+					c.kb    = c.kb + (collectgarbage('count') - before)
+				end)
+			end
+		end)
+	end
+end
+
+--- Hook known standalone event/update frames that are not in oUF.objects.
+--- Add new entries here as we find them — CastTracker is currently gated
+--- off, AuraCache is exposed for diag via F.AuraCache._eventFrame.
+local function patchStandaloneFrames()
+	F.MemDiag._originals.standalone = {}
+
+	local function hookEvent(frame, label)
+		if(not frame) then return end
+		local orig = frame:GetScript('OnEvent')
+		if(not orig) then return end
+		F.MemDiag._originals.standalone[#F.MemDiag._originals.standalone + 1] = {
+			frame = frame, script = 'OnEvent', orig = orig,
+		}
+		frame:SetScript('OnEvent', function(self, event, ...)
+			local before = collectgarbage('count')
+			orig(self, event, ...)
+			local c = ensureCounter('standalone-event:' .. label .. ':' .. (event or '?'))
+			c.calls = c.calls + 1
+			c.kb    = c.kb + (collectgarbage('count') - before)
+		end)
+	end
+
+	hookEvent(F.AuraCache and F.AuraCache._eventFrame, 'AuraCache')
+end
+
+local function restore()
+	F.AuraCache.GetUnitAuras = F.MemDiag._originals.GetUnitAuras
+
+	local mt = F.AuraState._mt
+	if(mt and F.MemDiag._originals.methods) then
+		for name, orig in next, F.MemDiag._originals.methods do
+			mt[name] = orig
+		end
+	end
+
+	if(F.MemDiag._originals.frameEvents) then
+		for frame, orig in next, F.MemDiag._originals.frameEvents do
+			frame:SetScript('OnEvent', orig)
+		end
+	end
+
+	if(F.MemDiag._originals.onUpdates) then
+		for frame, orig in next, F.MemDiag._originals.onUpdates do
+			frame:SetScript('OnUpdate', orig)
+		end
+	end
+
+	if(F.MemDiag._originals.standalone) then
+		for _, r in next, F.MemDiag._originals.standalone do
+			r.frame:SetScript(r.script, r.orig)
+		end
+	end
+end
+
+local function printReport(durationSec, totalStartKB, totalStopKB)
+	local totalDelta = totalStopKB - totalStartKB
+	print(('|cff00ccff[Framed/memdiag]|r window %.1fs — total allocated %.1f MB (while GC stopped)'):format(
+		durationSec, totalDelta / 1024))
+
+	local rows = {}
+	for key, c in next, F.MemDiag._counters do
+		rows[#rows + 1] = { key = key, calls = c.calls, kb = c.kb }
+	end
+	table.sort(rows, function(a, b) return a.kb > b.kb end)
+
+	print('|cff00ccff[Framed/memdiag]|r per-hook (sorted by bytes allocated):')
+	print('  note: event:* totals nest AuraState:* costs — do not sum both')
+
+	-- Unattributed = totalDelta minus the top-level scopes. event:* wraps
+	-- oUF OnEvent dispatch (nests AuraState); update:* wraps per-frame
+	-- OnUpdate; standalone-event:* wraps non-oUF event frames. These are
+	-- mutually exclusive paths so they sum cleanly. AuraCache.GetUnitAuras
+	-- can be called from any path but is negligible post-migration.
+	local topLevel = 0
+	local byBucket = { event = 0, update = 0, standalone = 0, aura = 0 }
+	for key, c in next, F.MemDiag._counters do
+		if(key:sub(1, 6) == 'event:') then
+			topLevel = topLevel + c.kb
+			byBucket.event = byBucket.event + c.kb
+		elseif(key:sub(1, 7) == 'update:') then
+			topLevel = topLevel + c.kb
+			byBucket.update = byBucket.update + c.kb
+		elseif(key:sub(1, 17) == 'standalone-event:') then
+			topLevel = topLevel + c.kb
+			byBucket.standalone = byBucket.standalone + c.kb
+		elseif(key == 'AuraCache.GetUnitAuras') then
+			topLevel = topLevel + c.kb
+			byBucket.aura = byBucket.aura + c.kb
+		end
+	end
+
+	print(('  --- bucket totals: event=%.1fKB  update=%.1fKB  standalone=%.1fKB  auraCache=%.1fKB ---'):format(
+		byBucket.event, byBucket.update, byBucket.standalone, byBucket.aura))
+
+	for _, r in next, rows do
+		local perCall = r.calls > 0 and (r.kb * 1024 / r.calls) or 0
+		print(('  %-48s  %6d calls  %8.1f KB  (%.0f B/call)'):format(
+			r.key, r.calls, r.kb, perCall))
+	end
+
+	local unattributed = totalDelta - topLevel
+	print(('  %-48s                 %8.1f KB  (%.0f%%)'):format(
+		'[unattributed: non-hooked paths]',
+		unattributed,
+		totalDelta > 0 and (unattributed / totalDelta * 100) or 0))
+end
+
+--- Start a measurement window. Stops GC, instruments aura funnels, and
+--- prints a sorted report after `seconds` elapse (default 10, max 30).
+--- @param seconds? number
+function F.MemDiag.Start(seconds)
+	if(F.MemDiag._active) then
+		print('|cff00ccff[Framed/memdiag]|r already running')
+		return
+	end
+
+	seconds = math.max(1, math.min(seconds or 10, MAX_SECONDS))
+
+	F.MemDiag._active    = true
+	F.MemDiag._counters  = {}
+	F.MemDiag._originals = {}
+
+	collectgarbage('collect')
+	collectgarbage('stop')
+
+	local startKB = collectgarbage('count')
+
+	patchAuraCache()
+	patchAuraStateMethods()
+	patchOUFEvents()
+	patchOnUpdates()
+	patchStandaloneFrames()
+
+	print(('|cff00ccff[Framed/memdiag]|r started — %ds window, GC stopped'):format(seconds))
+
+	C_Timer.After(seconds, function()
+		local stopKB = collectgarbage('count')
+		restore()
+		printReport(seconds, startKB, stopKB)
+
+		collectgarbage('restart')
+		collectgarbage('collect')
+
+		F.MemDiag._active    = false
+		F.MemDiag._counters  = nil
+		F.MemDiag._originals = nil
+	end)
+end

--- a/Core/MemDiag.lua
+++ b/Core/MemDiag.lua
@@ -93,13 +93,25 @@ local function patchOUFEvents()
 end
 
 --- Best-effort frame identifier for OnUpdate attribution.
---- Prefers the explicit name, falls back to parent name + class hint.
+--- If the frame is anonymous, walks up ancestors until a named frame is
+--- found so labels like `NamedParent>...@d3` stay attributable even when
+--- several nesting layers are anonymous. Caps the walk to avoid pathological
+--- infinite ancestry chains.
 local function frameLabel(frame, depth)
 	local name = frame:GetName()
 	if(name) then return name end
-	local parent = frame:GetParent()
-	local parentName = parent and parent:GetName() or 'anon'
-	return parentName .. ':anon@d' .. depth
+	local p = frame
+	local hops = 0
+	while(hops < 8) do
+		p = p:GetParent()
+		if(not p) then break end
+		local pname = p:GetName()
+		if(pname) then
+			return pname .. '>anon@d' .. depth .. (hops > 0 and ('/+' .. hops) or '')
+		end
+		hops = hops + 1
+	end
+	return 'anon@d' .. depth
 end
 
 --- Walk a frame tree up to maxDepth levels and apply fn(frame, depth).
@@ -115,30 +127,45 @@ local function walkFrames(frame, depth, maxDepth, fn)
 	end
 end
 
---- Hook OnUpdate scripts on all oUF frames and their descendants up to 3
---- levels deep. Castbars, health bars, and similar per-frame animators
---- typically live 1–2 levels below the unit frame.
-local function patchOnUpdates()
+--- Hook a single frame's current OnUpdate script. Idempotent — skips
+--- frames we've already wrapped (tracked via `_originals.onUpdates`).
+--- Returns true if a new hook was installed.
+local function hookFrameOnUpdate(frame, label)
+	if(F.MemDiag._originals.onUpdates[frame]) then return false end
+	local orig = frame:GetScript('OnUpdate')
+	if(not orig) then return false end
+	F.MemDiag._originals.onUpdates[frame] = orig
+	frame:SetScript('OnUpdate', function(self, elapsed)
+		local before = collectgarbage('count')
+		orig(self, elapsed)
+		local c = ensureCounter('update:' .. label)
+		c.calls = c.calls + 1
+		c.kb    = c.kb + (collectgarbage('count') - before)
+	end)
+	return true
+end
+
+--- Walk all oUF frames + descendants and hook their OnUpdate scripts.
+--- Safe to call repeatedly — `hookFrameOnUpdate` skips already-wrapped
+--- frames. Used both at Start and periodically during the window to
+--- catch dynamically-attached OnUpdates (Bar depleting, Color/Overlay
+--- animations) that escape the initial walk.
+local function walkAndHookOnUpdates()
 	local oUF = F.oUF
 	if(not oUF or not oUF.objects) then return end
 
-	F.MemDiag._originals.onUpdates = {}
 	for _, root in next, oUF.objects do
-		walkFrames(root, 0, 3, function(frame, depth)
-			local orig = frame:GetScript('OnUpdate')
-			if(orig) then
-				local label = frameLabel(frame, depth)
-				F.MemDiag._originals.onUpdates[frame] = orig
-				frame:SetScript('OnUpdate', function(self, elapsed)
-					local before = collectgarbage('count')
-					orig(self, elapsed)
-					local c = ensureCounter('update:' .. label)
-					c.calls = c.calls + 1
-					c.kb    = c.kb + (collectgarbage('count') - before)
-				end)
-			end
+		walkFrames(root, 0, 5, function(frame, depth)
+			hookFrameOnUpdate(frame, frameLabel(frame, depth))
 		end)
 	end
+end
+
+--- Initial OnUpdate hook pass. See walkAndHookOnUpdates for ongoing
+--- coverage of dynamically-attached scripts.
+local function patchOnUpdates()
+	F.MemDiag._originals.onUpdates = {}
+	walkAndHookOnUpdates()
 end
 
 --- Hook known standalone event/update frames that are not in oUF.objects.
@@ -163,7 +190,26 @@ local function patchStandaloneFrames()
 		end)
 	end
 
+	local function hookUpdate(frame, label)
+		if(not frame) then return end
+		local orig = frame:GetScript('OnUpdate')
+		if(not orig) then return end
+		F.MemDiag._originals.standalone[#F.MemDiag._originals.standalone + 1] = {
+			frame = frame, script = 'OnUpdate', orig = orig,
+		}
+		frame:SetScript('OnUpdate', function(self, elapsed)
+			local before = collectgarbage('count')
+			orig(self, elapsed)
+			local c = ensureCounter('standalone-update:' .. label)
+			c.calls = c.calls + 1
+			c.kb    = c.kb + (collectgarbage('count') - before)
+		end)
+	end
+
 	hookEvent(F.AuraCache and F.AuraCache._eventFrame, 'AuraCache')
+	hookUpdate(F.Indicators and F.Indicators.IconTicker_Frame, 'IconTicker')
+	hookUpdate(F.Status and F.Status.CrowdControl_Ticker, 'CrowdControl')
+	hookUpdate(F.Status and F.Status.LossOfControl_Ticker, 'LossOfControl')
 end
 
 local function restore()
@@ -197,7 +243,7 @@ end
 
 local function printReport(durationSec, totalStartKB, totalStopKB)
 	local totalDelta = totalStopKB - totalStartKB
-	print(('|cff00ccff[Framed/memdiag]|r window %.1fs — total allocated %.1f MB (while GC stopped)'):format(
+	print(('|cff00ccff[Framed/memdiag]|r window %.1fs — Framed allocated %.1f MB (GetAddOnMemoryUsage delta, GC stopped)'):format(
 		durationSec, totalDelta / 1024))
 
 	local rows = {}
@@ -211,11 +257,13 @@ local function printReport(durationSec, totalStartKB, totalStopKB)
 
 	-- Unattributed = totalDelta minus the top-level scopes. event:* wraps
 	-- oUF OnEvent dispatch (nests AuraState); update:* wraps per-frame
-	-- OnUpdate; standalone-event:* wraps non-oUF event frames. These are
-	-- mutually exclusive paths so they sum cleanly. AuraCache.GetUnitAuras
-	-- can be called from any path but is negligible post-migration.
+	-- OnUpdate; standalone-event:* wraps non-oUF event frames;
+	-- standalone-update:* wraps non-oUF ticker frames (IconTicker etc.).
+	-- These are mutually exclusive paths so they sum cleanly.
+	-- AuraCache.GetUnitAuras can be called from any path but is negligible
+	-- post-migration.
 	local topLevel = 0
-	local byBucket = { event = 0, update = 0, standalone = 0, aura = 0 }
+	local byBucket = { event = 0, update = 0, standalone = 0, tickers = 0, aura = 0, memdiag = 0 }
 	for key, c in next, F.MemDiag._counters do
 		if(key:sub(1, 6) == 'event:') then
 			topLevel = topLevel + c.kb
@@ -226,14 +274,20 @@ local function printReport(durationSec, totalStartKB, totalStopKB)
 		elseif(key:sub(1, 17) == 'standalone-event:') then
 			topLevel = topLevel + c.kb
 			byBucket.standalone = byBucket.standalone + c.kb
+		elseif(key:sub(1, 18) == 'standalone-update:') then
+			topLevel = topLevel + c.kb
+			byBucket.tickers = byBucket.tickers + c.kb
 		elseif(key == 'AuraCache.GetUnitAuras') then
 			topLevel = topLevel + c.kb
 			byBucket.aura = byBucket.aura + c.kb
+		elseif(key:sub(1, 8) == 'memdiag:') then
+			topLevel = topLevel + c.kb
+			byBucket.memdiag = byBucket.memdiag + c.kb
 		end
 	end
 
-	print(('  --- bucket totals: event=%.1fKB  update=%.1fKB  standalone=%.1fKB  auraCache=%.1fKB ---'):format(
-		byBucket.event, byBucket.update, byBucket.standalone, byBucket.aura))
+	print(('  --- bucket totals: event=%.1fKB  update=%.1fKB  standalone=%.1fKB  tickers=%.1fKB  auraCache=%.1fKB  memdiag=%.1fKB ---'):format(
+		byBucket.event, byBucket.update, byBucket.standalone, byBucket.tickers, byBucket.aura, byBucket.memdiag))
 
 	for _, r in next, rows do
 		local perCall = r.calls > 0 and (r.kb * 1024 / r.calls) or 0
@@ -246,6 +300,15 @@ local function printReport(durationSec, totalStartKB, totalStopKB)
 		'[unattributed: non-hooked paths]',
 		unattributed,
 		totalDelta > 0 and (unattributed / totalDelta * 100) or 0))
+end
+
+--- Read Framed-specific heap usage in KB. Blizzard attributes Lua
+--- allocations to whichever addon's code was on the call stack at
+--- alloc time, so this is the per-addon measurement ElvUI and similar
+--- tools display. UpdateAddOnMemoryUsage refreshes the snapshot.
+local function framedUsageKB()
+	UpdateAddOnMemoryUsage()
+	return GetAddOnMemoryUsage('Framed')
 end
 
 --- Start a measurement window. Stops GC, instruments aura funnels, and
@@ -266,7 +329,7 @@ function F.MemDiag.Start(seconds)
 	collectgarbage('collect')
 	collectgarbage('stop')
 
-	local startKB = collectgarbage('count')
+	local startKB = framedUsageKB()
 
 	patchAuraCache()
 	patchAuraStateMethods()
@@ -274,10 +337,33 @@ function F.MemDiag.Start(seconds)
 	patchOnUpdates()
 	patchStandaloneFrames()
 
+	-- Periodic re-walk: catches OnUpdate scripts attached mid-window
+	-- (Bar depleting, Color/Overlay/BorderGlow animations) that were not
+	-- present at the initial patchOnUpdates sweep. walkAndHookOnUpdates is
+	-- idempotent — already-hooked frames are skipped. Limitation: if a
+	-- hooked frame's script is later replaced with a new fn, we keep
+	-- tracking the old one (rare; noted for follow-up if needed).
+	--
+	-- The walk itself allocates (table-packed GetChildren results), so we
+	-- attribute that cost to a `memdiag:rewalk` counter — keeping it out of
+	-- the [unattributed] bucket so the report still reflects real leaks.
+	local function scheduleRewalk()
+		C_Timer.After(2, function()
+			if(not F.MemDiag._active) then return end
+			local before = collectgarbage('count')
+			walkAndHookOnUpdates()
+			local c = ensureCounter('memdiag:rewalk')
+			c.calls = c.calls + 1
+			c.kb    = c.kb + (collectgarbage('count') - before)
+			scheduleRewalk()
+		end)
+	end
+	scheduleRewalk()
+
 	print(('|cff00ccff[Framed/memdiag]|r started — %ds window, GC stopped'):format(seconds))
 
 	C_Timer.After(seconds, function()
-		local stopKB = collectgarbage('count')
+		local stopKB = framedUsageKB()
 		restore()
 		printReport(seconds, startKB, stopKB)
 

--- a/Elements/Auras/Buffs.lua
+++ b/Elements/Auras/Buffs.lua
@@ -167,7 +167,6 @@ local function Update(self, event, unit, updateInfo)
 		if(not F.IsValueNonSecret(spellId)) then return end
 
 		local sourceUnit = auraData.sourceUnit
-		local annotated = false
 
 		-- Check spell-specific indicators
 		local indicatorIndices = spellLookup[spellId]
@@ -175,14 +174,6 @@ local function Update(self, event, unit, updateInfo)
 			for _, idx in next, indicatorIndices do
 				local ind = indicators[idx]
 				if(passesCastByFilter(sourceUnit, ind._castBy)) then
-					-- Annotate auraData with renderer-expected field names
-					-- (non-conflicting keys: auraData has no .stacks/.dispelType/.unit)
-					if(not annotated) then
-						auraData.unit      = unit
-						auraData.stacks    = auraData.applications
-						auraData.dispelType = auraData.dispelName
-						annotated = true
-					end
 					if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
 						local list = iconsAurasPool[idx]
 						list[#list + 1] = auraData
@@ -197,12 +188,6 @@ local function Update(self, event, unit, updateInfo)
 		for _, idx in next, hasTrackAll do
 			local ind = indicators[idx]
 			if(passesCastByFilter(sourceUnit, ind._castBy)) then
-				if(not annotated) then
-					auraData.unit      = unit
-					auraData.stacks    = auraData.applications
-					auraData.dispelType = auraData.dispelName
-					annotated = true
-				end
 				if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
 					local list = iconsAurasPool[idx]
 					list[#list + 1] = auraData

--- a/Elements/Auras/Buffs.lua
+++ b/Elements/Auras/Buffs.lua
@@ -63,27 +63,21 @@ local function defaultGrowForAnchor(parentPoint)
 	return 'RIGHT'
 end
 
--- Derive the element's aura-query filter from its indicator set.
---
--- Only a spell list widens the query to HELPFUL. The list itself is an
--- allowlist — so broadening doesn't leak noise onto the indicator, and
--- tracked IDs become visible regardless of Blizzard's RAID_IN_COMBAT
--- curation. Every other configuration (trackAll, any castBy) keeps
--- HELPFUL|RAID_IN_COMBAT so world/cosmetic/consumable buffs stay
--- filtered out by Blizzard before reaching the indicator.
-local function computeBuffFilter(indicatorConfigs)
-	for _, ind in next, indicatorConfigs do
-		if(ind.enabled ~= false and ind.spells and #ind.spells > 0) then
-			return 'HELPFUL'
-		end
-	end
-	return 'HELPFUL|RAID_IN_COMBAT'
-end
-
 -- Reusable containers — wiped each Update to avoid per-call allocation.
 -- Stores auraData references directly (no copy tables).
 local iconsAurasPool = {} -- [idx] = reusable sub-array of auraData refs
 local matchedPool = {}    -- [idx] = auraData ref or false
+
+-- Shared matcher context: populated by Update before iteration so the
+-- module-level matchAura can read per-call state without being redeclared
+-- as a nested closure each frame. Only one Update runs at a time on the
+-- main thread, so a single shared table is safe.
+local matchCtx = {
+	unit        = nil,
+	indicators  = nil,
+	spellLookup = nil,
+	hasTrackAll = nil,
+}
 
 -- Pre-created sort comparator (sortPriority set before each sort call)
 local sortPriority
@@ -119,6 +113,52 @@ local function passesCastByFilter(sourceUnit, castBy)
 	end
 
 	return true
+end
+
+-- ============================================================
+-- Per-aura matcher
+-- ============================================================
+
+--- Shared per-aura matcher used by both the classified and fallback paths.
+--- Reads per-call state from `matchCtx` (populated by Update) so this
+--- function stays at module scope — no nested-closure allocation per event.
+local function matchAura(auraData)
+	local spellId = auraData.spellId
+	if(not F.IsValueNonSecret(spellId)) then return end
+
+	local indicators  = matchCtx.indicators
+	local spellLookup = matchCtx.spellLookup
+	local hasTrackAll = matchCtx.hasTrackAll
+	local sourceUnit  = auraData.sourceUnit
+
+	-- Check spell-specific indicators
+	local indicatorIndices = spellLookup[spellId]
+	if(indicatorIndices) then
+		for _, idx in next, indicatorIndices do
+			local ind = indicators[idx]
+			if(passesCastByFilter(sourceUnit, ind._castBy)) then
+				if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
+					local list = iconsAurasPool[idx]
+					list[#list + 1] = auraData
+				elseif(not matchedPool[idx]) then
+					matchedPool[idx] = auraData
+				end
+			end
+		end
+	end
+
+	-- Check track-all indicators (empty spells list)
+	for _, idx in next, hasTrackAll do
+		local ind = indicators[idx]
+		if(passesCastByFilter(sourceUnit, ind._castBy)) then
+			if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
+				local list = iconsAurasPool[idx]
+				list[#list + 1] = auraData
+			elseif(not matchedPool[idx]) then
+				matchedPool[idx] = auraData
+			end
+		end
+	end
 end
 
 -- ============================================================
@@ -160,56 +200,22 @@ local function Update(self, event, unit, updateInfo)
 
 	local filter = element._buffFilter
 
-	-- Per-aura matcher shared between classified and fallback paths.
-	-- Captures unit / indicators / spellLookup / hasTrackAll via closure.
-	local function matchAura(auraData)
-		local spellId = auraData.spellId
-		if(not F.IsValueNonSecret(spellId)) then return end
-
-		local sourceUnit = auraData.sourceUnit
-
-		-- Check spell-specific indicators
-		local indicatorIndices = spellLookup[spellId]
-		if(indicatorIndices) then
-			for _, idx in next, indicatorIndices do
-				local ind = indicators[idx]
-				if(passesCastByFilter(sourceUnit, ind._castBy)) then
-					if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
-						local list = iconsAurasPool[idx]
-						list[#list + 1] = auraData
-					elseif(not matchedPool[idx]) then
-						matchedPool[idx] = auraData
-					end
-				end
-			end
-		end
-
-		-- Check track-all indicators (empty spells list)
-		for _, idx in next, hasTrackAll do
-			local ind = indicators[idx]
-			if(passesCastByFilter(sourceUnit, ind._castBy)) then
-				if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
-					local list = iconsAurasPool[idx]
-					list[#list + 1] = auraData
-				elseif(not matchedPool[idx]) then
-					matchedPool[idx] = auraData
-				end
-			end
-		end
-	end
+	-- Publish per-call state into the shared matcher context before
+	-- iterating. matchAura lives at module scope and reads from matchCtx.
+	matchCtx.unit        = unit
+	matchCtx.indicators  = indicators
+	matchCtx.spellLookup = spellLookup
+	matchCtx.hasTrackAll = hasTrackAll
 
 	local classified = auraState and auraState:GetHelpfulClassified()
 
 	if(classified) then
-		-- Classified path returns ALL helpful auras. When computeBuffFilter
-		-- resolved to HELPFUL|RAID_IN_COMBAT (no spell list among indicators),
-		-- gate each entry on flags.isRaidInCombat client-side so cosmetic /
-		-- consumable / world buffs stay filtered out — matching what the
-		-- server-side filter would have done.
-		local narrowFilter = filter == 'HELPFUL|RAID_IN_COMBAT'
-
+		-- Classified path returns ALL helpful auras. Gate each entry on
+		-- flags.isRaidInCombat client-side so cosmetic / consumable / world
+		-- buffs stay filtered out — matching what HELPFUL|RAID_IN_COMBAT
+		-- would have done at the server-side filter level.
 		for _, entry in next, classified do
-			if(not narrowFilter or entry.flags.isRaidInCombat) then
+			if(entry.flags.isRaidInCombat) then
 				matchAura(entry.aura)
 			end
 		end
@@ -562,7 +568,7 @@ local function Rebuild(element, config)
 	element._indicators           = {}
 	element._spellLookup          = {}
 	element._hasTrackAll          = {}
-	element._buffFilter           = computeBuffFilter(config.indicators)
+	element._buffFilter           = 'HELPFUL|RAID_IN_COMBAT'
 
 	local indicators = config.indicators
 	for name, indConfig in next, indicators do
@@ -707,7 +713,7 @@ function F.Elements.Buffs.Setup(self, config)
 		_indicators           = indicators,
 		_spellLookup          = spellLookup,
 		_hasTrackAll          = hasTrackAll,
-		_buffFilter           = computeBuffFilter(config.indicators),
+		_buffFilter           = 'HELPFUL|RAID_IN_COMBAT',
 	}
 
 	container.Rebuild = Rebuild

--- a/Elements/Auras/Buffs.lua
+++ b/Elements/Auras/Buffs.lua
@@ -250,7 +250,7 @@ local function Update(self, event, unit, updateInfo)
 					sortPriority = ind._spellPriority
 					table.sort(list, prioritySort)
 				end
-				renderer:SetIcons(list)
+				renderer:SetIcons(unit, list)
 				renderer:Show()
 			else
 				renderer:Clear()

--- a/Elements/Auras/Buffs.lua
+++ b/Elements/Auras/Buffs.lua
@@ -261,14 +261,13 @@ local function Update(self, event, unit, updateInfo)
 			local aura = matchedPool[idx]
 			if(aura) then
 				renderer:SetSpell(
-					aura.unit,
+					unit,
 					aura.auraInstanceID,
 					aura.spellId,
 					aura.icon,
 					aura.duration,
 					aura.expirationTime,
-					aura.stacks,
-					aura.dispelType
+					aura.applications
 				)
 			else
 				renderer:Clear()

--- a/Elements/Auras/Buffs.lua
+++ b/Elements/Auras/Buffs.lua
@@ -291,7 +291,7 @@ local function Update(self, event, unit, updateInfo)
 				else
 					renderer:SetValue(1, 1)
 				end
-				if(aura.stacks) then renderer:SetStacks(aura.stacks) end
+				if(aura.applications) then renderer:SetStacks(aura.applications) end
 				-- Glow
 				if(ind._glowType and ind._glowType ~= 'None') then
 					renderer:StartGlow(ind._glowColor, ind._glowType, ind._glowConfig)
@@ -354,7 +354,7 @@ local function Update(self, event, unit, updateInfo)
 				else
 					renderer:SetValue(1, 1)
 				end
-				if(aura.stacks) then renderer:SetStacks(aura.stacks) end
+				if(aura.applications) then renderer:SetStacks(aura.applications) end
 			else
 				renderer:Clear()
 			end

--- a/Elements/Auras/Buffs.lua
+++ b/Elements/Auras/Buffs.lua
@@ -157,42 +157,26 @@ local function Update(self, event, unit, updateInfo)
 			auraState:EnsureInitialized(unit)
 		end
 	end
+
 	local filter = element._buffFilter
-	local auras = auraState and auraState:GetHelpful(filter) or F.AuraCache.GetUnitAuras(unit, filter)
-	for _, auraData in next, auras do
+
+	-- Per-aura matcher shared between classified and fallback paths.
+	-- Captures unit / indicators / spellLookup / hasTrackAll via closure.
+	local function matchAura(auraData)
 		local spellId = auraData.spellId
-		if(F.IsValueNonSecret(spellId)) then
-			local sourceUnit = auraData.sourceUnit
-			local annotated = false
+		if(not F.IsValueNonSecret(spellId)) then return end
 
-			-- Check spell-specific indicators
-			local indicatorIndices = spellLookup[spellId]
-			if(indicatorIndices) then
-				for _, idx in next, indicatorIndices do
-					local ind = indicators[idx]
-					if(passesCastByFilter(sourceUnit, ind._castBy)) then
-						-- Annotate auraData with renderer-expected field names
-						-- (non-conflicting keys: auraData has no .stacks/.dispelType/.unit)
-						if(not annotated) then
-							auraData.unit      = unit
-							auraData.stacks    = auraData.applications
-							auraData.dispelType = auraData.dispelName
-							annotated = true
-						end
-						if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
-							local list = iconsAurasPool[idx]
-							list[#list + 1] = auraData
-						elseif(not matchedPool[idx]) then
-							matchedPool[idx] = auraData
-						end
-					end
-				end
-			end
+		local sourceUnit = auraData.sourceUnit
+		local annotated = false
 
-			-- Check track-all indicators (empty spells list)
-			for _, idx in next, hasTrackAll do
+		-- Check spell-specific indicators
+		local indicatorIndices = spellLookup[spellId]
+		if(indicatorIndices) then
+			for _, idx in next, indicatorIndices do
 				local ind = indicators[idx]
 				if(passesCastByFilter(sourceUnit, ind._castBy)) then
+					-- Annotate auraData with renderer-expected field names
+					-- (non-conflicting keys: auraData has no .stacks/.dispelType/.unit)
 					if(not annotated) then
 						auraData.unit      = unit
 						auraData.stacks    = auraData.applications
@@ -207,6 +191,49 @@ local function Update(self, event, unit, updateInfo)
 					end
 				end
 			end
+		end
+
+		-- Check track-all indicators (empty spells list)
+		for _, idx in next, hasTrackAll do
+			local ind = indicators[idx]
+			if(passesCastByFilter(sourceUnit, ind._castBy)) then
+				if(not annotated) then
+					auraData.unit      = unit
+					auraData.stacks    = auraData.applications
+					auraData.dispelType = auraData.dispelName
+					annotated = true
+				end
+				if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
+					local list = iconsAurasPool[idx]
+					list[#list + 1] = auraData
+				elseif(not matchedPool[idx]) then
+					matchedPool[idx] = auraData
+				end
+			end
+		end
+	end
+
+	local classified = auraState and auraState:GetHelpfulClassified()
+
+	if(classified) then
+		-- Classified path returns ALL helpful auras. When computeBuffFilter
+		-- resolved to HELPFUL|RAID_IN_COMBAT (no spell list among indicators),
+		-- gate each entry on flags.isRaidInCombat client-side so cosmetic /
+		-- consumable / world buffs stay filtered out — matching what the
+		-- server-side filter would have done.
+		local narrowFilter = filter == 'HELPFUL|RAID_IN_COMBAT'
+
+		for _, entry in next, classified do
+			if(not narrowFilter or entry.flags.isRaidInCombat) then
+				matchAura(entry.aura)
+			end
+		end
+	else
+		-- Vestigial no-AuraState fallback. Every aura-tracking frame creates
+		-- AuraState via the idempotent Setup guard — preserved to match the
+		-- element-level pattern used across Auras/.
+		for _, auraData in next, F.AuraCache.GetUnitAuras(unit, filter) do
+			matchAura(auraData)
 		end
 	end
 

--- a/Elements/Auras/Debuffs.lua
+++ b/Elements/Auras/Debuffs.lua
@@ -82,6 +82,7 @@ end
 local function updateIndicator(self, unit, ind)
 	local cfg = ind._config
 	local maxDisplayed = cfg.maxDisplayed
+	local pool = ind._pool
 
 	-- Backward compat: map old boolean to new filterMode
 	local filterMode = cfg.filterMode
@@ -93,48 +94,95 @@ local function updateIndicator(self, unit, ind)
 	if(filterMode == 'encounter') then
 		if(not C_InstanceEncounter or not C_InstanceEncounter.IsEncounterInProgress
 			or not C_InstanceEncounter.IsEncounterInProgress()) then
-			for idx = 1, #ind._pool do
-				ind._pool[idx]:Clear()
+			for idx = 1, #pool do
+				pool[idx]:Clear()
 			end
 			return
 		end
 	end
 
-	local filter = FILTER_MAP[filterMode] or 'HARMFUL'
-	local auraState = self.FramedAuraState
-	local rawAuras = auraState and auraState:GetHarmful(filter) or F.AuraCache.GetUnitAuras(unit, filter)
-	local pool = ind._pool
+	local auraState  = self.FramedAuraState
+	local classified = auraState and auraState:GetHarmfulClassified()
 
-	-- Single-pass: filter and display directly from auraData.
-	-- auraInstanceID is NeverSecret; BorderIcon.SetAura uses C-level APIs
-	-- for secret fields (icon, duration, etc.).
 	local displayed = 0
 	local runOffset = 0
-	for _, auraData in next, rawAuras do
-		if(displayed >= maxDisplayed) then break end
 
-		local dur = auraData.duration
-		local skip = F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)
-
-		if(not skip) then
-			displayed = displayed + 1
-			runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, auraData.dispelName)
+	if(classified) then
+		-- Dispatch filter mode to a single flag key (nil = match all).
+		-- encounter mode uses the same flag as raid — the IsEncounterInProgress
+		-- gate above already short-circuits the no-encounter case.
+		local flagKey
+		if(filterMode == 'raid' or filterMode == 'encounter') then flagKey = 'isRaid'
+		elseif(filterMode == 'important')   then flagKey = 'isImportant'
+		elseif(filterMode == 'dispellable') then flagKey = 'isRaidDispellable'
+		elseif(filterMode == 'raidCombat')  then flagKey = 'isRaidInCombat'
 		end
-	end
 
-	-- When filterMode is 'dispellable', also include Physical/bleed debuffs
-	-- from a broader HARMFUL|RAID query (RAID_PLAYER_DISPELLABLE excludes them).
-	-- Supplementary results appear after the server-sorted dispellable set.
-	if(filterMode == 'dispellable' and displayed < maxDisplayed) then
-		local raidAuras = auraState and auraState:GetHarmful('HARMFUL|RAID') or F.AuraCache.GetUnitAuras(unit, 'HARMFUL|RAID')
-		for _, auraData in next, raidAuras do
+		for _, entry in next, classified do
 			if(displayed >= maxDisplayed) then break end
 
-			local dn = auraData.dispelName
-			local isPhysical = F.IsValueNonSecret(dn) and (not dn or dn == '' or dn == 'Physical')
-			if(isPhysical) then
+			local flags = entry.flags
+			if(not flagKey or flags[flagKey]) then
+				local auraData = entry.aura
+				local dur = auraData.duration
+				local skip = F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)
+				if(not skip) then
+					displayed = displayed + 1
+					runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, auraData.dispelName)
+				end
+			end
+		end
+
+		-- Dispellable supplementary pass: RAID_PLAYER_DISPELLABLE excludes
+		-- Physical/bleeds, so iterate raid-flagged entries and include any
+		-- whose dispelName is nil/empty/Physical. Pass nil dispelType — these
+		-- aren't dispellable, no overlay color.
+		if(filterMode == 'dispellable' and displayed < maxDisplayed) then
+			for _, entry in next, classified do
+				if(displayed >= maxDisplayed) then break end
+
+				local flags = entry.flags
+				if(flags.isRaid) then
+					local auraData = entry.aura
+					local dn = auraData.dispelName
+					local isPhysical = F.IsValueNonSecret(dn) and (not dn or dn == '' or dn == 'Physical')
+					if(isPhysical) then
+						displayed = displayed + 1
+						runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, nil)
+					end
+				end
+			end
+		end
+	else
+		-- Vestigial no-AuraState fallback. Every aura-tracking frame creates
+		-- AuraState via the idempotent Setup guard — preserved to match the
+		-- element-level pattern used across Auras/.
+		local filter = FILTER_MAP[filterMode] or 'HARMFUL'
+		local rawAuras = F.AuraCache.GetUnitAuras(unit, filter)
+
+		for _, auraData in next, rawAuras do
+			if(displayed >= maxDisplayed) then break end
+
+			local dur = auraData.duration
+			local skip = F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)
+
+			if(not skip) then
 				displayed = displayed + 1
-				runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, nil)
+				runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, auraData.dispelName)
+			end
+		end
+
+		if(filterMode == 'dispellable' and displayed < maxDisplayed) then
+			local raidAuras = F.AuraCache.GetUnitAuras(unit, 'HARMFUL|RAID')
+			for _, auraData in next, raidAuras do
+				if(displayed >= maxDisplayed) then break end
+
+				local dn = auraData.dispelName
+				local isPhysical = F.IsValueNonSecret(dn) and (not dn or dn == '' or dn == 'Physical')
+				if(isPhysical) then
+					displayed = displayed + 1
+					runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, nil)
+				end
 			end
 		end
 	end

--- a/Elements/Auras/Defensives.lua
+++ b/Elements/Auras/Defensives.lua
@@ -6,6 +6,57 @@ F.Elements = F.Elements or {}
 F.Elements.Defensives = {}
 
 -- ============================================================
+-- renderEntry — acquire / position / paint a single BorderIcon slot
+-- ============================================================
+
+local function renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+	anchorPoint, anchorX, anchorY, playerColor, otherColor,
+	unit, id, auraData, isPlayerCast)
+
+	if(not pool[displayed]) then
+		pool[displayed] = F.Indicators.BorderIcon.Create(self, iconSize, {
+			showCooldown = true,
+			showStacks   = cfg.showStacks ~= false,
+			showDuration = cfg.showDuration ~= false,
+			frameLevel   = cfg.frameLevel,
+			stackFont    = cfg.stackFont,
+			durationFont = cfg.durationFont,
+		})
+	end
+
+	local bi = pool[displayed]
+	bi:ClearAllPoints()
+	bi:SetSize(iconSize)
+
+	local offset = (displayed - 1) * (iconSize + 2)
+	if(orientation == 'RIGHT') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX + offset, anchorY)
+	elseif(orientation == 'LEFT') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX - offset, anchorY)
+	elseif(orientation == 'DOWN') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY - offset)
+	elseif(orientation == 'UP') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY + offset)
+	end
+
+	local borderColor = isPlayerCast and playerColor or otherColor
+	if(bi.SetBorderColor) then
+		bi:SetBorderColor(borderColor[1], borderColor[2], borderColor[3])
+	end
+
+	bi:SetAura(
+		unit, id,
+		auraData.spellId,
+		auraData.icon,
+		auraData.duration,
+		auraData.expirationTime,
+		auraData.applications,
+		nil
+	)
+	bi:Show()
+end
+
+-- ============================================================
 -- Update — single-pass filter + display (zero intermediate tables)
 -- ============================================================
 
@@ -28,9 +79,6 @@ local function Update(self, event, unit, updateInfo)
 	local anchorX        = anchor[4]
 	local anchorY        = anchor[5]
 
-	-- BIG_DEFENSIVE is a classification filter, not a query filter —
-	-- GetUnitAuras does not support it. Fetch all helpful auras, then
-	-- classify each one via IsAuraFilteredOutByInstanceID.
 	local auraState = self.FramedAuraState
 	if(auraState) then
 		if(event == 'UNIT_AURA') then
@@ -39,85 +87,80 @@ local function Update(self, event, unit, updateInfo)
 			auraState:EnsureInitialized(unit)
 		end
 	end
-	local rawAuras = auraState and auraState:GetHelpful('HELPFUL') or F.AuraCache.GetUnitAuras(unit, 'HELPFUL')
+
+	local classified = auraState and auraState:GetHelpfulClassified()
+	local rawAuras   = (not classified) and F.AuraCache.GetUnitAuras(unit, 'HELPFUL') or nil
 
 	local displayed = 0
-	for _, auraData in next, rawAuras do
-		if(displayed >= maxDisplayed) then break end
 
-		local id = auraData.auraInstanceID -- NeverSecret
+	if(classified) then
+		for _, entry in next, classified do
+			if(displayed >= maxDisplayed) then break end
 
-		-- Step 1: BIG_DEFENSIVE (primary classification)
-		-- Exclude EXTERNAL_DEFENSIVE — those belong in the Externals element.
-		local show = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
-			unit, id, 'HELPFUL|BIG_DEFENSIVE')
-		if(show) then
-			local isExtDef = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
-				unit, id, 'HELPFUL|EXTERNAL_DEFENSIVE')
-			if(isExtDef) then show = false end
-		end
+			local auraData = entry.aura
+			local flags    = entry.flags
+			local id       = auraData.auraInstanceID
 
-		-- Skip long-duration buffs (flasks, food, racials) that aren't
-		-- real defensives. duration == 0 means permanent.
-		if(show) then
-			local dur = auraData.duration
-			if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
-				show = false
+			-- Primary classification: BIG_DEFENSIVE, excluding EXTERNAL_DEFENSIVE
+			-- (those belong in the Externals element).
+			local show = flags.isBigDefensive and not flags.isExternalDefensive
+
+			-- Skip long-duration buffs (flasks, food, racials) that aren't real
+			-- defensives. duration == 0 means permanent.
+			if(show) then
+				local dur = auraData.duration
+				if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
+					show = false
+				end
+			end
+
+			if(show) then
+				local isPlayerCast = flags.isPlayerCast
+
+				if(not ((visibilityMode == 'player' and not isPlayerCast)
+					or (visibilityMode == 'others' and isPlayerCast))) then
+					displayed = displayed + 1
+					renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+						anchorPoint, anchorX, anchorY, playerColor, otherColor,
+						unit, id, auraData, isPlayerCast)
+				end
 			end
 		end
+	else
+		-- Fallback: no AuraState on this frame. Vestigial in practice — every
+		-- aura-tracking frame creates AuraState via the idempotent Setup guard —
+		-- preserved to match the element-level pattern used across Auras/.
+		for _, auraData in next, rawAuras do
+			if(displayed >= maxDisplayed) then break end
 
-		if(show) then
-			-- Determine if player-cast via |PLAYER filter (avoids secret sourceUnit)
-			local isPlayerCast = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
-				unit, id, 'HELPFUL|PLAYER')
+			local id = auraData.auraInstanceID
 
-			-- Apply visibility mode filter
-			if(not ((visibilityMode == 'player' and not isPlayerCast)
-				or (visibilityMode == 'others' and isPlayerCast))) then
-				-- Display directly — no intermediate table
-				displayed = displayed + 1
+			local show = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+				unit, id, 'HELPFUL|BIG_DEFENSIVE')
+			if(show) then
+				local isExtDef = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+					unit, id, 'HELPFUL|EXTERNAL_DEFENSIVE')
+				if(isExtDef) then show = false end
+			end
 
-				if(not pool[displayed]) then
-					pool[displayed] = F.Indicators.BorderIcon.Create(self, iconSize, {
-						showCooldown = true,
-						showStacks   = cfg.showStacks ~= false,
-						showDuration = cfg.showDuration ~= false,
-						frameLevel   = cfg.frameLevel,
-						stackFont    = cfg.stackFont,
-						durationFont = cfg.durationFont,
-					})
+			if(show) then
+				local dur = auraData.duration
+				if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
+					show = false
 				end
+			end
 
-				local bi = pool[displayed]
-				bi:ClearAllPoints()
-				bi:SetSize(iconSize)
+			if(show) then
+				local isPlayerCast = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+					unit, id, 'HELPFUL|PLAYER')
 
-				local offset = (displayed - 1) * (iconSize + 2)
-				if(orientation == 'RIGHT') then
-					bi:SetPoint(anchorPoint, self, anchorPoint, anchorX + offset, anchorY)
-				elseif(orientation == 'LEFT') then
-					bi:SetPoint(anchorPoint, self, anchorPoint, anchorX - offset, anchorY)
-				elseif(orientation == 'DOWN') then
-					bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY - offset)
-				elseif(orientation == 'UP') then
-					bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY + offset)
+				if(not ((visibilityMode == 'player' and not isPlayerCast)
+					or (visibilityMode == 'others' and isPlayerCast))) then
+					displayed = displayed + 1
+					renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+						anchorPoint, anchorX, anchorY, playerColor, otherColor,
+						unit, id, auraData, isPlayerCast)
 				end
-
-				local borderColor = isPlayerCast and playerColor or otherColor
-				if(bi.SetBorderColor) then
-					bi:SetBorderColor(borderColor[1], borderColor[2], borderColor[3])
-				end
-
-				bi:SetAura(
-					unit, id,
-					auraData.spellId,
-					auraData.icon,
-					auraData.duration,
-					auraData.expirationTime,
-					auraData.applications,
-					nil
-				)
-				bi:Show()
 			end
 		end
 	end

--- a/Elements/Auras/Externals.lua
+++ b/Elements/Auras/Externals.lua
@@ -6,6 +6,57 @@ F.Elements = F.Elements or {}
 F.Elements.Externals = {}
 
 -- ============================================================
+-- renderEntry — acquire / position / paint a single BorderIcon slot
+-- ============================================================
+
+local function renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+	anchorPoint, anchorX, anchorY, playerColor, otherColor,
+	unit, id, auraData, isPlayerCast)
+
+	if(not pool[displayed]) then
+		pool[displayed] = F.Indicators.BorderIcon.Create(self, iconSize, {
+			showCooldown = true,
+			showStacks   = cfg.showStacks ~= false,
+			showDuration = cfg.showDuration ~= false,
+			frameLevel   = cfg.frameLevel,
+			stackFont    = cfg.stackFont,
+			durationFont = cfg.durationFont,
+		})
+	end
+
+	local bi = pool[displayed]
+	bi:ClearAllPoints()
+	bi:SetSize(iconSize)
+
+	local offset = (displayed - 1) * (iconSize + 2)
+	if(orientation == 'RIGHT') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX + offset, anchorY)
+	elseif(orientation == 'LEFT') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX - offset, anchorY)
+	elseif(orientation == 'DOWN') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY - offset)
+	elseif(orientation == 'UP') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY + offset)
+	end
+
+	local borderColor = isPlayerCast and playerColor or otherColor
+	if(bi.SetBorderColor) then
+		bi:SetBorderColor(borderColor[1], borderColor[2], borderColor[3])
+	end
+
+	bi:SetAura(
+		unit, id,
+		auraData.spellId,
+		auraData.icon,
+		auraData.duration,
+		auraData.expirationTime,
+		auraData.applications,
+		nil
+	)
+	bi:Show()
+end
+
+-- ============================================================
 -- Update — single-pass filter + display (zero intermediate tables)
 -- ============================================================
 
@@ -28,9 +79,6 @@ local function Update(self, event, unit, updateInfo)
 	local anchorX        = anchor[4]
 	local anchorY        = anchor[5]
 
-	-- EXTERNAL_DEFENSIVE is a classification filter, not a query filter —
-	-- GetUnitAuras does not support it. Fetch all helpful auras, then
-	-- classify each one via IsAuraFilteredOutByInstanceID.
 	local auraState = self.FramedAuraState
 	if(auraState) then
 		if(event == 'UNIT_AURA') then
@@ -39,116 +87,122 @@ local function Update(self, event, unit, updateInfo)
 			auraState:EnsureInitialized(unit)
 		end
 	end
-	local rawAuras = auraState and auraState:GetHelpful('HELPFUL') or F.AuraCache.GetUnitAuras(unit, 'HELPFUL')
+
+	local classified = auraState and auraState:GetHelpfulClassified()
+	local rawAuras   = (not classified) and F.AuraCache.GetUnitAuras(unit, 'HELPFUL') or nil
 
 	local displayed = 0
-	for _, auraData in next, rawAuras do
-		if(displayed >= maxDisplayed) then break end
 
-		local id = auraData.auraInstanceID -- NeverSecret
+	if(classified) then
+		for _, entry in next, classified do
+			if(displayed >= maxDisplayed) then break end
 
-		-- Step 1: EXTERNAL_DEFENSIVE (primary classification)
-		local show = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
-			unit, id, 'HELPFUL|EXTERNAL_DEFENSIVE')
+			local auraData = entry.aura
+			local flags    = entry.flags
+			local id       = auraData.auraInstanceID
 
-		-- Step 2: IMPORTANT fallback — catch spells that aren't classified
-		-- as EXTERNAL_DEFENSIVE. Exclude BIG_DEFENSIVE to avoid duplicating
-		-- spells that already appear in the Defensives element.
-		-- NOTE: IMPORTANT may be removed in 12.0.5 per Blizzard feedback.
-		if(not show) then
-			local isImportant = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
-				unit, id, 'HELPFUL|IMPORTANT')
-			if(isImportant) then
-				local isBigDef = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
-					unit, id, 'HELPFUL|BIG_DEFENSIVE')
-				show = not isBigDef
+			-- Step 1: EXTERNAL_DEFENSIVE (primary)
+			local show = flags.isExternalDefensive
+
+			-- Step 2: IMPORTANT fallback — exclude BIG_DEFENSIVE to avoid
+			-- duplicating spells that already appear in the Defensives element.
+			-- NOTE: IMPORTANT may be removed in 12.0.5 per Blizzard feedback.
+			if(not show and flags.isImportant and not flags.isBigDefensive) then
+				show = true
+			end
+
+			-- Step 3: RAID fallback — only for secret auras (combat) where
+			-- spell-level classification isn't available. Catches Power Infusion
+			-- and similar raid-important buffs. Too broad out of combat (catches
+			-- basic HoTs like Rejuvenation). Exclude BIG_DEFENSIVE.
+			if(not show) then
+				local isSecret = not F.IsValueNonSecret(auraData.spellId)
+				if(isSecret and flags.isRaid and not flags.isBigDefensive) then
+					show = true
+				end
+			end
+
+			-- Skip long-duration buffs (flasks, food, racials) that slip through
+			-- classification filters. duration == 0 means permanent.
+			if(show) then
+				local dur = auraData.duration
+				if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
+					show = false
+				end
+			end
+
+			if(show) then
+				local isPlayerCast = flags.isPlayerCast
+
+				if(not ((visibilityMode == 'player' and not isPlayerCast)
+					or (visibilityMode == 'others' and isPlayerCast))) then
+					displayed = displayed + 1
+					renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+						anchorPoint, anchorX, anchorY, playerColor, otherColor,
+						unit, id, auraData, isPlayerCast)
+				end
 			end
 		end
+	else
+		-- Fallback: no AuraState on this frame. Vestigial in practice — every
+		-- aura-tracking frame creates AuraState via the idempotent Setup guard —
+		-- preserved to match the element-level pattern used across Auras/.
+		for _, auraData in next, rawAuras do
+			if(displayed >= maxDisplayed) then break end
 
-		-- Step 3: RAID fallback — only for secret auras (combat) where
-		-- spell-level classification isn't available. Catches Power Infusion
-		-- and similar raid-important buffs. Too broad out of combat (catches
-		-- basic HoTs like Rejuvenation). Exclude BIG_DEFENSIVE to avoid
-		-- duplicating with Defensives.
-		if(not show) then
-			local isSecret = not F.IsValueNonSecret(auraData.spellId)
-			if(isSecret) then
-				local isRaid = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
-					unit, id, 'HELPFUL|RAID')
-				if(isRaid) then
+			local id = auraData.auraInstanceID
+
+			-- Step 1: EXTERNAL_DEFENSIVE (primary classification)
+			local show = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+				unit, id, 'HELPFUL|EXTERNAL_DEFENSIVE')
+
+			-- Step 2: IMPORTANT fallback — exclude BIG_DEFENSIVE.
+			if(not show) then
+				local isImportant = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+					unit, id, 'HELPFUL|IMPORTANT')
+				if(isImportant) then
 					local isBigDef = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
 						unit, id, 'HELPFUL|BIG_DEFENSIVE')
 					show = not isBigDef
 				end
 			end
-		end
 
-		-- Skip long-duration buffs (flasks, food, racials) that slip through
-		-- classification filters. duration == 0 means permanent.
-		if(show) then
-			local dur = auraData.duration
-			if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
-				show = false
+			-- Step 3: RAID fallback for secret auras — exclude BIG_DEFENSIVE.
+			if(not show) then
+				local isSecret = not F.IsValueNonSecret(auraData.spellId)
+				if(isSecret) then
+					local isRaid = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+						unit, id, 'HELPFUL|RAID')
+					if(isRaid) then
+						local isBigDef = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+							unit, id, 'HELPFUL|BIG_DEFENSIVE')
+						show = not isBigDef
+					end
+				end
 			end
-		end
 
-		if(show) then
-			-- Determine if player-cast via |PLAYER filter (avoids secret sourceUnit)
-			local isPlayerCast = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
-				unit, id, 'HELPFUL|PLAYER')
-
-			-- Apply visibility mode filter
-			if(not ((visibilityMode == 'player' and not isPlayerCast)
-				or (visibilityMode == 'others' and isPlayerCast))) then
-				-- Display directly — no intermediate table
-				displayed = displayed + 1
-
-				if(not pool[displayed]) then
-					pool[displayed] = F.Indicators.BorderIcon.Create(self, iconSize, {
-						showCooldown = true,
-						showStacks   = cfg.showStacks ~= false,
-						showDuration = cfg.showDuration ~= false,
-						frameLevel   = cfg.frameLevel,
-						stackFont    = cfg.stackFont,
-						durationFont = cfg.durationFont,
-					})
+			if(show) then
+				local dur = auraData.duration
+				if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
+					show = false
 				end
+			end
 
-				local bi = pool[displayed]
-				bi:ClearAllPoints()
-				bi:SetSize(iconSize)
+			if(show) then
+				local isPlayerCast = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+					unit, id, 'HELPFUL|PLAYER')
 
-				local offset = (displayed - 1) * (iconSize + 2)
-				if(orientation == 'RIGHT') then
-					bi:SetPoint(anchorPoint, self, anchorPoint, anchorX + offset, anchorY)
-				elseif(orientation == 'LEFT') then
-					bi:SetPoint(anchorPoint, self, anchorPoint, anchorX - offset, anchorY)
-				elseif(orientation == 'DOWN') then
-					bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY - offset)
-				elseif(orientation == 'UP') then
-					bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY + offset)
+				if(not ((visibilityMode == 'player' and not isPlayerCast)
+					or (visibilityMode == 'others' and isPlayerCast))) then
+					displayed = displayed + 1
+					renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+						anchorPoint, anchorX, anchorY, playerColor, otherColor,
+						unit, id, auraData, isPlayerCast)
 				end
-
-				local borderColor = isPlayerCast and playerColor or otherColor
-				if(bi.SetBorderColor) then
-					bi:SetBorderColor(borderColor[1], borderColor[2], borderColor[3])
-				end
-
-				bi:SetAura(
-					unit, id,
-					auraData.spellId,
-					auraData.icon,
-					auraData.duration,
-					auraData.expirationTime,
-					auraData.applications,
-					nil
-				)
-				bi:Show()
 			end
 		end
 	end
 
-	-- Hide pool entries beyond active count
 	for idx = displayed + 1, #pool do
 		pool[idx]:Clear()
 	end

--- a/Elements/Auras/MissingBuffs.lua
+++ b/Elements/Auras/MissingBuffs.lua
@@ -103,14 +103,17 @@ local function ensureCached(spellId)
 end
 
 --- Check whether a buff matching targetSpellId exists in the pre-fetched
---- aura list. Avoids any table creation — just iterates the API result
---- and compares spellId/name directly.
---- @param rawAuras table  Result of C_UnitAuras.GetUnitAuras(unit, 'HELPFUL')
+--- aura list. Accepts either AuraState classified entries ({ aura, flags })
+--- or raw auraData objects — the fallback path still feeds raw auras when
+--- AuraState is unavailable. `item.aura or item` keeps both shapes working
+--- without a call-site branch.
+--- @param auras table  Classified entries or raw auraData objects
 --- @param targetSpellId number
 --- @return boolean
-local function auraListHasBuff(rawAuras, targetSpellId)
+local function auraListHasBuff(auras, targetSpellId)
 	local targetName = ensureCached(targetSpellId)
-	for _, auraData in next, rawAuras do
+	for _, item in next, auras do
+		local auraData = item.aura or item
 		local sid = auraData.spellId
 		if(F.IsValueNonSecret(sid) and sid == targetSpellId) then return true end
 		if(targetName) then
@@ -192,7 +195,8 @@ local function Update(self, event, unit, updateInfo)
 			auraState:EnsureInitialized(unit)
 		end
 	end
-	local rawAuras = auraState and auraState:GetHelpful('HELPFUL') or C_UnitAuras.GetUnitAuras(unit, 'HELPFUL')
+	local auras = auraState and auraState:GetHelpfulClassified()
+		or C_UnitAuras.GetUnitAuras(unit, 'HELPFUL')
 
 	for _, spellId in next, BUFF_ORDER do
 		local providingClass = RAID_BUFFS[spellId]
@@ -203,7 +207,7 @@ local function Update(self, event, unit, updateInfo)
 		if(isNpc and providingClass ~= playerClass) then
 			slot.bi:Hide()
 			if(slot.glow:IsActive()) then slot.glow:Stop() end
-		elseif(providingClass and groupClasses[providingClass] and not auraListHasBuff(rawAuras, spellId)) then
+		elseif(providingClass and groupClasses[providingClass] and not auraListHasBuff(auras, spellId)) then
 			-- Missing buff from a class in the group — show and reposition
 			slot.bi.icon:SetTexture(iconCache[spellId])
 			slot.bi:ClearAllPoints()

--- a/Elements/Indicators/Bars.lua
+++ b/Elements/Indicators/Bars.lua
@@ -36,8 +36,8 @@ function BarsMethods:SetBars(auraList)
 		else
 			bar:SetValue(1, 1)
 		end
-		if(aura.stacks) then
-			bar:SetStacks(aura.stacks)
+		if(aura.applications) then
+			bar:SetStacks(aura.applications)
 		end
 		bar:Show()
 		-- Apply per-bar glow if active

--- a/Elements/Indicators/Icon.lua
+++ b/Elements/Indicators/Icon.lua
@@ -26,8 +26,7 @@ local IconMethods = {}
 --- @param duration number Duration in seconds (may be a secret value)
 --- @param expirationTime number Expiration GetTime() value (may be a secret value)
 --- @param stacks number Stack count
---- @param dispelType string|nil Dispel/debuff type ('Magic', 'Curse', etc.)
-function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, duration, expirationTime, stacks, dispelType)
+function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, duration, expirationTime, stacks)
 	-- Texture
 	if(self._displayType == C.IconDisplay.COLORED_SQUARE) then
 		-- Per-spell color first, then base indicator color

--- a/Elements/Indicators/IconTicker.lua
+++ b/Elements/Indicators/IconTicker.lua
@@ -20,6 +20,8 @@ local activeCount = 0
 
 tickerFrame:Hide()  -- starts hidden; shown when first icon registers
 
+F.Indicators.IconTicker_Frame = tickerFrame
+
 tickerFrame:SetScript('OnUpdate', function(self, elapsed)
 	self._elapsed = (self._elapsed or 0) + elapsed
 	if(self._elapsed < TICKER_INTERVAL) then return end

--- a/Elements/Indicators/Icons.lua
+++ b/Elements/Indicators/Icons.lua
@@ -13,8 +13,9 @@ F.Indicators.Icons = {}
 local IconsMethods = {}
 
 --- Fill icons from the pool with aura data and lay them out.
---- @param auraList table Array of { spellID, icon, duration, expirationTime, stacks, dispelType }
-function IconsMethods:SetIcons(auraList)
+--- @param unit string Unit token passed through to Icon:SetSpell for GetAuraDuration lookup
+--- @param auraList table Array of { auraInstanceID, spellId, icon, duration, expirationTime, applications }
+function IconsMethods:SetIcons(unit, auraList)
 	local cfg = self._config
 	local container = self._frame
 	local count = math.min(#auraList, cfg.maxIcons)
@@ -71,14 +72,13 @@ function IconsMethods:SetIcons(auraList)
 		end
 
 		icon:SetSpell(
-			aura.unit,
+			unit,
 			aura.auraInstanceID,
 			aura.spellId,
 			aura.icon,
 			aura.duration,
 			aura.expirationTime,
-			aura.stacks,
-			aura.dispelType
+			aura.applications
 		)
 		icon:Show()
 

--- a/Elements/Status/CrowdControl.lua
+++ b/Elements/Status/CrowdControl.lua
@@ -80,6 +80,9 @@ end
 local tickerFrame = CreateFrame('Frame')
 tickerFrame:Hide()
 
+F.Status = F.Status or {}
+F.Status.CrowdControl_Ticker = tickerFrame
+
 local activeTimers = {}
 
 tickerFrame:SetScript('OnUpdate', function(_, elapsed)

--- a/Elements/Status/LossOfControl.lua
+++ b/Elements/Status/LossOfControl.lua
@@ -180,6 +180,9 @@ end
 local tickerFrame = CreateFrame('Frame')
 tickerFrame:Hide()
 
+F.Status = F.Status or {}
+F.Status.LossOfControl_Ticker = tickerFrame
+
 local activeTimers = {}
 
 tickerFrame:SetScript('OnUpdate', function(_, elapsed)

--- a/Framed.toc
+++ b/Framed.toc
@@ -36,6 +36,7 @@ Core/Config.lua
 Core/CastTracker.lua
 Core/AuraCache.lua
 Core/AuraState.lua
+Core/MemDiag.lua
 Core/Backups.lua
 
 # Widgets

--- a/Init.lua
+++ b/Init.lua
@@ -499,6 +499,16 @@ SlashCmdList['FRAMED'] = function(msg)
 		for i = 1, math.min(10, #rows) do
 			print(('  %2d. %-32s  %7.1f MB'):format(i, rows[i].name, rows[i].kb / 1024))
 		end
+
+		-- Classified entry pool aggregate across all live AuraState instances.
+		local totalPooled = 0
+		local instanceCount = 0
+		for instance in next, F.AuraState._instances do
+			instanceCount = instanceCount + 1
+			totalPooled = totalPooled + #instance._classifiedFreeList
+		end
+		print(('|cff00ccff[Framed/mem]|r aurastate pool: %d entries across %d instances'):format(
+			totalPooled, instanceCount))
 	elseif(cmd == 'casttracker') then
 		if(arg1 == 'off' or arg1 == 'disable') then
 			F.CastTracker:Disable()

--- a/Init.lua
+++ b/Init.lua
@@ -38,10 +38,10 @@ eventFrame:SetScript('OnEvent', function(self, event, arg1)
 		-- Start auto-switching (detects content type and activates preset)
 		F.AutoSwitch.Check()
 
-		-- Enable cast tracker for targeted spells
-		if(F.CastTracker) then
-			F.CastTracker:Enable()
-		end
+		-- Cast tracker is gated off alongside TargetedSpells
+		-- (see Units/StyleBuilder.lua TARGETED_SPELLS_ENABLED).
+		-- Re-enable here if the feature is restored.
+		-- if(F.CastTracker) then F.CastTracker:Enable() end
 
 		-- Minimap icon via LibDataBroker + LibDBIcon
 		local LDB = LibStub('LibDataBroker-1.1')

--- a/Init.lua
+++ b/Init.lua
@@ -519,6 +519,32 @@ SlashCmdList['FRAMED'] = function(msg)
 		else
 			print('|cff00ccff Framed|r casttracker: use "on" or "off"')
 		end
+	elseif(cmd == 'pools') then
+		local rows = {}
+		for instance in next, F.AuraState._instances do
+			local owner = instance._owner
+			local ownerName = owner and owner.GetName and owner:GetName() or '<anon>'
+			local row = {
+				name = ownerName,
+				unit = instance._unit or '?',
+				pooled = #instance._classifiedFreeList,
+				helpful = 0,
+				harmful = 0,
+			}
+			for _ in next, instance._helpfulClassifiedById do
+				row.helpful = row.helpful + 1
+			end
+			for _ in next, instance._harmfulClassifiedById do
+				row.harmful = row.harmful + 1
+			end
+			rows[#rows + 1] = row
+		end
+		table.sort(rows, function(a, b) return a.pooled > b.pooled end)
+		print('|cff00ccff Framed|r classified pool per instance:')
+		print(('  %-32s %-12s %6s %6s %6s'):format('frame', 'unit', 'pooled', 'live+', 'live-'))
+		for _, r in next, rows do
+			print(('  %-32s %-12s %6d %6d %6d'):format(r.name, r.unit, r.pooled, r.helpful, r.harmful))
+		end
 	elseif(cmd == 'help') then
 		print('|cff00ccff Framed|r v' .. F.version .. ' — Commands:')
 		print('  /framed — Open settings')
@@ -533,6 +559,7 @@ SlashCmdList['FRAMED'] = function(msg)
 		print('  /framed aurastate [unit] — Dump classified aura flags (default: target)')
 		print('  /framed memdiag [seconds] — Measure aura-path allocation churn (default 10s, max 30s; stops GC for the window)')
 		print('  /framed memusage [raw] — Framed + total memory snapshot (default forces GC; "raw" skips it)')
+		print('  /framed pools — Dump per-instance classified pool sizes (for #144 diagnostics)')
 		print('  /framed casttracker on|off — Toggle CastTracker (for memdiag A/B testing)')
 	else
 		-- Default: open settings

--- a/Init.lua
+++ b/Init.lua
@@ -450,6 +450,65 @@ SlashCmdList['FRAMED'] = function(msg)
 
 		dumpList('HELPFUL', state:GetHelpfulClassified())
 		dumpList('HARMFUL', state:GetHarmfulClassified())
+	elseif(cmd == 'memdiag') then
+		local seconds = tonumber(arg1:match('^(%d+)')) or 10
+		F.MemDiag.Start(seconds)
+	elseif(cmd == 'memusage') then
+		-- `raw` suffix skips the forced GC (see live allocated state);
+		-- default forces a collect so we see post-GC live footprint.
+		local forceGC = (arg1 ~= 'raw')
+		if(forceGC) then collectgarbage('collect') end
+
+		UpdateAddOnMemoryUsage()
+		local totalKB = collectgarbage('count')
+		local framedKB = GetAddOnMemoryUsage('Framed')
+
+		-- Track delta from the previous call for yoyo amplitude sampling.
+		local prev = F._lastMemSnapshot
+		F._lastMemSnapshot = { total = totalKB, framed = framedKB, t = GetTime() }
+
+		local mode = forceGC and 'post-GC' or 'raw'
+		print(('|cff00ccff[Framed/mem]|r (%s) Framed: %.1f MB  |  total: %.1f MB  |  share: %.1f%%'):format(
+			mode,
+			framedKB / 1024,
+			totalKB / 1024,
+			totalKB > 0 and (framedKB / totalKB * 100) or 0))
+
+		if(prev) then
+			local dt = GetTime() - prev.t
+			print(('  delta since last sample (%.1fs ago):  Framed %+.1f MB  |  total %+.1f MB'):format(
+				dt,
+				(framedKB - prev.framed) / 1024,
+				(totalKB - prev.total) / 1024))
+		end
+
+		-- Top 10 addons by memory
+		local rows = {}
+		for i = 1, C_AddOns.GetNumAddOns() do
+			local name = C_AddOns.GetAddOnInfo(i)
+			local loaded = C_AddOns.IsAddOnLoaded(i)
+			if(loaded) then
+				local kb = GetAddOnMemoryUsage(name)
+				if(kb and kb > 0) then
+					rows[#rows + 1] = { name = name, kb = kb }
+				end
+			end
+		end
+		table.sort(rows, function(a, b) return a.kb > b.kb end)
+		print('|cff00ccff[Framed/mem]|r top 10 addons by memory:')
+		for i = 1, math.min(10, #rows) do
+			print(('  %2d. %-32s  %7.1f MB'):format(i, rows[i].name, rows[i].kb / 1024))
+		end
+	elseif(cmd == 'casttracker') then
+		if(arg1 == 'off' or arg1 == 'disable') then
+			F.CastTracker:Disable()
+			print('|cff00ccff Framed|r cast tracker disabled')
+		elseif(arg1 == 'on' or arg1 == 'enable') then
+			F.CastTracker:Enable()
+			print('|cff00ccff Framed|r cast tracker enabled')
+		else
+			print('|cff00ccff Framed|r casttracker: use "on" or "off"')
+		end
 	elseif(cmd == 'help') then
 		print('|cff00ccff Framed|r v' .. F.version .. ' — Commands:')
 		print('  /framed — Open settings')
@@ -462,6 +521,9 @@ SlashCmdList['FRAMED'] = function(msg)
 		print('  /framed debugicons — Debug indicator element state')
 		print('  /framed testimport — Generate a synthetic-diff import string for testing backfill')
 		print('  /framed aurastate [unit] — Dump classified aura flags (default: target)')
+		print('  /framed memdiag [seconds] — Measure aura-path allocation churn (default 10s, max 30s; stops GC for the window)')
+		print('  /framed memusage [raw] — Framed + total memory snapshot (default forces GC; "raw" skips it)')
+		print('  /framed casttracker on|off — Toggle CastTracker (for memdiag A/B testing)')
 	else
 		-- Default: open settings
 		if(F.Settings and F.Settings.Toggle) then

--- a/Units/StyleBuilder.lua
+++ b/Units/StyleBuilder.lua
@@ -380,8 +380,12 @@ function F.StyleBuilder.Apply(self, unit, config, unitType)
 		F.Elements.MissingBuffs.Setup(self, missingBuffsConfig)
 	end
 
+	-- TargetedSpells runtime-gated off — Blizzard 12.0.x secret-tainting
+	-- leaves cast source/target unreliable. Config keys left in place so
+	-- SavedVariables remain stable until a full removal PR lands.
+	local TARGETED_SPELLS_ENABLED = false
 	local targetedSpellsConfig = F.StyleBuilder.GetAuraConfig(unitType, 'targetedSpells')
-	if(targetedSpellsConfig and targetedSpellsConfig.enabled and F.Elements.TargetedSpells) then
+	if(TARGETED_SPELLS_ENABLED and targetedSpellsConfig and targetedSpellsConfig.enabled and F.Elements.TargetedSpells) then
 		F.Elements.TargetedSpells.Setup(self, targetedSpellsConfig)
 	end
 

--- a/docs/superpowers/plans/2026-04-21-b1-externals-classified.md
+++ b/docs/superpowers/plans/2026-04-21-b1-externals-classified.md
@@ -1,0 +1,386 @@
+# B1 — Externals Classified Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `Elements/Auras/Externals.lua` to consume `auraState:GetHelpfulClassified()` via `entry.flags.*` reads, eliminating 5 `IsAuraFilteredOutByInstanceID` probes per aura per UNIT_AURA.
+
+**Architecture:** Two-path iteration (classified / raw fallback) mirroring B2 Defensives. Extract inline render block into a module-local `renderEntry` helper. Flag reads: `isExternalDefensive` (primary), `isImportant` + `!isBigDefensive` (IMPORTANT fallback), `isRaid` + secret-spellId + `!isBigDefensive` (RAID fallback), `isPlayerCast` (border color). `renderEntry` signature matches B2's exactly — same helper shape across aura elements.
+
+**Tech Stack:** Lua 5.1, oUF, `F.AuraState.GetHelpfulClassified`, `F.IsValueNonSecret`, `F.Indicators.BorderIcon`.
+
+---
+
+## Context
+
+### Current probes (pre-B1)
+
+```
+Step 1 (primary):       HELPFUL|EXTERNAL_DEFENSIVE       → isExternalDefensive
+Step 2 (IMPORTANT):     HELPFUL|IMPORTANT                → isImportant
+                        HELPFUL|BIG_DEFENSIVE            → isBigDefensive (exclusion)
+Step 3 (RAID fallback): F.IsValueNonSecret(spellId)      → (not a probe)
+                        HELPFUL|RAID                     → isRaid
+                        HELPFUL|BIG_DEFENSIVE            → isBigDefensive (duplicate of step 2, same flag)
+Border color:           HELPFUL|PLAYER                   → isPlayerCast
+```
+
+Five unique classification probes become five flag reads. The duplicate `BIG_DEFENSIVE` probe (step 2 vs step 3) collapses to a single flag read.
+
+### Why Externals is a bigger win than Defensives
+
+Defensives eliminated 3 probes per aura. Externals eliminates 5. With A1's classify() doing 4 probes per aura once and caching, the per-UNIT_AURA cost drops from `N_aura × 5` to `4` (amortized; cached across all consumers).
+
+### Cross-element invariant preserved
+
+`not flags.isBigDefensive` gates the IMPORTANT and RAID fallback branches. This keeps spells classified as `BIG_DEFENSIVE` in the Defensives element and off the Externals element (no double-display). B2 Defensives uses the complementary check: `flags.isBigDefensive and not flags.isExternalDefensive` — the two elements partition the HELPFUL space cleanly.
+
+### RAID fallback rationale (preserved verbatim)
+
+In combat, Power Infusion and similar raid-important buffs may have a secret `spellId`. Spell-level classification is unavailable in that window, so the element falls back to the `HELPFUL|RAID` filter to catch them. Out of combat, `spellId` is non-secret — the RAID filter would be too broad (would catch every Rejuvenation), so the fallback is gated by `not F.IsValueNonSecret(auraData.spellId)`. Post-migration logic is identical; only the probe is replaced with a flag read.
+
+### Migration shape (reference — B2's pattern)
+
+```lua
+local classified = auraState and auraState:GetHelpfulClassified()
+local rawAuras   = (not classified) and F.AuraCache.GetUnitAuras(unit, 'HELPFUL') or nil
+
+if(classified) then
+    for _, entry in next, classified do
+        local auraData = entry.aura
+        local flags    = entry.flags
+        local id       = auraData.auraInstanceID
+        -- flag-based classification chain
+    end
+else
+    -- vestigial raw-probe fallback preserved
+end
+```
+
+---
+
+## Task 1: Migrate `Elements/Auras/Externals.lua`
+
+**Files:**
+- Modify: `Elements/Auras/Externals.lua` (~245 lines, full Update() rewrite + renderEntry helper)
+
+- [ ] **Step 1: Read the current file and the B2 reference**
+
+Read the current file to confirm no drift since spec was written:
+```
+Read: Elements/Auras/Externals.lua
+```
+
+Read B2's final form as the template for `renderEntry` shape and two-path structure:
+```
+Read: Elements/Auras/Defensives.lua
+```
+
+- [ ] **Step 2: Extract `renderEntry` helper above `Update`**
+
+Insert before the existing `Update` function. Signature and body match B2's exactly — this keeps the two element files structurally parallel.
+
+```lua
+-- ============================================================
+-- renderEntry — acquire / position / paint a single BorderIcon slot
+-- ============================================================
+
+local function renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+	anchorPoint, anchorX, anchorY, playerColor, otherColor,
+	unit, id, auraData, isPlayerCast)
+
+	if(not pool[displayed]) then
+		pool[displayed] = F.Indicators.BorderIcon.Create(self, iconSize, {
+			showCooldown = true,
+			showStacks   = cfg.showStacks ~= false,
+			showDuration = cfg.showDuration ~= false,
+			frameLevel   = cfg.frameLevel,
+			stackFont    = cfg.stackFont,
+			durationFont = cfg.durationFont,
+		})
+	end
+
+	local bi = pool[displayed]
+	bi:ClearAllPoints()
+	bi:SetSize(iconSize)
+
+	local offset = (displayed - 1) * (iconSize + 2)
+	if(orientation == 'RIGHT') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX + offset, anchorY)
+	elseif(orientation == 'LEFT') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX - offset, anchorY)
+	elseif(orientation == 'DOWN') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY - offset)
+	elseif(orientation == 'UP') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY + offset)
+	end
+
+	local borderColor = isPlayerCast and playerColor or otherColor
+	if(bi.SetBorderColor) then
+		bi:SetBorderColor(borderColor[1], borderColor[2], borderColor[3])
+	end
+
+	bi:SetAura(
+		unit, id,
+		auraData.spellId,
+		auraData.icon,
+		auraData.duration,
+		auraData.expirationTime,
+		auraData.applications,
+		nil
+	)
+	bi:Show()
+end
+```
+
+- [ ] **Step 3: Replace the body of `Update` with the two-path iteration**
+
+Keep the preamble unchanged (config unpacking, unit guard). Replace the aura loop (lines ~42–149 in the current file) with:
+
+```lua
+	local auraState = self.FramedAuraState
+	if(auraState) then
+		if(event == 'UNIT_AURA') then
+			auraState:ApplyUpdateInfo(unit, updateInfo)
+		else
+			auraState:EnsureInitialized(unit)
+		end
+	end
+
+	local classified = auraState and auraState:GetHelpfulClassified()
+	local rawAuras   = (not classified) and F.AuraCache.GetUnitAuras(unit, 'HELPFUL') or nil
+
+	local displayed = 0
+
+	if(classified) then
+		for _, entry in next, classified do
+			if(displayed >= maxDisplayed) then break end
+
+			local auraData = entry.aura
+			local flags    = entry.flags
+			local id       = auraData.auraInstanceID
+
+			-- Step 1: EXTERNAL_DEFENSIVE (primary)
+			local show = flags.isExternalDefensive
+
+			-- Step 2: IMPORTANT fallback — exclude BIG_DEFENSIVE to avoid
+			-- duplicating spells that already appear in the Defensives element.
+			-- NOTE: IMPORTANT may be removed in 12.0.5 per Blizzard feedback.
+			if(not show and flags.isImportant and not flags.isBigDefensive) then
+				show = true
+			end
+
+			-- Step 3: RAID fallback — only for secret auras (combat) where
+			-- spell-level classification isn't available. Catches Power Infusion
+			-- and similar raid-important buffs. Too broad out of combat (catches
+			-- basic HoTs like Rejuvenation). Exclude BIG_DEFENSIVE.
+			if(not show) then
+				local isSecret = not F.IsValueNonSecret(auraData.spellId)
+				if(isSecret and flags.isRaid and not flags.isBigDefensive) then
+					show = true
+				end
+			end
+
+			-- Skip long-duration buffs (flasks, food, racials) that slip through
+			-- classification filters. duration == 0 means permanent.
+			if(show) then
+				local dur = auraData.duration
+				if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
+					show = false
+				end
+			end
+
+			if(show) then
+				local isPlayerCast = flags.isPlayerCast
+
+				if(not ((visibilityMode == 'player' and not isPlayerCast)
+					or (visibilityMode == 'others' and isPlayerCast))) then
+					displayed = displayed + 1
+					renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+						anchorPoint, anchorX, anchorY, playerColor, otherColor,
+						unit, id, auraData, isPlayerCast)
+				end
+			end
+		end
+	else
+		-- Fallback: no AuraState on this frame. Vestigial in practice — every
+		-- aura-tracking frame creates AuraState via the idempotent Setup guard —
+		-- preserved to match the element-level pattern used across Auras/.
+		for _, auraData in next, rawAuras do
+			if(displayed >= maxDisplayed) then break end
+
+			local id = auraData.auraInstanceID
+
+			-- Step 1: EXTERNAL_DEFENSIVE (primary classification)
+			local show = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+				unit, id, 'HELPFUL|EXTERNAL_DEFENSIVE')
+
+			-- Step 2: IMPORTANT fallback — exclude BIG_DEFENSIVE.
+			if(not show) then
+				local isImportant = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+					unit, id, 'HELPFUL|IMPORTANT')
+				if(isImportant) then
+					local isBigDef = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+						unit, id, 'HELPFUL|BIG_DEFENSIVE')
+					show = not isBigDef
+				end
+			end
+
+			-- Step 3: RAID fallback for secret auras — exclude BIG_DEFENSIVE.
+			if(not show) then
+				local isSecret = not F.IsValueNonSecret(auraData.spellId)
+				if(isSecret) then
+					local isRaid = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+						unit, id, 'HELPFUL|RAID')
+					if(isRaid) then
+						local isBigDef = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+							unit, id, 'HELPFUL|BIG_DEFENSIVE')
+						show = not isBigDef
+					end
+				end
+			end
+
+			if(show) then
+				local dur = auraData.duration
+				if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
+					show = false
+				end
+			end
+
+			if(show) then
+				local isPlayerCast = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+					unit, id, 'HELPFUL|PLAYER')
+
+				if(not ((visibilityMode == 'player' and not isPlayerCast)
+					or (visibilityMode == 'others' and isPlayerCast))) then
+					displayed = displayed + 1
+					renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+						anchorPoint, anchorX, anchorY, playerColor, otherColor,
+						unit, id, auraData, isPlayerCast)
+				end
+			end
+		end
+	end
+
+	for idx = displayed + 1, #pool do
+		pool[idx]:Clear()
+	end
+```
+
+- [ ] **Step 4: Verify syntax**
+
+Run:
+```
+luajit -e "assert(loadfile('Elements/Auras/Externals.lua')); print('SYNTAX OK')"
+```
+Expected: `SYNTAX OK`
+
+- [ ] **Step 5: Commit**
+
+```
+git add Elements/Auras/Externals.lua
+git commit -m "feat(externals): migrate to AuraState classified API (B1 #137)
+
+Replace 5 IsAuraFilteredOutByInstanceID probes per aura per UNIT_AURA
+with entry.flags.* reads from auraState:GetHelpfulClassified():
+- isExternalDefensive (primary)
+- isImportant + !isBigDefensive (IMPORTANT fallback)
+- isRaid + secret-spellId + !isBigDefensive (RAID fallback)
+- isPlayerCast (border color)
+
+Two-path iteration (classified / raw fallback) mirrors B2 Defensives.
+Extract inline render block into a renderEntry helper matching B2's
+signature. Behavior unchanged — same externals render, same RAID
+fallback gating, same BIG_DEFENSIVE cross-element exclusion."
+```
+
+---
+
+## Task 2: Live smoke test in LFR
+
+**Files:** none (live addon test)
+
+- [ ] **Step 1: Push commit**
+
+```
+git push origin working-testing
+```
+
+- [ ] **Step 2: Ask user to /reload in LFR**
+
+User runs `/reload` in raid finder and verifies:
+
+1. **External defensives render** — healer-cast Power Word: Shield / Ironbark / Blessing of Protection on player frame show up in the Externals element with the "other" border color.
+2. **Self-cast PWS** (discipline priest only) — if player casts PWS on self, it shows with the "player" border color.
+3. **Secret-spellID combat buffs** — Power Infusion (or similar) applied by a raid member during combat renders via the RAID fallback.
+4. **BIG_DEFENSIVE cross-element exclusion** — player casts Ice Block / Divine Shield / Shield Wall: it renders in **Defensives**, not Externals. No double-display.
+5. **Out-of-combat RAID gating** — healer casts Rejuvenation on player outside combat: should NOT appear in Externals (gated by secret-spellID check; spellId is non-secret out of combat).
+6. **End-of-duration** — no flash, no render anomalies (same regression check as B2).
+7. **No Lua errors** — no `AuraState.lua:22` taint, no `Externals.lua` errors.
+
+- [ ] **Step 3: If any regression, stop and diagnose**
+
+If a defensive doesn't render, flash returns, or Lua errors appear: capture the error text, re-read current file state, diagnose. Revert only if the fix is unclear.
+
+---
+
+## Task 3: Create PR
+
+**Files:** none (GitHub PR via gh)
+
+- [ ] **Step 1: Confirm commits on working-testing**
+
+```
+git log --oneline origin/working..HEAD
+```
+Expected: shows the B1 migration commit and plan-doc commit.
+
+- [ ] **Step 2: Open PR**
+
+```
+gh pr create --base working --head working-testing \
+  --title "B1 — migrate Externals to AuraState classified API (#137)" \
+  --body "<body below>"
+```
+
+PR body:
+
+```markdown
+## Summary
+
+- **B1: Externals migrated to AuraState classified API** (#115, #137) — `Elements/Auras/Externals.lua` now reads `entry.flags.*` from `auraState:GetHelpfulClassified()` instead of issuing 5 `IsAuraFilteredOutByInstanceID` probes per aura per UNIT_AURA. Second consumer of A1's classification infrastructure (after B2 Defensives).
+- **Migration detail** — 5 flag reads replace 5 C-API probes: `isExternalDefensive` (primary), `isImportant` + `!isBigDefensive` (IMPORTANT fallback), `isRaid` + secret-spellId + `!isBigDefensive` (RAID fallback), `isPlayerCast` (border color). Duplicate `BIG_DEFENSIVE` probe across fallbacks collapses to a single flag read.
+- **Structure** — two-path iteration (classified / raw fallback) mirrors B2 Defensives; extract inline render block into a `renderEntry` helper matching B2's signature.
+- **Behavior unchanged** — same externals render, same RAID fallback gating, same BIG_DEFENSIVE cross-element exclusion.
+- **No version bump** — remaining B-series (B4 Dispellable, B5 Buffs/Debuffs, B3 castBy) will ship in a bundled release once they land.
+
+Plan: `docs/superpowers/plans/2026-04-21-b1-externals-classified.md`
+
+## Test plan
+
+- [x] LFR — external defensives render with other-color border
+- [x] LFR — secret-spellID combat buffs (Power Infusion) render via RAID fallback
+- [x] LFR — BIG_DEFENSIVE cross-element exclusion holds (Ice Block stays in Defensives)
+- [x] Out-of-combat — Rejuvenation does NOT appear in Externals (RAID fallback gated by secret-spellID)
+- [x] No Lua errors, no end-of-duration flash
+
+## Follow-ups
+
+- B4 #140 (Dispellable) — separate plan + PR
+- B5 #141 (Buffs/Debuffs) — separate plan + PR
+- B3 #139 (castBy flag-based) — separate plan + PR
+- Bundled release after B-series completes
+```
+
+- [ ] **Step 3: Report PR URL to user**
+
+---
+
+## Self-review
+
+**1. Spec coverage:** B1 maps to spec line 502 ("#137 B1 — `Elements/Auras/Externals.lua` — Replace 5-probe classification chain with flag reads"). All four call-outs covered: self PWS (`isPlayerCast` border), external Ironbark (`isExternalDefensive`), IMPORTANT-only non-defensive helpful (`isImportant` + `!isBigDefensive`), RAID fallback for secret-spellID (`isRaid` + secret + `!isBigDefensive`).
+
+**2. Placeholder scan:** No "TBD", no "similar to B2" — renderEntry body repeated in full. Commit message concrete. PR body concrete. No dangling "fill in details".
+
+**3. Type consistency:** `entry.aura` / `entry.flags` shape matches A1's `classify()` output. Flag names (`isExternalDefensive`, `isImportant`, `isBigDefensive`, `isRaid`, `isPlayerCast`) match `Core/AuraState.lua:18-35` exactly. `renderEntry` signature matches B2's exactly.
+
+**4. Cross-element invariant:** `!flags.isBigDefensive` gate preserved on both IMPORTANT and RAID fallback branches. Defensives uses `flags.isBigDefensive and not flags.isExternalDefensive`. The two elements partition the HELPFUL classification space cleanly — no overlap, no gap.

--- a/docs/superpowers/plans/2026-04-21-b2-defensives-classified.md
+++ b/docs/superpowers/plans/2026-04-21-b2-defensives-classified.md
@@ -1,0 +1,468 @@
+# B2 Defensives Classified-API Migration Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `Elements/Auras/Defensives.lua` from inline `IsAuraFilteredOutByInstanceID` probes to flag reads on AuraState's classified store. Smoke-test migration for the B-series.
+
+**Architecture:** Replace three C-API probes per aura (BIG_DEFENSIVE, EXTERNAL_DEFENSIVE, PLAYER) with field reads on `entry.flags.*` from `auraState:GetHelpfulClassified()`. Preserve the no-AuraState fallback path for frames that don't create one (vestigial, matches existing element-level convention).
+
+**Tech Stack:** Lua 5.1, oUF, Framed's `F.AuraState` classified API (shipped in A1 / v0.8.14-alpha).
+
+---
+
+## Context and References
+
+- **Spec:** `docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md`
+- **A1 implementation:** `Core/AuraState.lua` — `classify()` at line 14, `GetHelpfulClassified()` at line 375
+- **Current Defensives probes:** `Elements/Auras/Defensives.lua:52-56` (BIG_DEFENSIVE + EXTERNAL_DEFENSIVE), line 71 (PLAYER)
+- **Issue:** #138 (B2 Defensives)
+- **Parent:** #115 (UNIT_AURA fan-out rearchitecture)
+
+## Scope note — three probes, not one
+
+The spec's per-element table says "Single BIG_DEFENSIVE probe becomes `flags.isBigDefensive` read + `flags.isPlayerCast` for border-color distinction." The actual code has three probes: BIG_DEFENSIVE (line 52), EXTERNAL_DEFENSIVE exclusion (line 55), and PLAYER (line 71). All three map to existing flags in A1's `classify()`. The migration covers all three.
+
+## Fallback path
+
+When `self.FramedAuraState` is nil (no aura element on the frame has created one), the existing fallback at line 42 uses `F.AuraCache.GetUnitAuras` and raw AuraData. Keep that path using the original probe logic — the spec at line 272 calls this branch "vestigial but preserved to match the existing element-level `auraState and ... or fallback` pattern." Do not touch it.
+
+---
+
+## File Structure
+
+- **Modify:** `Elements/Auras/Defensives.lua` — replace the inner loop of `Update` with a two-path pattern: classified iteration when AuraState exists, raw-AuraData iteration (current code) when it doesn't.
+
+No new files. No changes to `Core/AuraState.lua`.
+
+---
+
+## Task 1: Migrate Defensives.lua Update to classified API
+
+**Files:**
+- Modify: `Elements/Auras/Defensives.lua:44-123` (the main `for _, auraData in next, rawAuras do` loop)
+
+- [ ] **Step 1: Verify current probe positions with Grep**
+
+Run: `Grep -n "IsAuraFilteredOutByInstanceID" Elements/Auras/Defensives.lua`
+Expected output:
+```
+52:		local show = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+55:			local isExtDef = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+71:			local isPlayerCast = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+```
+
+If positions differ, re-read the file before editing.
+
+- [ ] **Step 2: Restructure the fetch + iterate block**
+
+Replace lines 34-42 and the `for _, auraData in next, rawAuras do` loop (line 45) through `end` of that loop (line 123) with two-path iteration. Concretely:
+
+Replace this block (lines 31-45):
+```lua
+	-- BIG_DEFENSIVE is a classification filter, not a query filter —
+	-- GetUnitAuras does not support it. Fetch all helpful auras, then
+	-- classify each one via IsAuraFilteredOutByInstanceID.
+	local auraState = self.FramedAuraState
+	if(auraState) then
+		if(event == 'UNIT_AURA') then
+			auraState:ApplyUpdateInfo(unit, updateInfo)
+		else
+			auraState:EnsureInitialized(unit)
+		end
+	end
+	local rawAuras = auraState and auraState:GetHelpful('HELPFUL') or F.AuraCache.GetUnitAuras(unit, 'HELPFUL')
+
+	local displayed = 0
+	for _, auraData in next, rawAuras do
+```
+
+With:
+```lua
+	local auraState = self.FramedAuraState
+	if(auraState) then
+		if(event == 'UNIT_AURA') then
+			auraState:ApplyUpdateInfo(unit, updateInfo)
+		else
+			auraState:EnsureInitialized(unit)
+		end
+	end
+
+	local classified = auraState and auraState:GetHelpfulClassified()
+	local rawAuras   = (not classified) and F.AuraCache.GetUnitAuras(unit, 'HELPFUL') or nil
+
+	local displayed = 0
+
+	if(classified) then
+		for _, entry in next, classified do
+			if(displayed >= maxDisplayed) then break end
+
+			local auraData = entry.aura
+			local flags    = entry.flags
+			local id       = auraData.auraInstanceID
+
+			-- Primary classification: BIG_DEFENSIVE, excluding EXTERNAL_DEFENSIVE
+			-- (those belong in the Externals element).
+			local show = flags.isBigDefensive and not flags.isExternalDefensive
+
+			-- Skip long-duration buffs (flasks, food, racials) that aren't real
+			-- defensives. duration == 0 means permanent.
+			if(show) then
+				local dur = auraData.duration
+				if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
+					show = false
+				end
+			end
+
+			if(show) then
+				local isPlayerCast = flags.isPlayerCast
+
+				if(not ((visibilityMode == 'player' and not isPlayerCast)
+					or (visibilityMode == 'others' and isPlayerCast))) then
+					displayed = displayed + 1
+					renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+						anchorPoint, anchorX, anchorY, playerColor, otherColor,
+						unit, id, auraData, isPlayerCast)
+				end
+			end
+		end
+	else
+		for _, auraData in next, rawAuras do
+			if(displayed >= maxDisplayed) then break end
+
+			local id = auraData.auraInstanceID
+
+			local show = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+				unit, id, 'HELPFUL|BIG_DEFENSIVE')
+			if(show) then
+				local isExtDef = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+					unit, id, 'HELPFUL|EXTERNAL_DEFENSIVE')
+				if(isExtDef) then show = false end
+			end
+
+			if(show) then
+				local dur = auraData.duration
+				if(F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)) then
+					show = false
+				end
+			end
+
+			if(show) then
+				local isPlayerCast = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+					unit, id, 'HELPFUL|PLAYER')
+
+				if(not ((visibilityMode == 'player' and not isPlayerCast)
+					or (visibilityMode == 'others' and isPlayerCast))) then
+					displayed = displayed + 1
+					renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+						anchorPoint, anchorX, anchorY, playerColor, otherColor,
+						unit, id, auraData, isPlayerCast)
+				end
+			end
+		end
+	end
+
+	for idx = displayed + 1, #pool do
+		pool[idx]:Clear()
+	end
+end
+```
+
+And delete the original monolithic loop body (the big `if(show) then ... bi:Show()` render block that was lines 77-121 in the original) — moved into `renderEntry` below.
+
+- [ ] **Step 3: Extract the BorderIcon render into a local `renderEntry` helper**
+
+Add this module-local function between the `local oUF = F.oUF` block and the `Update` function (so before line 12):
+
+```lua
+-- ============================================================
+-- renderEntry — acquire / position / paint a single BorderIcon slot
+-- ============================================================
+
+local function renderEntry(self, element, pool, displayed, iconSize, cfg, orientation,
+	anchorPoint, anchorX, anchorY, playerColor, otherColor,
+	unit, id, auraData, isPlayerCast)
+
+	if(not pool[displayed]) then
+		pool[displayed] = F.Indicators.BorderIcon.Create(self, iconSize, {
+			showCooldown = true,
+			showStacks   = cfg.showStacks ~= false,
+			showDuration = cfg.showDuration ~= false,
+			frameLevel   = cfg.frameLevel,
+			stackFont    = cfg.stackFont,
+			durationFont = cfg.durationFont,
+		})
+	end
+
+	local bi = pool[displayed]
+	bi:ClearAllPoints()
+	bi:SetSize(iconSize)
+
+	local offset = (displayed - 1) * (iconSize + 2)
+	if(orientation == 'RIGHT') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX + offset, anchorY)
+	elseif(orientation == 'LEFT') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX - offset, anchorY)
+	elseif(orientation == 'DOWN') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY - offset)
+	elseif(orientation == 'UP') then
+		bi:SetPoint(anchorPoint, self, anchorPoint, anchorX, anchorY + offset)
+	end
+
+	local borderColor = isPlayerCast and playerColor or otherColor
+	if(bi.SetBorderColor) then
+		bi:SetBorderColor(borderColor[1], borderColor[2], borderColor[3])
+	end
+
+	bi:SetAura(
+		unit, id,
+		auraData.spellId,
+		auraData.icon,
+		auraData.duration,
+		auraData.expirationTime,
+		auraData.applications,
+		nil
+	)
+	bi:Show()
+end
+```
+
+- [ ] **Step 4: Verify the file is syntactically valid**
+
+Run: `Bash luac -p Elements/Auras/Defensives.lua` (if luac is installed locally) OR visually scan the file structure: every `function … end`, every `if … then … end`, every `for … do … end` pair closes cleanly.
+
+If local `luac` not available, check by `Read`-ing the final file and visually verify indentation and structure.
+
+- [ ] **Step 5: Grep for any orphaned probe calls**
+
+Run: `Grep -n "IsAuraFilteredOutByInstanceID" Elements/Auras/Defensives.lua`
+Expected: only the three probes inside the `else` (no-AuraState fallback) block — roughly 3 matches. If zero, the fallback got inadvertently removed; revisit. If >3, the happy path still has probes; revisit.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Elements/Auras/Defensives.lua
+git commit -m "$(cat <<'EOF'
+feat(defensives): migrate to AuraState classified API (B2 #138)
+
+Replace 3 IsAuraFilteredOutByInstanceID probes per aura
+(BIG_DEFENSIVE, EXTERNAL_DEFENSIVE, PLAYER) with flag reads on
+entry.flags.* from auraState:GetHelpfulClassified().
+
+The no-AuraState fallback path keeps its original probe logic —
+per spec, this branch is vestigial but preserved for consistency
+with the element-level pattern used across Auras/.
+
+Render slot acquisition/positioning/painting factored into a
+local renderEntry helper so both paths share it without copy-paste.
+
+Part of #115 UNIT_AURA fan-out rearchitecture.
+EOF
+)"
+```
+
+---
+
+## Task 2: Live smoke test
+
+Framed has no automated test harness; verification is in-game per `feedback_coding_standards` and the spec's "Testing Strategy" section.
+
+**Files:** None.
+
+- [ ] **Step 1: /reload in WoW**
+
+The addon folder is a symlink (per `feedback_wow_sync`), so the edited Defensives.lua is already live. `/reload` to pick it up.
+
+- [ ] **Step 2: Verify with `/framed aurastate player`**
+
+Cast Power Word: Shield on yourself (or similar self-buff), then run `/framed aurastate player`. Confirm the printed flags include `external-defensive` and `important` for PWS. This confirms the classified API is populated before Defensives reads it.
+
+- [ ] **Step 3: Self-defensive test — Divine Shield / Ice Block / Cloak / Shield Wall**
+
+Cast a personal defensive (class-appropriate):
+- Paladin: Divine Shield
+- Mage: Ice Block
+- Rogue: Cloak of Shadows
+- Warrior: Shield Wall
+
+**Expected:** Defensive BorderIcon appears on your player frame with green (player-cast) border color. Position matches the configured anchor. Duration text displays. Icon clears when the aura expires.
+
+**If regression:** revert Task 1's commit, re-examine the flag mapping.
+
+- [ ] **Step 4: External-defensive exclusion**
+
+Have a healer cast Power Word: Shield on you (or use a target dummy + offer PWS yourself). **Expected:** PWS does NOT appear in Defensives — it's classified as `isExternalDefensive` and excluded. It should appear in Externals instead.
+
+If PWS appears in Defensives: the `not flags.isExternalDefensive` exclusion didn't fire. Check Step 2's `/framed aurastate player` output to confirm `external-defensive` is in the flag list.
+
+- [ ] **Step 5: Visibility mode test**
+
+Open Framed Settings → Defensives panel. Toggle `visibilityMode` through `all` / `player` / `others` and confirm:
+- `all`: all BIG_DEFENSIVE auras render
+- `player`: only player-cast renders (green border)
+- `others`: only other-cast renders (yellow border)
+
+- [ ] **Step 6: Border color distinction**
+
+If you have a target dummy setup, stand a second character near your main's view. Have it apply a big defensive to you (if any class can externally apply something that's classified as BIG_DEFENSIVE and NOT EXTERNAL_DEFENSIVE — rare, but test whatever applies). Otherwise confirm via the self-cast path that the green (player) border shows correctly.
+
+- [ ] **Step 7: Long-duration skip**
+
+Confirm flasks / food buffs / racial buffs (all duration 0 or >= 600s) do NOT appear. This exercises the `dur == 0 or dur >= 600` filter after the flag check.
+
+- [ ] **Step 8: Combat churn — 5-man or target dummy burst**
+
+Run a dungeon pull or a 60s target-dummy rotation with all personal cooldowns active. Watch for:
+- No Lua errors in `/etrace` or BugSack
+- Icons appear/disappear cleanly with cooldown usage
+- No visual flicker or orphaned icons after auras drop
+
+- [ ] **Step 9: Report findings**
+
+Post a brief summary back to the user confirming:
+- Which personal defensives were tested
+- Border color distinction worked
+- External-defensive exclusion worked
+- No regressions observed in a combat session
+
+If any step reveals a regression, STOP, do not proceed to Task 3, and consult the user.
+
+---
+
+## Task 3: Release cut
+
+**Files:**
+- Modify: `CHANGELOG.md` (new v0.8.15-alpha block)
+- Modify: `Framed.toc:5` (version bump)
+- Modify: `Settings/Cards/About.lua` (regenerated by sync-changelog.lua)
+
+Per `feedback_release_workflow`: fix commit first (Task 1), bump commit second (this task) touches only CHANGELOG / TOC / About.
+
+- [ ] **Step 1: Add v0.8.15-alpha block to CHANGELOG.md**
+
+Open `CHANGELOG.md` and insert between `[Unreleased]` and `v0.8.14-alpha`:
+
+```markdown
+## v0.8.15-alpha
+
+- **B2 Defensives migrated to classified API** (#115, #138) — `Elements/Auras/Defensives.lua` now reads `entry.flags.*` from `auraState:GetHelpfulClassified()` instead of issuing 3 `IsAuraFilteredOutByInstanceID` probes per aura per UNIT_AURA. First consumer of A1's classification infrastructure. Behavior unchanged — same defensives render, same player/other border distinction, same long-duration skip.
+```
+
+- [ ] **Step 2: Run sync-changelog.lua**
+
+```bash
+./tools/sync-changelog.lua
+```
+
+This regenerates the `-- BEGIN/END GENERATED CHANGELOG` block in `Settings/Cards/About.lua` with the new entries (most-recent-2 kept).
+
+- [ ] **Step 3: Bump Framed.toc version**
+
+Edit `Framed.toc` line 5:
+```
+## Version: 0.8.14-alpha
+```
+to:
+```
+## Version: 0.8.15-alpha
+```
+
+- [ ] **Step 4: Verify the bump commit's diff is scoped correctly**
+
+Run: `Bash git status && git diff --stat`
+Expected three files changed: `CHANGELOG.md`, `Framed.toc`, `Settings/Cards/About.lua`. Nothing else.
+
+If other files appear, stash them before committing the bump — the release-workflow memory requires the bump commit to be narrow.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md Framed.toc Settings/Cards/About.lua
+git commit -m "Bump to v0.8.15-alpha"
+```
+
+- [ ] **Step 6: Push**
+
+```bash
+git push origin working-testing
+```
+
+---
+
+## Task 4: Create PRs (working-testing → working, then working → main)
+
+Follows the same two-stage promotion pattern used for v0.8.14-alpha (PRs #145 + #146). Per `project_framed_worktree`: working-testing → working for dev promotion; working → main triggers release automation.
+
+**Files:** None.
+
+- [ ] **Step 1: Create working-testing → working PR**
+
+```bash
+gh pr create --base working --head working-testing \
+  --title "v0.8.15-alpha — B2 Defensives classified-API migration" \
+  --body "$(cat <<'EOF'
+## Summary
+- **B2 Defensives migrated to classified API** (#115, #138) — first element consumer of A1's classification layer. Replaces 3 `IsAuraFilteredOutByInstanceID` probes per aura (BIG_DEFENSIVE, EXTERNAL_DEFENSIVE, PLAYER) with flag reads.
+- Behavior unchanged; smoke-test migration validates the `entry.flags.*` pattern for the rest of the B-series.
+- Version bump 0.8.14-alpha → 0.8.15-alpha.
+
+## Test plan
+- [x] Self-cast personal defensive (Divine Shield / Ice Block / etc.) renders with green border
+- [x] PWS (external-defensive) does NOT appear in Defensives (appears in Externals)
+- [x] Visibility mode all / player / others each filter correctly
+- [x] Long-duration skip (flasks / food / racials) preserved
+- [x] Combat session with cooldowns — no Lua errors, no orphaned icons
+
+## Follow-ups
+- B1 Externals (#137) next in the series
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for working-testing → working PR to be reviewed and merged**
+
+STOP here. Hand back to the user for merge. Once merged, continue to Step 3.
+
+- [ ] **Step 3: Create working → main promotion PR**
+
+Run after the working-testing PR is merged:
+
+```bash
+gh pr create --base main --head working \
+  --title "Promote v0.8.15-alpha to main" \
+  --body "$(cat <<'EOF'
+## Summary
+- **B2 Defensives migrated to classified API** (#115, #138) — first element consumer of A1's classification layer; 3 probes per aura replaced with flag reads. Behavior unchanged.
+- Version bump 0.8.14-alpha → 0.8.15-alpha.
+
+## Test plan
+QA completed on the `working-testing` → `working` leg (previous PR). Promotion only.
+
+## Post-merge
+- [ ] Confirm `auto-tag.yml` creates `v0.8.15-alpha` tag
+- [ ] Confirm `release.yml` publishes to CurseForge and posts to Discord
+
+## Follow-ups
+- B1 Externals (#137) next in the series
+- #118 gen-check defect — remains blocked until all B-series elements ship
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Hand back to user**
+
+Report both PR URLs. The user owns the merge; auto-tag + release automation fire on the main merge.
+
+---
+
+## Rollback strategy
+
+Per the spec's "Rollback strategy" section (line 556):
+1. `git revert` the Task 1 commit (and the bump in Task 3 if already landed).
+2. AuraState's classification layer stays in place; Defensives reverts to its pre-B2 probe path against `_helpfulById`.
+3. Other B-issues (none shipped yet) unaffected.
+
+A1's API surface is append-only — reverting B2 does not require touching `Core/AuraState.lua`.

--- a/docs/superpowers/plans/2026-04-22-b3-buffs-classified.md
+++ b/docs/superpowers/plans/2026-04-22-b3-buffs-classified.md
@@ -1,0 +1,560 @@
+# B3 — Buffs Classified Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `Elements/Auras/Buffs.lua` from `auraState:GetHelpful(filterString)` to `auraState:GetHelpfulClassified()`, preserving the #113 secret-sourceUnit castBy fix exactly, without any semantic change to `passesCastByFilter`.
+
+**Architecture:** Two-path iteration (classified / raw fallback) mirroring B1/B2/B4. When the effective server filter would be `HELPFUL|RAID_IN_COMBAT` (no indicator has a spell list), the classified loop gates entries on `flags.isRaidInCombat` so track-all indicators don't suddenly see cosmetic/consumable/world buffs. `passesCastByFilter` is unchanged — it reads `entry.aura.sourceUnit` the same way it used to read `auraData.sourceUnit`. A1 extension: `isRaidInCombat` becomes `prefix`-based (both helpful and harmful) instead of harmful-only; `RAID_IN_COMBAT` is a symmetric Blizzard modifier, so widening the gate costs one extra probe per helpful classify and unlocks the Buffs narrow-filter path.
+
+**Tech Stack:** Lua 5.1, oUF, `F.AuraState.GetHelpfulClassified`, `F.IsValueNonSecret`, existing `passesCastByFilter` helper.
+
+---
+
+## Context
+
+### Current aura-fetch shape (pre-B3)
+
+```lua
+local filter = element._buffFilter  -- 'HELPFUL' or 'HELPFUL|RAID_IN_COMBAT'
+local auras = auraState and auraState:GetHelpful(filter) or F.AuraCache.GetUnitAuras(unit, filter)
+for _, auraData in next, auras do
+    local spellId = auraData.spellId
+    if(F.IsValueNonSecret(spellId)) then
+        local sourceUnit = auraData.sourceUnit
+        -- check spellLookup[spellId] + hasTrackAll
+        -- passesCastByFilter(sourceUnit, ind._castBy)
+        -- annotate + push to pool / first-match
+    end
+end
+```
+
+### `computeBuffFilter` semantics (preserved)
+
+```lua
+local function computeBuffFilter(indicatorConfigs)
+    for _, ind in next, indicatorConfigs do
+        if(ind.enabled ~= false and ind.spells and #ind.spells > 0) then
+            return 'HELPFUL'
+        end
+    end
+    return 'HELPFUL|RAID_IN_COMBAT'
+end
+```
+
+**Key property:** if *any* enabled indicator has a spell list, the filter widens to `HELPFUL` **globally** — which means track-all indicators in mixed configs also see cosmetic/world/consumable buffs (the existing trade-off for making tracked spells visible). B3 must preserve this exact behavior.
+
+### Narrow-filter gating in classified path
+
+Pre-B3, `GetHelpful('HELPFUL|RAID_IN_COMBAT')` returned only server-filtered auras. Post-B3, `GetHelpfulClassified()` returns **all** helpful auras on the unit. To preserve narrow-mode semantics without a regression:
+
+```lua
+local narrowFilter = element._buffFilter == 'HELPFUL|RAID_IN_COMBAT'
+for _, entry in next, classified do
+    local flags = entry.flags
+    if(not narrowFilter or flags.isRaidInCombat) then
+        local auraData = entry.aura
+        -- ...existing spell-match + castBy logic, unchanged
+    end
+end
+```
+
+This keeps flasks / food / racial / cosmetic buffs out of track-all indicators when no spell list is configured — matching Blizzard's server-side behavior.
+
+### Why `isRaidInCombat` must be relaxed to both sides
+
+B4 introduced `isRaidInCombat` as a harmful-only probe (`not isHelpful and ... or false`). `RAID_IN_COMBAT` is a symmetric Blizzard filter modifier — `HELPFUL|RAID_IN_COMBAT` is a real, queryable filter (Buffs already uses it as the narrow default). So B3's Task 1 relaxes the gate to match `isExternalDefensive` / `isImportant` / `isPlayerCast`:
+
+```lua
+flags.isRaidInCombat = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|RAID_IN_COMBAT') == false
+```
+
+Cost: one extra probe per helpful classify. B4 Debuffs' use (`flags.isRaidInCombat` for the `raidCombat` filter mode) is unaffected — harmful auras still get `HARMFUL|RAID_IN_COMBAT` probed and the result is unchanged. `isRaidDispellable` stays harmful-only (`RAID_PLAYER_DISPELLABLE` is semantically harmful-only — dispelling applies to debuffs).
+
+### castBy semantics — pure migration, no refinement
+
+Issue #139 calls out that `isFromPlayerOrPet` is available as a first-class flag and could inform the secret-sourceUnit fallback, but **also explicitly warns against using it as a direct `castBy='me'` proxy** (it's "any player or pet on your side", including every raid member's pets). The safer B3 scope is:
+
+- **In B3:** keep `passesCastByFilter` byte-identical. Read `sourceUnit` from `entry.aura.sourceUnit` (same location as pre-B3's `auraData.sourceUnit`). The #113 fix survives unchanged because the function body doesn't change.
+- **Defer** any refinement that tightens the secret-source fallback using `isFromPlayerOrPet`. That's a behavior change, not a migration — belongs in a follow-up issue so it can be evaluated on its own merits.
+
+PR body should flag this as follow-up.
+
+### Annotation pattern (unchanged, called out for safety)
+
+The current code mutates `auraData` in place with `auraData.unit`, `auraData.stacks`, `auraData.dispelType` to satisfy renderer expectations. In the classified path, `entry.aura` **is** the same `auraData` reference as before (AuraState's classified store wraps the same AuraCache-owned auraData). Annotations still stick to the shared reference. This is a pre-existing hazard (not introduced by B3) — flag but don't fix in this PR.
+
+### Fallback path (no AuraState)
+
+Vestigial but preserved, matching B1/B2/B4. When `self.FramedAuraState` is nil, the element falls through to `F.AuraCache.GetUnitAuras(unit, element._buffFilter)` with the original server filter string. All downstream logic — spell-lookup, castBy, annotation, dispatch — stays verbatim in the fallback branch.
+
+---
+
+## File Structure
+
+- **Modify:** `Core/AuraState.lua` — relax `isRaidInCombat` gate from `not isHelpful` to `prefix`-based.
+- **Modify:** `Elements/Auras/Buffs.lua` — replace the aura-fetch + inner loop with two-path (classified / fallback). `passesCastByFilter`, `computeBuffFilter`, renderer dispatch, annotation, spell-priority sort all unchanged.
+
+No new files. No changes to renderers, `Rebuild`, `Setup`, or any of the renderer-creation helpers.
+
+---
+
+## Task 1: Relax `isRaidInCombat` gate to both helpful and harmful
+
+**Files:**
+- Modify: `Core/AuraState.lua` — the `flags.isRaidInCombat` line (currently lines 39-41)
+
+- [ ] **Step 1: Read the current classify() to confirm line positions**
+
+Read `Core/AuraState.lua:30-42`. Confirm the existing block still has `isRaidInCombat` as the last flag, gated with `not isHelpful and ... or false`. If the file drifted, re-read before editing.
+
+- [ ] **Step 2: Replace the harmful-only gate with prefix-based probe**
+
+Replace:
+
+```lua
+	flags.isRaidInCombat      = not isHelpful
+	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|RAID_IN_COMBAT') == false
+	                            or false
+```
+
+With:
+
+```lua
+	flags.isRaidInCombat      = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|RAID_IN_COMBAT') == false
+```
+
+Leave `isRaidDispellable` alone — `RAID_PLAYER_DISPELLABLE` is harmful-only semantically.
+
+- [ ] **Step 3: Verify the edit landed correctly**
+
+Run: `Grep -n "isRaidInCombat\|isRaidDispellable" Core/AuraState.lua`
+Expected:
+```
+36:	flags.isRaidDispellable   = not isHelpful
+37:	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|RAID_PLAYER_DISPELLABLE') == false
+38:	                            or false
+39:	flags.isRaidInCombat      = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|RAID_IN_COMBAT') == false
+```
+
+`isRaidDispellable` stays harmful-gated. `isRaidInCombat` becomes a single-line prefix-based probe.
+
+- [ ] **Step 4: Confirm Debuffs' `raidCombat` filter is unaffected**
+
+Run: `Grep -n "isRaidInCombat" Elements/Auras/Debuffs.lua`
+Expected: one match at the `flagKey = 'isRaidInCombat'` dispatch line inside `updateIndicator`. Harmful auras still get `HARMFUL|RAID_IN_COMBAT` probed; the flag result is identical to pre-Task-1.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Core/AuraState.lua
+git commit -m "$(cat <<'EOF'
+refactor(aurastate): widen isRaidInCombat to both helpful and harmful
+
+RAID_IN_COMBAT is a symmetric Blizzard filter modifier — both
+HELPFUL|RAID_IN_COMBAT and HARMFUL|RAID_IN_COMBAT are real filters.
+Prior harmful-only gate was B4-scoped; widening unlocks B3 Buffs,
+which uses HELPFUL|RAID_IN_COMBAT as its narrow default filter.
+
+isRaidDispellable stays harmful-only — RAID_PLAYER_DISPELLABLE is
+semantically harmful-only (dispelling applies to debuffs).
+
+Debuffs' raidCombat filter mode is unaffected — harmful auras still
+probe HARMFUL|RAID_IN_COMBAT and return identical results.
+
+Cost: one additional filter probe per helpful classify. Amortized
+across all helpful-side consumers (first one being B3 Buffs).
+
+Part of #115 UNIT_AURA fan-out rearchitecture (#139 prep).
+EOF
+)"
+```
+
+---
+
+## Task 2: Migrate `Elements/Auras/Buffs.lua` Update loop to classified path
+
+**Files:**
+- Modify: `Elements/Auras/Buffs.lua:128-211` (the aura-fetch + per-aura inner loop)
+
+- [ ] **Step 1: Read the current Update to confirm line ranges**
+
+Read `Elements/Auras/Buffs.lua:128-211`. Confirm:
+- `auraState` setup at lines 152-159 (UNIT_AURA / fullrefresh branch)
+- Filter + fetch at lines 160-161
+- Per-aura loop at lines 162-211 with spell-specific then track-all indicator matching
+
+If any ranges drifted, re-read before editing.
+
+- [ ] **Step 2: Replace the fetch + loop block with two-path classified / fallback**
+
+The existing block (lines 152-211):
+
+```lua
+	local auraState = self.FramedAuraState
+	if(auraState) then
+		if(event == 'UNIT_AURA') then
+			auraState:ApplyUpdateInfo(unit, updateInfo)
+		else
+			auraState:EnsureInitialized(unit)
+		end
+	end
+	local filter = element._buffFilter
+	local auras = auraState and auraState:GetHelpful(filter) or F.AuraCache.GetUnitAuras(unit, filter)
+	for _, auraData in next, auras do
+		local spellId = auraData.spellId
+		if(F.IsValueNonSecret(spellId)) then
+			local sourceUnit = auraData.sourceUnit
+			local annotated = false
+
+			-- Check spell-specific indicators
+			local indicatorIndices = spellLookup[spellId]
+			if(indicatorIndices) then
+				for _, idx in next, indicatorIndices do
+					local ind = indicators[idx]
+					if(passesCastByFilter(sourceUnit, ind._castBy)) then
+						-- Annotate auraData with renderer-expected field names
+						-- (non-conflicting keys: auraData has no .stacks/.dispelType/.unit)
+						if(not annotated) then
+							auraData.unit      = unit
+							auraData.stacks    = auraData.applications
+							auraData.dispelType = auraData.dispelName
+							annotated = true
+						end
+						if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
+							local list = iconsAurasPool[idx]
+							list[#list + 1] = auraData
+						elseif(not matchedPool[idx]) then
+							matchedPool[idx] = auraData
+						end
+					end
+				end
+			end
+
+			-- Check track-all indicators (empty spells list)
+			for _, idx in next, hasTrackAll do
+				local ind = indicators[idx]
+				if(passesCastByFilter(sourceUnit, ind._castBy)) then
+					if(not annotated) then
+						auraData.unit      = unit
+						auraData.stacks    = auraData.applications
+						auraData.dispelType = auraData.dispelName
+						annotated = true
+					end
+					if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
+						local list = iconsAurasPool[idx]
+						list[#list + 1] = auraData
+					elseif(not matchedPool[idx]) then
+						matchedPool[idx] = auraData
+					end
+				end
+			end
+		end
+	end
+```
+
+Replace with:
+
+```lua
+	local auraState = self.FramedAuraState
+	if(auraState) then
+		if(event == 'UNIT_AURA') then
+			auraState:ApplyUpdateInfo(unit, updateInfo)
+		else
+			auraState:EnsureInitialized(unit)
+		end
+	end
+
+	local classified   = auraState and auraState:GetHelpfulClassified()
+	local buffFilter   = element._buffFilter
+	local narrowFilter = buffFilter == 'HELPFUL|RAID_IN_COMBAT'
+
+	-- Inner loop helper: match one auraData against all indicators and
+	-- push into the appropriate pool. Factored out so classified and
+	-- fallback paths share the same matching logic byte-for-byte.
+	local function matchAura(auraData)
+		local spellId = auraData.spellId
+		if(not F.IsValueNonSecret(spellId)) then return end
+
+		local sourceUnit = auraData.sourceUnit
+		local annotated = false
+
+		-- Check spell-specific indicators
+		local indicatorIndices = spellLookup[spellId]
+		if(indicatorIndices) then
+			for _, idx in next, indicatorIndices do
+				local ind = indicators[idx]
+				if(passesCastByFilter(sourceUnit, ind._castBy)) then
+					if(not annotated) then
+						auraData.unit      = unit
+						auraData.stacks    = auraData.applications
+						auraData.dispelType = auraData.dispelName
+						annotated = true
+					end
+					if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
+						local list = iconsAurasPool[idx]
+						list[#list + 1] = auraData
+					elseif(not matchedPool[idx]) then
+						matchedPool[idx] = auraData
+					end
+				end
+			end
+		end
+
+		-- Check track-all indicators (empty spells list)
+		for _, idx in next, hasTrackAll do
+			local ind = indicators[idx]
+			if(passesCastByFilter(sourceUnit, ind._castBy)) then
+				if(not annotated) then
+					auraData.unit      = unit
+					auraData.stacks    = auraData.applications
+					auraData.dispelType = auraData.dispelName
+					annotated = true
+				end
+				if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
+					local list = iconsAurasPool[idx]
+					list[#list + 1] = auraData
+				elseif(not matchedPool[idx]) then
+					matchedPool[idx] = auraData
+				end
+			end
+		end
+	end
+
+	if(classified) then
+		for _, entry in next, classified do
+			local flags = entry.flags
+			if(not narrowFilter or flags.isRaidInCombat) then
+				matchAura(entry.aura)
+			end
+		end
+	else
+		-- Vestigial no-AuraState fallback. Every aura-tracking frame creates
+		-- AuraState via the idempotent Setup guard — preserved to match the
+		-- element-level pattern used across Auras/.
+		local auras = F.AuraCache.GetUnitAuras(unit, buffFilter)
+		for _, auraData in next, auras do
+			matchAura(auraData)
+		end
+	end
+```
+
+**Note on `matchAura` closure cost:** one closure allocation per Update per frame. This is fine at runtime — the alternative (inlining both paths) would duplicate ~40 lines of matching logic and be a maintenance hazard. If profiling later shows the closure as a hotspot, hoist it to a module-local function that takes the captured state as explicit parameters (`matchAura(auraData, unit, indicators, spellLookup, hasTrackAll, iconsAurasPool, matchedPool)`). Not worth doing preemptively.
+
+- [ ] **Step 3: Syntax check**
+
+Run: `luac -p Elements/Auras/Buffs.lua` if available. Otherwise visually scan the edited region:
+- `local function matchAura(auraData)` opens; closes before the `if(classified)` block
+- `if(classified) then ... else ... end` balanced
+- `narrowFilter` local declared once near the top
+- No stray duplicate `local auras = ...` outside the fallback branch
+
+- [ ] **Step 4: Grep for stale `GetHelpful(` calls**
+
+Run: `Grep -n "GetHelpful(" Elements/Auras/Buffs.lua`
+Expected: zero matches. The classified path uses `GetHelpfulClassified()`; fallback uses `F.AuraCache.GetUnitAuras`.
+
+Run: `Grep -n "computeBuffFilter\|_buffFilter" Elements/Auras/Buffs.lua`
+Expected: `computeBuffFilter` definition + two call sites (Rebuild + Setup); `_buffFilter` stored on the element in Rebuild + Setup + read in Update's `buffFilter` local. Unchanged count relative to pre-B3.
+
+- [ ] **Step 5: Confirm `passesCastByFilter` was not touched**
+
+Run: `Grep -n "function passesCastByFilter" Elements/Auras/Buffs.lua`
+Expected: exactly one match — the existing definition. Body bytes identical to pre-B3. This is the #113 fix; must not regress.
+
+Run: `Grep -n "passesCastByFilter(" Elements/Auras/Buffs.lua`
+Expected: two call sites (spell-specific + track-all), both inside `matchAura`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Elements/Auras/Buffs.lua
+git commit -m "$(cat <<'EOF'
+feat(buffs): migrate to AuraState classified API (B3 #139)
+
+Replace auraState:GetHelpful(filterString) fetch with
+GetHelpfulClassified() + narrow-filter gating on flags.isRaidInCombat
+when the effective filter would be HELPFUL|RAID_IN_COMBAT.
+
+Preserves:
+  - passesCastByFilter byte-identical (the #113 secret-sourceUnit fix)
+  - computeBuffFilter global widening semantics (any spell-list
+    indicator widens the whole element to HELPFUL)
+  - Annotation pattern (auraData.unit / .stacks / .dispelType)
+  - Per-indicator spell priority sort, renderer dispatch (7 types),
+    spell-lookup + track-all matching
+  - Vestigial no-AuraState fallback
+
+Matching logic factored into a local matchAura helper so classified
+and fallback paths share it. No behavior change relative to pre-B3
+for any castBy / filter / indicator combination.
+
+Follow-up (not in this PR): evaluate refining the secret-sourceUnit
+fallback with flags.isFromPlayerOrPet for castBy='me'. Deferred
+because it's a behavior change, not a migration.
+
+Part of #115 UNIT_AURA fan-out rearchitecture.
+EOF
+)"
+```
+
+- [ ] **Step 7: Push to working-testing**
+
+```bash
+git push origin working-testing
+```
+
+---
+
+## Task 3: Live smoke test — castBy matrix in LFR
+
+Buffs is the riskiest B-migration per #139. Test matrix must cover `castBy` × indicator-config × combat-state, with explicit attention to the #113 secret-sourceUnit regression mode.
+
+**Files:** None.
+
+- [ ] **Step 1: /reload in WoW**
+
+The addon folder is a symlink — edits to `Core/AuraState.lua` and `Elements/Auras/Buffs.lua` are already live. `/reload` to pick them up.
+
+- [ ] **Step 2: Sanity-check classified output**
+
+Run `/framed aurastate player` out of combat. Confirm helpful auras print `isRaidInCombat` in the flag list where appropriate (e.g., in-combat raid buffs should show it; flasks/racials should not). The flag is now present on helpful entries — earlier B4 builds only had it on harmful.
+
+- [ ] **Step 3: `castBy = 'me'` without spell list, in combat**
+
+Configure a Buffs indicator: `castBy = 'me'`, no `spells` list (track-all). Pull a mob and confirm your self-cast HoTs / shields / class buffs appear on your own frame during combat. The #113 regression would manifest as NOTHING showing up (secret sourceUnit → all auras silently filtered).
+
+**If nothing shows up:** `passesCastByFilter`'s secret-source over-match broke. Revert immediately and file a regression issue.
+
+- [ ] **Step 4: `castBy = 'me'` with spell list, in combat**
+
+Configure an indicator with specific tracked self-cast spells (e.g., your own HoT spellIDs). In combat, confirm tracked spells render. Because the filter widens to `HELPFUL` when any spell list is present, this indicator reaches the classified loop with `narrowFilter = false` — every helpful aura is considered, then spell-list matching narrows.
+
+- [ ] **Step 5: `castBy = 'me'` with spell list, out of combat**
+
+Cast a tracked spell on yourself out of combat. Confirm it renders. (This is the baseline sanity — sourceUnit is non-secret out of combat, so the fast path works.)
+
+- [ ] **Step 6: `castBy = 'others'` with spell list**
+
+Configure an indicator tracking a specific follower/party HoT (e.g., a druid's Rejuvenation spellID). Have a party member cast it on you out of combat — confirm it renders. Then pull, and confirm it continues to render in combat even when sourceUnit may be secret (the over-match in `passesCastByFilter` should still match 'others').
+
+- [ ] **Step 7: `castBy = 'others'` without spell list**
+
+Configure a track-all indicator with `castBy = 'others'`. Out of combat in a group, confirm party-applied buffs render (e.g., Fortitude, Arcane Intellect, follower HoTs). In combat — same set should render (with over-match on secret sources).
+
+- [ ] **Step 8: `castBy = 'anyone'` / `'all'`**
+
+Configure a track-all indicator with `castBy = 'anyone'` (or the legacy `'all'`). Confirm every raid-in-combat buff shows up when the indicator is the only one in the config (`narrowFilter = true`, flag-gated), and confirm cosmetic/flask buffs **don't** appear out of combat.
+
+Then add a second indicator with a spell list (e.g., your class's tracked spell). Reload. Now `narrowFilter = false` — confirm track-all indicator starts showing cosmetic/flask buffs (this is the documented widening trade-off). If it doesn't, the filter-widening semantics regressed.
+
+- [ ] **Step 9: Narrow-filter correctness — flasks / food / racials**
+
+With a track-all indicator and NO spell-list indicator in the config, out of combat: confirm flasks / food buffs / racial buffs do NOT render. This exercises `narrowFilter = true` + `flags.isRaidInCombat = false`.
+
+If flasks appear here: the narrow-filter gate is misbehaving. Debug via `/framed aurastate player` — confirm the flask aura's `isRaidInCombat` flag is false.
+
+- [ ] **Step 10: Renderer dispatch — one of each type**
+
+Configure indicators with different renderer types and confirm each renders:
+- `ICON` — a single tracked spell
+- `ICONS` — a track-all list with multiple auras sorted by priority
+- `BAR` — a duration-driven bar for a tracked spell
+- `BARS` — multi-bar list
+- `BORDER` — a border-glow indicator tied to a spell
+- `RECTANGLE` — a color block
+- `OVERLAY` — a health overlay
+
+Verify glows/colors/stacks/durations all look correct. No renderer-dispatch code changed in B3, but this confirms no downstream integration got disturbed by the loop rewrite.
+
+- [ ] **Step 11: Combat churn — full LFR pull**
+
+Run a full LFR pull. Watch BugSack / `/etrace` for Lua errors. Confirm:
+- Icons / bars appear and disappear cleanly as auras cycle
+- No flicker during UNIT_AURA bursts
+- Priority sort holds (spell-list indicators stay in configured order)
+- No orphaned renderers after buff drop-offs
+
+- [ ] **Step 12: Report findings**
+
+Post a brief summary covering each matrix cell (`me` / `others` / `anyone` × with/without spells × in/out of combat), narrow-filter correctness, and renderer types verified. Specifically call out: did the #113 secret-sourceUnit scenario still work (self-cast visibility in combat)?
+
+If ANY cell regresses, STOP and consult before Task 4. Per `feedback_aura_indicators_fragile` — don't paper over regressions.
+
+---
+
+## Task 4: Create PR (working-testing → working)
+
+Same pattern as B1 (#150), B2 (#147), B4 (#151).
+
+**Files:** None.
+
+- [ ] **Step 1: Confirm branch state**
+
+```bash
+git status
+```
+Expected: `On branch working-testing`, clean tree, up-to-date with origin.
+
+- [ ] **Step 2: Create the PR**
+
+```bash
+gh pr create --base working --head working-testing \
+  --title "B3 — migrate Buffs to AuraState classified API (#139)" \
+  --body "$(cat <<'EOF'
+## Summary
+- **B3 Buffs migrated to classified API** (#115, #139) — `Update` now iterates `auraState:GetHelpfulClassified()` with narrow-filter gating on `flags.isRaidInCombat` when the effective filter would be `HELPFUL|RAID_IN_COMBAT`. Per-aura spell-match + castBy logic factored into a local `matchAura` helper shared by classified and fallback paths.
+- **AuraState extension** — `isRaidInCombat` relaxed from harmful-only to both-sides (prefix-based probe), matching `isExternalDefensive` / `isImportant` / `isPlayerCast`. `RAID_IN_COMBAT` is a symmetric Blizzard filter modifier. `isRaidDispellable` stays harmful-only (dispelling is semantically harmful-only). B4 Debuffs' `raidCombat` mode is unaffected.
+- **#113 fix preserved exactly** — `passesCastByFilter` body is byte-identical; the secret-sourceUnit over-match still protects self-cast visibility in combat.
+
+## Preserved behavior
+- `computeBuffFilter` global widening (any spell-list indicator widens element-wide to `HELPFUL`)
+- Annotation pattern (`auraData.unit` / `.stacks` / `.dispelType`) — existing shared-reference hazard, not introduced by B3
+- Per-indicator spell priority sort
+- All 7 renderer types (`ICON` / `ICONS` / `BAR` / `BARS` / `BORDER` / `RECTANGLE` / `OVERLAY`)
+- Vestigial no-AuraState fallback
+
+## Test plan
+- [x] `castBy='me'` no spell list, in combat — self-casts visible (#113 scenario)
+- [x] `castBy='me'` with spell list, in+out of combat
+- [x] `castBy='others'` with spell list, in+out of combat
+- [x] `castBy='others'` no spell list, in group
+- [x] `castBy='anyone'` narrow filter, no cosmetic leak
+- [x] `castBy='anyone'` wide filter (mixed config), documented cosmetic-leak trade-off intact
+- [x] Flasks / food / racials hidden under narrow filter
+- [x] One of each renderer type renders correctly
+- [x] LFR pull — no Lua errors, no flicker
+
+## Follow-ups (not in this PR)
+- Evaluate refining the secret-sourceUnit fallback in `passesCastByFilter` using `flags.isFromPlayerOrPet` for `castBy='me'` (can reject sources that are definitively NOT a player/pet). Deferred because it's a behavior change, not a migration.
+- B5 MissingBuffs (#141) — final B-series element. Inverse filter, trickier shape.
+- Release cut bundling B1+B2+B4+B3 (and possibly B5) into the next alpha.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Report PR URL to user**
+
+Hand back for review + merge.
+
+---
+
+## Rollback strategy
+
+If B3 regresses:
+
+1. `git revert` Task 2's commit — Buffs reverts to the probe/filter-string path; #113 fix still in place (untouched).
+2. Optionally `git revert` Task 1's commit — the widened `isRaidInCombat` flag is inert if no consumer reads it (B4 Debuffs' usage is harmful-side only; relaxing to both sides doesn't change harmful-side results). Safe to leave in place.
+3. Other B-series migrations are unaffected.
+
+AuraState API surface stays append-only. No saved-variable migration required.
+
+---
+
+## Self-review
+
+- **Spec coverage:** #139 covers migrating Buffs.lua + preserving #113. Task 1 extends A1 for the narrow filter, Task 2 does the migration with `passesCastByFilter` untouched, Task 3 exercises the castBy matrix including the #113 regression mode, Task 4 opens the PR. ✓
+- **Placeholder scan:** No TBD / TODO / vague steps. Every step has code or concrete commands. ✓
+- **Type consistency:** `isRaidInCombat` spelled identically in AuraState Task 1, Buffs narrow-filter check (Task 2), and Debuffs' existing `raidCombat` dispatch. `narrowFilter` local used once per Update. `matchAura` closure captures match the variables used by its body. ✓
+- **Risk handling:** The riskiest parts (castBy semantics, narrow-filter widening) are flagged as "preserved exactly" with byte-identical code paths and explicit test cells that would catch regressions. Secret-source refinement is deferred, not silently included. ✓

--- a/docs/superpowers/plans/2026-04-22-b4-debuffs-classified.md
+++ b/docs/superpowers/plans/2026-04-22-b4-debuffs-classified.md
@@ -1,0 +1,573 @@
+# B4 — Debuffs Classified Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate `Elements/Auras/Debuffs.lua` to consume `auraState:GetHarmfulClassified()` via per-indicator flag dispatch, eliminating one server-filter fetch (plus a second for the dispellable double-pass) per indicator per UNIT_AURA.
+
+**Architecture:** Extend `Core/AuraState.lua` classify() with two harmful-only flags (`isRaidDispellable`, `isRaidInCombat`). Replace `updateIndicator`'s `auraState:GetHarmful(filterString)` call with a single `GetHarmfulClassified()` iteration dispatched via a pre-loop `flagKey` lookup. Preserve: the `encounter`-mode `IsEncounterInProgress` gate, the long-duration skip, the dispellable Physical/bleed double-pass, boss `bigIconSize`, and the `dispelName` coloring passed to `BorderIcon:SetAura`. Vestigial no-AuraState fallback keeps the current server-filter path.
+
+**Tech Stack:** Lua 5.1, oUF, `F.AuraState.GetHarmfulClassified`, `F.IsValueNonSecret`, `F.Indicators.BorderIcon`.
+
+---
+
+## Context
+
+### Current filter map (pre-B4)
+
+```lua
+local FILTER_MAP = {
+    all          = 'HARMFUL',
+    raid         = 'HARMFUL|RAID',
+    important    = 'HARMFUL|IMPORTANT',
+    dispellable  = 'HARMFUL|RAID_PLAYER_DISPELLABLE',
+    raidCombat   = 'HARMFUL|RAID_IN_COMBAT',
+    encounter    = 'HARMFUL|RAID',
+}
+```
+
+### Classified flag mapping
+
+| filterMode | Classified flag | New? |
+|------------|-----------------|------|
+| `all` | (no flag — all entries pass) | — |
+| `raid` | `flags.isRaid` | existing Tier 1 |
+| `important` | `flags.isImportant` | existing Tier 2 |
+| `dispellable` | `flags.isRaidDispellable` | **NEW** |
+| `raidCombat` | `flags.isRaidInCombat` | **NEW** |
+| `encounter` | `flags.isRaid` (gated on `IsEncounterInProgress`) | existing Tier 1 |
+
+Only two new flags. `raid` and `encounter` both read `flags.isRaid` — the encounter-mode difference is the `IsEncounterInProgress()` short-circuit already at the top of `updateIndicator`, which stays.
+
+### Preserved behavior (must not drift)
+
+1. **Boss bigIconSize** — `F.IsValueNonSecret(auraData.isBossAura) and auraData.isBossAura` inside `displayAura`. Boss auras render at `cfg.bigIconSize`; others at `cfg.iconSize`. Size affects running pixel offset.
+2. **Long-duration skip** — `dur == 0 or dur >= 600` guarded by `F.IsValueNonSecret`, filters flasks / permanent debuffs / racials from rendering in the primary pass.
+3. **Dispel-type coloring** — `auraData.dispelName` is passed as the 7th arg to `BorderIcon:SetAura`. `BorderIcon` uses this to drive the colored overlay (the fix that landed earlier for the dispel-type bug relies on it being passed here).
+4. **Red border** — `bi:SetBorderColor(1, 0, 0, 1)` inside `displayAura`; all debuffs use this color regardless of dispel type.
+5. **Dispellable + Physical/bleed double-pass** — `RAID_PLAYER_DISPELLABLE` excludes Physical/bleed debuffs from the server-side result. After the primary dispellable pass, a supplementary `HARMFUL|RAID`-equivalent iteration picks up auras whose `dispelName` is nil/empty/`'Physical'`. The supplementary pass passes `nil` for the dispelType (not `auraData.dispelName`) so the BorderIcon doesn't draw a dispel-color overlay for non-dispellable debuffs.
+6. **Per-indicator architecture** — one `FramedDebuffs` element has N named indicators, each with its own `_config` / `_pool` / `_container`. `Update` loops all indicators and calls `updateIndicator(self, unit, ind)` per indicator. That shape is unchanged.
+
+### Why only one fetch per indicator (not per filter)
+
+Before B4: each indicator calls `GetHarmful(filterString)`, which populates a view keyed by filter string. The helpful classified view is a single list — one populate, read from by any number of callers. After B4, `GetHarmfulClassified()` is fetched **once per indicator** (still technically re-populated per indicator on first access, but the classification cache is shared — only the view's list rebuild repeats if dirty). Further, since classification is cached per auraInstanceID, the second indicator's iteration on the same unit reuses the cached `entry` wrappers.
+
+Net: N indicators × M auras drops from `N × M × (1 probe chain resolving one filter string)` to `M probes once` (all classified-cached) + `N × M flag reads`. Flag reads are field lookups on a Lua table — ~free.
+
+### Fallback path (no AuraState)
+
+Vestigial but preserved, matching B1/B2. When `self.FramedAuraState` is nil, the element falls through to `F.AuraCache.GetUnitAuras(unit, filterString)` with the original server filter. All downstream logic (long-duration skip, dispellable double-pass, boss sizing) stays verbatim in the fallback branch.
+
+### New flag definitions (Task 1)
+
+Mirrors A1's `isBigDefensive` pattern — a harmful-only probe wrapped with `not isHelpful and ... or false`:
+
+```lua
+flags.isRaidDispellable = not isHelpful
+                          and IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|RAID_PLAYER_DISPELLABLE') == false
+                          or false
+flags.isRaidInCombat    = not isHelpful
+                          and IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|RAID_IN_COMBAT') == false
+                          or false
+```
+
+Harmful classify() goes from 3 probes (isExternalDefensive, isImportant, isPlayerCast) to 5. Helpful classify() unchanged.
+
+---
+
+## File Structure
+
+- **Modify:** `Core/AuraState.lua` — add two flags to `classify()` (lines 22-35 area).
+- **Modify:** `Elements/Auras/Debuffs.lua` — replace `updateIndicator` body with classified-path + vestigial fallback.
+
+No new files. No changes to `Core/AuraCache.lua`, `F.AuraState.GetHarmful*`, or `BorderIcon`.
+
+---
+
+## Task 1: Add `isRaidDispellable` and `isRaidInCombat` flags to AuraState.classify()
+
+**Files:**
+- Modify: `Core/AuraState.lua:18-38` (the `classify` function)
+
+- [ ] **Step 1: Read the current classify() to confirm no drift**
+
+Read `Core/AuraState.lua` lines 18-38 to confirm the probe block still starts at line 30 with `flags.isExternalDefensive`. If the file has drifted, re-read before editing.
+
+- [ ] **Step 2: Add the two new flags after `isBigDefensive`**
+
+Edit `Core/AuraState.lua`. The existing block (lines 30-35):
+
+```lua
+	flags.isExternalDefensive = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|EXTERNAL_DEFENSIVE') == false
+	flags.isImportant         = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|IMPORTANT')          == false
+	flags.isPlayerCast        = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|PLAYER')             == false
+	flags.isBigDefensive      = isHelpful
+	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HELPFUL|BIG_DEFENSIVE') == false
+	                            or false
+```
+
+Becomes:
+
+```lua
+	flags.isExternalDefensive = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|EXTERNAL_DEFENSIVE') == false
+	flags.isImportant         = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|IMPORTANT')          == false
+	flags.isPlayerCast        = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|PLAYER')             == false
+	flags.isBigDefensive      = isHelpful
+	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HELPFUL|BIG_DEFENSIVE') == false
+	                            or false
+	flags.isRaidDispellable   = not isHelpful
+	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|RAID_PLAYER_DISPELLABLE') == false
+	                            or false
+	flags.isRaidInCombat      = not isHelpful
+	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|RAID_IN_COMBAT') == false
+	                            or false
+```
+
+- [ ] **Step 3: Verify the probes only fire for harmful auras**
+
+Grep the section to confirm:
+
+Run: `Grep -n "isRaidDispellable\|isRaidInCombat" Core/AuraState.lua`
+Expected: two matches, each under `not isHelpful and ... or false`.
+
+No changes needed to the `/framed aurastate` slash handler — `Init.lua:431-439`'s `formatFlags` enumerates `flags` dynamically (`for k, v in next, flags do`), so new flag keys appear automatically. Slash-output flag names will be the camelCase Lua keys (`isRaidDispellable`, `isRaidInCombat`), matching the existing `isExternalDefensive` / `isImportant` / etc. style.
+
+- [ ] **Step 4: Syntax check**
+
+Run: `luac -p Core/AuraState.lua` if luac is available locally. If not, visually scan the edited region and confirm:
+- Each `flags.X = ...` statement ends on its own line
+- `and` / `or` precedence matches the existing `isBigDefensive` pattern
+- No stray trailing commas (these are assignments, not a table literal)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Core/AuraState.lua
+git commit -m "$(cat <<'EOF'
+feat(aurastate): add isRaidDispellable + isRaidInCombat flags
+
+Mirrors the isBigDefensive helpful-only pattern on the harmful side —
+probes HARMFUL|RAID_PLAYER_DISPELLABLE and HARMFUL|RAID_IN_COMBAT once
+per aura per generation, cached on the classified entry.
+
+Consumed by B4 Debuffs (#140) to dispatch filter modes via flag reads
+instead of re-fetching per-filter server-side aura slices.
+
+Helpful classify() unchanged — both flags short-circuit to false when
+isHelpful is true.
+
+Part of #115 UNIT_AURA fan-out rearchitecture.
+EOF
+)"
+```
+
+---
+
+## Task 2: Migrate `Elements/Auras/Debuffs.lua` updateIndicator to classified path
+
+**Files:**
+- Modify: `Elements/Auras/Debuffs.lua` — `updateIndicator` function (lines 82-146)
+
+- [ ] **Step 1: Read the current file to confirm line ranges**
+
+Read `Elements/Auras/Debuffs.lua` lines 82-146. Confirm `updateIndicator` still has the FILTER_MAP lookup at line 103, the `GetHarmful(filter)` call at line 105, the primary loop at lines 113-123, and the dispellable double-pass at lines 128-140. If any of these ranges drifted, re-read the file before editing.
+
+- [ ] **Step 2: Replace `updateIndicator` body with two-path classified / fallback structure**
+
+Open `Elements/Auras/Debuffs.lua`. The current `updateIndicator` body (lines 82-146):
+
+```lua
+local function updateIndicator(self, unit, ind)
+	local cfg = ind._config
+	local maxDisplayed = cfg.maxDisplayed
+
+	-- Backward compat: map old boolean to new filterMode
+	local filterMode = cfg.filterMode
+	if(not filterMode and cfg.onlyDispellableByMe) then
+		filterMode = 'dispellable'
+	end
+
+	-- Encounter mode: only show during active boss encounters
+	if(filterMode == 'encounter') then
+		if(not C_InstanceEncounter or not C_InstanceEncounter.IsEncounterInProgress
+			or not C_InstanceEncounter.IsEncounterInProgress()) then
+			for idx = 1, #ind._pool do
+				ind._pool[idx]:Clear()
+			end
+			return
+		end
+	end
+
+	local filter = FILTER_MAP[filterMode] or 'HARMFUL'
+	local auraState = self.FramedAuraState
+	local rawAuras = auraState and auraState:GetHarmful(filter) or F.AuraCache.GetUnitAuras(unit, filter)
+	local pool = ind._pool
+
+	-- Single-pass: filter and display directly from auraData.
+	-- auraInstanceID is NeverSecret; BorderIcon.SetAura uses C-level APIs
+	-- for secret fields (icon, duration, etc.).
+	local displayed = 0
+	local runOffset = 0
+	for _, auraData in next, rawAuras do
+		if(displayed >= maxDisplayed) then break end
+
+		local dur = auraData.duration
+		local skip = F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)
+
+		if(not skip) then
+			displayed = displayed + 1
+			runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, auraData.dispelName)
+		end
+	end
+
+	-- When filterMode is 'dispellable', also include Physical/bleed debuffs
+	-- from a broader HARMFUL|RAID query (RAID_PLAYER_DISPELLABLE excludes them).
+	-- Supplementary results appear after the server-sorted dispellable set.
+	if(filterMode == 'dispellable' and displayed < maxDisplayed) then
+		local raidAuras = auraState and auraState:GetHarmful('HARMFUL|RAID') or F.AuraCache.GetUnitAuras(unit, 'HARMFUL|RAID')
+		for _, auraData in next, raidAuras do
+			if(displayed >= maxDisplayed) then break end
+
+			local dn = auraData.dispelName
+			local isPhysical = F.IsValueNonSecret(dn) and (not dn or dn == '' or dn == 'Physical')
+			if(isPhysical) then
+				displayed = displayed + 1
+				runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, nil)
+			end
+		end
+	end
+
+	-- Hide pool entries beyond active count
+	for idx = displayed + 1, #pool do
+		pool[idx]:Clear()
+	end
+end
+```
+
+Replace with:
+
+```lua
+local function updateIndicator(self, unit, ind)
+	local cfg = ind._config
+	local maxDisplayed = cfg.maxDisplayed
+	local pool = ind._pool
+
+	-- Backward compat: map old boolean to new filterMode
+	local filterMode = cfg.filterMode
+	if(not filterMode and cfg.onlyDispellableByMe) then
+		filterMode = 'dispellable'
+	end
+
+	-- Encounter mode: only show during active boss encounters
+	if(filterMode == 'encounter') then
+		if(not C_InstanceEncounter or not C_InstanceEncounter.IsEncounterInProgress
+			or not C_InstanceEncounter.IsEncounterInProgress()) then
+			for idx = 1, #pool do
+				pool[idx]:Clear()
+			end
+			return
+		end
+	end
+
+	local auraState  = self.FramedAuraState
+	local classified = auraState and auraState:GetHarmfulClassified()
+
+	local displayed = 0
+	local runOffset = 0
+
+	if(classified) then
+		-- Dispatch filter mode to a single flag key (nil = match all).
+		-- encounter mode uses the same flag as raid — the IsEncounterInProgress
+		-- gate above already short-circuits the no-encounter case.
+		local flagKey
+		if(filterMode == 'raid' or filterMode == 'encounter') then flagKey = 'isRaid'
+		elseif(filterMode == 'important')   then flagKey = 'isImportant'
+		elseif(filterMode == 'dispellable') then flagKey = 'isRaidDispellable'
+		elseif(filterMode == 'raidCombat')  then flagKey = 'isRaidInCombat'
+		end
+
+		for _, entry in next, classified do
+			if(displayed >= maxDisplayed) then break end
+
+			local flags = entry.flags
+			if(not flagKey or flags[flagKey]) then
+				local auraData = entry.aura
+				local dur = auraData.duration
+				local skip = F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)
+				if(not skip) then
+					displayed = displayed + 1
+					runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, auraData.dispelName)
+				end
+			end
+		end
+
+		-- Dispellable supplementary pass: RAID_PLAYER_DISPELLABLE excludes
+		-- Physical/bleeds, so iterate raid-flagged entries and include any
+		-- whose dispelName is nil/empty/Physical. Pass nil dispelType — these
+		-- aren't dispellable, no overlay color.
+		if(filterMode == 'dispellable' and displayed < maxDisplayed) then
+			for _, entry in next, classified do
+				if(displayed >= maxDisplayed) then break end
+
+				local flags = entry.flags
+				if(flags.isRaid) then
+					local auraData = entry.aura
+					local dn = auraData.dispelName
+					local isPhysical = F.IsValueNonSecret(dn) and (not dn or dn == '' or dn == 'Physical')
+					if(isPhysical) then
+						displayed = displayed + 1
+						runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, nil)
+					end
+				end
+			end
+		end
+	else
+		-- Vestigial no-AuraState fallback. Every aura-tracking frame creates
+		-- AuraState via the idempotent Setup guard — preserved to match the
+		-- element-level pattern used across Auras/.
+		local filter = FILTER_MAP[filterMode] or 'HARMFUL'
+		local rawAuras = F.AuraCache.GetUnitAuras(unit, filter)
+
+		for _, auraData in next, rawAuras do
+			if(displayed >= maxDisplayed) then break end
+
+			local dur = auraData.duration
+			local skip = F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)
+
+			if(not skip) then
+				displayed = displayed + 1
+				runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, auraData.dispelName)
+			end
+		end
+
+		if(filterMode == 'dispellable' and displayed < maxDisplayed) then
+			local raidAuras = F.AuraCache.GetUnitAuras(unit, 'HARMFUL|RAID')
+			for _, auraData in next, raidAuras do
+				if(displayed >= maxDisplayed) then break end
+
+				local dn = auraData.dispelName
+				local isPhysical = F.IsValueNonSecret(dn) and (not dn or dn == '' or dn == 'Physical')
+				if(isPhysical) then
+					displayed = displayed + 1
+					runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, nil)
+				end
+			end
+		end
+	end
+
+	-- Hide pool entries beyond active count
+	for idx = displayed + 1, #pool do
+		pool[idx]:Clear()
+	end
+end
+```
+
+- [ ] **Step 3: Syntax check**
+
+Run: `luac -p Elements/Auras/Debuffs.lua` if luac is available. Otherwise visually confirm:
+- `if(classified) then ... else ... end` block is balanced
+- Both branches close with `end` before the `-- Hide pool entries` trailing loop
+- No duplicate `local pool = ind._pool` (moved to the top)
+- `flagKey` lookup uses `elseif` chain (not `elif` or `else if`)
+
+- [ ] **Step 4: Grep for orphaned GetHarmful(filter) calls**
+
+Run: `Grep -n "GetHarmful(" Elements/Auras/Debuffs.lua`
+Expected: zero matches (all replaced with classified path or removed; the fallback uses `F.AuraCache.GetUnitAuras`).
+
+Run: `Grep -n "FILTER_MAP" Elements/Auras/Debuffs.lua`
+Expected: two matches — the table definition at line 13 and the fallback lookup inside the `else` branch. If >2, there's a stale classified-path reference; revisit.
+
+- [ ] **Step 5: Confirm preserved invariants via grep**
+
+Run: `Grep -n "bigIconSize\|isBossAura" Elements/Auras/Debuffs.lua`
+Expected: the existing `displayAura` references (lines ~29, ~51) — unchanged.
+
+Run: `Grep -n "dispelName" Elements/Auras/Debuffs.lua`
+Expected: three matches — primary render pass, double-pass Physical check, and `displayAura`'s `dispelType` parameter pass-through to `BorderIcon:SetAura`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Elements/Auras/Debuffs.lua
+git commit -m "$(cat <<'EOF'
+feat(debuffs): migrate to AuraState classified API (B4 #140)
+
+Replace per-indicator GetHarmful(filterString) + server-filter fetch
+with a single GetHarmfulClassified() iteration dispatched via a
+flagKey lookup. Filter modes map:
+
+  all          → no flag predicate
+  raid         → flags.isRaid
+  important    → flags.isImportant
+  dispellable  → flags.isRaidDispellable
+  raidCombat   → flags.isRaidInCombat
+  encounter    → flags.isRaid (gated on IsEncounterInProgress)
+
+Dispellable + Physical/bleed double-pass becomes a second loop over
+the same classified list, filtering on flags.isRaid + isPhysical
+dispelName check — same behavior, no extra fetch.
+
+Boss bigIconSize, long-duration skip, dispel-type coloring, red
+border, per-indicator architecture all preserved.
+
+Vestigial no-AuraState fallback keeps the original server-filter
+path for consistency with B1/B2.
+
+Part of #115 UNIT_AURA fan-out rearchitecture.
+EOF
+)"
+```
+
+- [ ] **Step 7: Push to working-testing**
+
+```bash
+git push origin working-testing
+```
+
+Per `feedback_commit_after_task`: push after each task to prevent crash data loss.
+
+---
+
+## Task 3: Live smoke test in LFR
+
+Framed has no automated test harness; verification is in-game per `feedback_coding_standards` and the spec's "Testing Strategy" section.
+
+**Files:** None.
+
+- [ ] **Step 1: /reload in WoW**
+
+The addon folder is a symlink (per `feedback_wow_sync`), so edits to `Core/AuraState.lua` and `Elements/Auras/Debuffs.lua` are already live. `/reload` to pick them up.
+
+- [ ] **Step 2: Verify new flags via `/framed aurastate target`**
+
+Target a raid member with a harmful debuff (any dungeon trash target works). Run `/framed aurastate target`. Confirm the HARMFUL section's printed flags for each aura include the new entries (`isRaidDispellable`, `isRaidInCombat`) when applicable. Flag names appear as the raw camelCase Lua keys per the handler's dynamic `formatFlags` loop.
+
+If neither appears in the output and you know the target has a dispellable debuff, the Task 1 flag addition didn't land — revisit.
+
+- [ ] **Step 3: `all` filter mode**
+
+Configure one Debuffs indicator with `filterMode = 'all'` (this is the default). Target a dummy with several debuffs applied. **Expected:** every debuff renders, respecting `maxDisplayed`, sorted by Blizzard's default harmful order. Long-duration debuffs (if any) are skipped.
+
+- [ ] **Step 4: `raid` filter mode**
+
+Configure an indicator with `filterMode = 'raid'`. In LFR during a pull, confirm only raid-flagged debuffs render (boss mechanics, DoTs cast by bosses on raid members). Trivial self-inflicted debuffs (e.g. hunger, class-internal markers) should NOT appear.
+
+- [ ] **Step 5: `important` filter mode**
+
+Configure an indicator with `filterMode = 'important'`. During an encounter, confirm only debuffs Blizzard flags IMPORTANT render — typically stuns, silences, and mechanics that require reaction.
+
+- [ ] **Step 6: `dispellable` filter mode + Physical/bleed double-pass**
+
+Configure an indicator with `filterMode = 'dispellable'`. As a healer or dispel-capable class in LFR, confirm:
+- Magic / Curse / Poison / Disease debuffs render (if dispellable by your class/spec)
+- Physical/bleed debuffs also render after the dispellable set (no dispel-color overlay — `dispelType` is nil for these)
+- Red border on all debuffs regardless of dispel type
+
+If only dispellable debuffs render and no physical/bleeds: the double-pass didn't fire. Check Step 2's `/framed aurastate` output to confirm `raid` flag appears on Physical debuffs.
+
+- [ ] **Step 7: `raidCombat` filter mode**
+
+Configure an indicator with `filterMode = 'raidCombat'`. Enter combat and confirm raid-important-in-combat debuffs render. Out of combat, the indicator should empty out.
+
+- [ ] **Step 8: `encounter` filter mode**
+
+Configure an indicator with `filterMode = 'encounter'`. Before a boss pull, confirm the indicator is empty. Start the encounter — raid-flagged debuffs render. Encounter ends — indicator clears. This exercises both the `IsEncounterInProgress` gate and the `flags.isRaid` match.
+
+- [ ] **Step 9: Boss bigIconSize**
+
+During an encounter where a boss aura is applied (any LFR boss with a boss-flagged mechanic), confirm that boss auras render at `cfg.bigIconSize` (visually larger than other icons). The running pixel offset advances by the bigger size for that slot; subsequent icons don't overlap.
+
+- [ ] **Step 10: Dispel-type coloring**
+
+Confirm that Magic debuffs show the magic-colored overlay, Curses the curse-colored overlay, etc. This verifies `auraData.dispelName` is still passed to `BorderIcon:SetAura` (and the color curve infrastructure we use for dispel coloring still runs).
+
+If all debuffs appear without a dispel-color overlay: the `displayAura` call is passing `nil` where it should pass `auraData.dispelName`. Revisit Task 2's primary render pass.
+
+- [ ] **Step 11: Combat churn — 5-man or raid pull**
+
+Run a full LFR pull with multiple debuffs cycling. Watch for:
+- No Lua errors in `/etrace` or BugSack
+- Icons appear/disappear cleanly as debuffs come and go
+- No orphaned icons after debuffs expire
+- No flicker during UNIT_AURA bursts
+
+- [ ] **Step 12: Report findings to user**
+
+Post a brief summary confirming each filter mode renders correctly, boss sizing works, dispel-type coloring is preserved, and no regressions observed in a combat session.
+
+If any step reveals a regression, STOP, do not proceed to Task 4, and consult the user. Per `feedback_aura_indicators_fragile`: indicator rendering is fragile and easy to break; any visual regression must be investigated, not papered over.
+
+---
+
+## Task 4: Create PR (working-testing → working)
+
+Follows the same pattern used for B1 (PR #150) and B2 (PR #147). Per `project_framed_worktree`: working-testing → working for dev promotion; the release cut (TOC bump + CHANGELOG entry + working → main) comes later when multiple B-migrations batch into a single version.
+
+**Files:** None.
+
+- [ ] **Step 1: Confirm branch is pushed and clean**
+
+```bash
+git status
+```
+Expected: `On branch working-testing`, `nothing to commit, working tree clean`, `Your branch is up to date with 'origin/working-testing'`.
+
+If not up to date, push before creating the PR.
+
+- [ ] **Step 2: Create the PR**
+
+```bash
+gh pr create --base working --head working-testing \
+  --title "B4 — migrate Debuffs to AuraState classified API (#140)" \
+  --body "$(cat <<'EOF'
+## Summary
+- **B4 Debuffs migrated to classified API** (#115, #140) — `updateIndicator` now iterates `auraState:GetHarmfulClassified()` once per indicator and dispatches filter modes via a single `flagKey` lookup. Eliminates the per-indicator `GetHarmful(filterString)` fetch + the dispellable double-pass's separate `HARMFUL|RAID` fetch.
+- **AuraState extension** — `classify()` gains two harmful-only flags: `isRaidDispellable` (HARMFUL|RAID_PLAYER_DISPELLABLE) and `isRaidInCombat` (HARMFUL|RAID_IN_COMBAT). Mirrors the helpful-side `isBigDefensive` short-circuit pattern; helpful classify() unchanged.
+- Behavior preserved: boss bigIconSize, long-duration skip, dispel-type coloring, red border, dispellable + Physical/bleed double-pass, per-indicator architecture.
+
+## Test plan
+- [x] `/framed aurastate target` prints `isRaidDispellable` / `isRaidInCombat` flags for harmful auras
+- [x] `all` mode — all debuffs render, long-duration skip preserved
+- [x] `raid` mode — raid-flagged debuffs only
+- [x] `important` mode — IMPORTANT-flagged debuffs only
+- [x] `dispellable` mode — dispellable debuffs plus Physical/bleed double-pass
+- [x] `raidCombat` mode — raid-in-combat debuffs only
+- [x] `encounter` mode — `IsEncounterInProgress` gate works, raid-flagged debuffs render during encounter
+- [x] Boss bigIconSize renders during encounter boss auras
+- [x] Dispel-type color overlay preserved (magic / curse / poison / disease / bleed)
+- [x] No Lua errors during LFR combat churn
+
+## Follow-ups
+- B3 Buffs (#139) — castBy flag still needs design (harmful + helpful `isFromPlayerOrPet` may not be a 1:1 substitute)
+- B5 MissingBuffs (#141) — trickier because it's an inverse filter
+- Release cut bundling B1+B2+B4 (and possibly B3/B5) into the next alpha version
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Report PR URL to user**
+
+Hand back to the user for review + merge. Do not attempt to merge yourself.
+
+---
+
+## Rollback strategy
+
+If B4 introduces a regression that needs urgent revert:
+
+1. `git revert` the Task 2 commit (Debuffs migration) — removes the classified-path consumer.
+2. Optionally `git revert` the Task 1 commit (AuraState flags) — the new flags are inert if no consumer reads them, so leaving them in place is safe and they'll be reused by future work.
+3. Other B-series elements (B1 Externals, B2 Defensives) are unaffected — they read different helpful-side flags.
+
+AuraState's API surface remains append-only after rollback. No cache or saved-variable migration required.
+
+---
+
+## Self-review (completed before plan ships)
+
+- **Spec coverage:** #140 covers migrating Debuffs.lua + harmful-side classification extension. Task 1 adds the flags; Task 2 migrates the element; Task 3 smoke-tests all 6 filter modes + the preserved behaviors called out in the issue. ✓
+- **Placeholder scan:** No TBD / TODO / vague "handle edge cases" — every step has concrete code or concrete commands. ✓
+- **Type consistency:** Flag names match across Task 1 definition (`isRaidDispellable` / `isRaidInCombat`) and Task 2 dispatch (`flags.isRaidDispellable` / `flags.isRaidInCombat`). `flagKey` values are string literals matching the flag names. `FILTER_MAP` keys match `filterMode` check branches. ✓
+- **Fallback parity:** No-AuraState branch uses `F.AuraCache.GetUnitAuras(unit, filter)` with the original `FILTER_MAP` string — same as pre-B4 behavior. ✓

--- a/docs/superpowers/plans/2026-04-22-b5-missingbuffs-classified.md
+++ b/docs/superpowers/plans/2026-04-22-b5-missingbuffs-classified.md
@@ -1,0 +1,151 @@
+# B5 — MissingBuffs Classified Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Switch `Elements/Auras/MissingBuffs.lua` from `AuraState:GetHelpful('HELPFUL')` to `AuraState:GetHelpfulClassified()` so every helpful-side B-series element consumes the same slice.
+
+**Architecture:** MissingBuffs is spellID set-membership, not classification filtering — it reads `auraData.spellId` and `auraData.name`, never any flag. The migration peels the `aura` field out of each classified entry inside `auraListHasBuff`. No flag use, no behavior change.
+
+**Tech Stack:** WoW 12.0.x Lua, embedded oUF, Framed AuraState.
+
+**Part of:** #115 UNIT_AURA fan-out rearchitecture, closes #141.
+
+---
+
+## Task 1: Migrate MissingBuffs.lua to classified path
+
+**Files:**
+- Modify: `Elements/Auras/MissingBuffs.lua:111-122` (auraListHasBuff helper)
+- Modify: `Elements/Auras/MissingBuffs.lua:195` (auraState read)
+
+- [ ] **Step 1: Rewrite `auraListHasBuff` to accept classified entries**
+
+The helper currently iterates auraData objects directly. Switch the loop to read `entry.aura`. Keep the name-fallback logic for secret-spellId cases.
+
+Current (lines 111-122):
+
+```lua
+local function auraListHasBuff(rawAuras, targetSpellId)
+	local targetName = ensureCached(targetSpellId)
+	for _, auraData in next, rawAuras do
+		local sid = auraData.spellId
+		if(F.IsValueNonSecret(sid) and sid == targetSpellId) then return true end
+		if(targetName) then
+			local n = auraData.name
+			if(F.IsValueNonSecret(n) and n == targetName) then return true end
+		end
+	end
+	return false
+end
+```
+
+Replace with:
+
+```lua
+-- Scan classified entries for a matching buff. Accepts either
+-- classified entries ({ aura, flags }) or raw aura objects — the
+-- fallback path still feeds raw auras when AuraState is unavailable.
+local function auraListHasBuff(auras, targetSpellId)
+	local targetName = ensureCached(targetSpellId)
+	for _, item in next, auras do
+		local auraData = item.aura or item
+		local sid = auraData.spellId
+		if(F.IsValueNonSecret(sid) and sid == targetSpellId) then return true end
+		if(targetName) then
+			local n = auraData.name
+			if(F.IsValueNonSecret(n) and n == targetName) then return true end
+		end
+	end
+	return false
+end
+```
+
+The `item.aura or item` form keeps the fallback path (which passes raw auras from `C_UnitAuras.GetUnitAuras`) working without branching at the call site.
+
+- [ ] **Step 2: Swap the auraState read**
+
+Current (line 195):
+
+```lua
+local rawAuras = auraState and auraState:GetHelpful('HELPFUL') or C_UnitAuras.GetUnitAuras(unit, 'HELPFUL')
+```
+
+Replace with:
+
+```lua
+local auras = auraState and auraState:GetHelpfulClassified()
+	or C_UnitAuras.GetUnitAuras(unit, 'HELPFUL')
+```
+
+Rename `rawAuras` → `auras` at the call site on line 206:
+
+```lua
+elseif(providingClass and groupClasses[providingClass] and not auraListHasBuff(auras, spellId)) then
+```
+
+- [ ] **Step 3: Verify no other consumers of `rawAuras`**
+
+Run: `grep -n rawAuras Elements/Auras/MissingBuffs.lua`
+
+Expected: no matches (the only reference outside the Update function was in the `auraListHasBuff` signature, which we already updated).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Elements/Auras/MissingBuffs.lua
+git commit -m "refactor(MissingBuffs): migrate to classified aura path (#141)"
+git push
+```
+
+---
+
+## Task 2: LFR smoke test
+
+- [ ] **Step 1: `/reload` in-game**
+
+Verify no errors on load.
+
+- [ ] **Step 2: Verify missing-buff detection**
+
+In a group (party or LFR) where multiple buff-providing classes are present:
+- Missing icons for classes present in group should glow/appear.
+- Apply the buff (e.g. Arcane Intellect) → icon should disappear next UNIT_AURA.
+- Remove the buff → icon should reappear.
+
+- [ ] **Step 3: Verify hidden-state cases**
+
+- Dead/ghost unit → all slots hidden.
+- Pet unit → all slots hidden.
+- NPC follower unit (delve): only own-class buff icon should be visible; other classes hidden (pre-existing NPC-secret-aura behavior).
+
+- [ ] **Step 4: Report back**
+
+User confirms smoke passes before opening PR.
+
+---
+
+## Task 3: Open PR
+
+- [ ] **Step 1: Open working-testing → working PR**
+
+```bash
+gh pr create --base working --head working-testing \
+  --title "B5 — migrate MissingBuffs to AuraState classified API (#141)" \
+  --body "..."
+```
+
+PR body should cover:
+- One-line migration (swap `GetHelpful('HELPFUL')` → `GetHelpfulClassified()`, peel `entry.aura` in helper).
+- No behavior change. Fallback path unchanged.
+- Closes #141.
+- Test plan reflects Task 2 steps.
+
+---
+
+## Self-review checklist
+
+- [x] Every spec step has actual code, not placeholder text.
+- [x] `item.aura or item` form preserves the fallback path (C_UnitAuras raw auras) without call-site branching.
+- [x] No flag reads (MissingBuffs never consumed classification flags — the classified view is used purely for slice consistency).
+- [x] No other call sites reference `rawAuras` or the old helper signature.
+- [x] Task ordering: migration → user-run smoke → PR, matching B1/B2/B3/B4 pattern.

--- a/docs/superpowers/plans/2026-04-22-buffs-annotation-cleanup.md
+++ b/docs/superpowers/plans/2026-04-22-buffs-annotation-cleanup.md
@@ -829,39 +829,15 @@ Or via `gh pr view <number> --web`.
 
 Share the PR URL. User reviews → merges `working-testing` → `working` → promotes to `main` on release cadence.
 
-- [ ] **Step 5: File the cf7fabb GitHub issue (if not already filed)**
+- [ ] **Step 5: Verify #167 is linked in the PR body**
 
-The spec's `**Issue:** TBD` front-matter entry should now point at a real issue. Create one if none exists:
-
-```bash
-gh issue create --title "Memory regression in idle party/raid introduced by cf7fabb" --body "$(cat <<'EOF'
-## Summary
-
-cf7fabb (`refactor(buffs): derive aura filter from indicator set, drop buffFilterMode`) introduced a measurable idle memory growth rate in party/raid when any buff indicator has a non-empty `spells` list.
-
-## Mechanism
-
-`computeBuffFilter` widens the helpful-aura query from `HELPFUL|RAID_IN_COMBAT` to plain `HELPFUL` whenever any enabled indicator tracks specific spells. With the wider filter, Blizzard's server-side stripping of Fort / Int / cosmetic / consumable / world buffs no longer applies, and those auras flow through Framed's `matchAura` every `UNIT_AURA` tick. Inside `matchAura`, each matched aura was mutated with three Framed-owned keys — suspected retention mechanism.
-
-## Fix
-
-PR #<this-pr>: stop mutating AuraData tables in `matchAura`. Readers migrated to `aura.applications` and the existing `unit` closure local. If idle growth persists after this lands, the follow-up is to restore `buffFilterMode` as explicit user config (Option A).
-
-## Bisect
-
-- Regression first reproduces on cf7fabb (HEAD-solo vs cf7fabb-solo measured identical, so the widened filter is the sole differential).
-- User's SavedVariables had 5 custom indicators with `spells = { 774 }` (Rejuvenation) triggering the widened filter on party frames.
-EOF
-)"
-```
-
-Then edit the spec's header to replace `**Issue:** TBD` with the real issue number, and commit that in a small follow-up:
+The cf7fabb regression issue was filed ahead of plan execution as #167, and the spec's header already points at it. Confirm the PR body mentions `Fixes #167` or `Closes #167` so merging the PR auto-closes the issue. If not, edit the PR:
 
 ```bash
-git add docs/superpowers/specs/2026-04-22-buffs-annotation-cleanup-design.md
-git commit -m "Link cf7fabb regression issue in Buffs annotation cleanup spec"
-git push origin working-testing
+gh pr edit <pr-number> --body "$(gh pr view <pr-number> --json body --jq .body)"$'\n\nFixes #167'
 ```
+
+No issue-filing step required here — it already exists.
 
 ---
 

--- a/docs/superpowers/plans/2026-04-22-buffs-annotation-cleanup.md
+++ b/docs/superpowers/plans/2026-04-22-buffs-annotation-cleanup.md
@@ -1,0 +1,876 @@
+# Buffs AuraData Annotation Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Per user preference (`feedback_inline_execution`), Framed plans execute inline rather than subagent-driven.
+
+**Goal:** Stop mutating Blizzard's `AuraData` tables inside `Elements/Auras/Buffs.lua`'s `matchAura` closure. Update every downstream reader (5 sites across 3 files) to source the same values from native Blizzard fields (`aura.applications`) and from the existing `unit` closure local. Drop the unused `dispelType` plumbing from the Buffs rendering path entirely.
+
+**Architecture:** `matchAura` currently writes three Framed-owned keys onto every matched `AuraData` (`.unit`, `.stacks`, `.dispelType`). With cf7fabb's widened filter, that mutation now runs on every helpful aura every `UNIT_AURA` tick — including cosmetic/consumable/world buffs Blizzard previously stripped server-side — suspected as the retention mechanism behind the idle party/raid memory regression. The fix routes renderers to read `aura.applications` directly (the Blizzard-native name for the same integer), passes `unit` via parameter where needed, and deletes the two annotation blocks once every reader has been migrated.
+
+**Tech Stack:** Lua (WoW 12.0.x client API), `C_UnitAuras` AuraData struct (`.applications`, `.dispelName`, `.auraInstanceID`).
+
+**Spec:** `docs/superpowers/specs/2026-04-22-buffs-annotation-cleanup-design.md`
+
+**Branch:** `working-testing` (Framed's single-workspace convention — PRs merge `working-testing` → `working`). Lands as a separate PR after the FullRefresh varargs PR (#155 item 3) merges, to keep MemDiag A/B attribution between the two allocation sources separable.
+
+---
+
+## File Structure
+
+**Modify:** `Elements/Indicators/Icons.lua`
+- Add `unit` as first parameter to `IconsMethods:SetIcons`.
+- Update the `icon:SetSpell` call inside the loop to read the `unit` param (not `aura.unit`), read `aura.applications` (not `aura.stacks`), and drop the `aura.dispelType` argument.
+- Drop the `dispelType` entry from the LuaDoc `@param auraList` comment.
+
+**Modify:** `Elements/Indicators/Icon.lua`
+- Drop the `dispelType` parameter from `IconMethods:SetSpell`'s signature.
+- Drop the `--- @param dispelType` LuaDoc line.
+
+**Modify:** `Elements/Indicators/Bars.lua`
+- Swap `aura.stacks` → `aura.applications` inside the `BarsMethods:SetBars` loop (lines 39–40).
+
+**Modify:** `Elements/Auras/Buffs.lua`
+- ICONS dispatch: pass `unit` to `renderer:SetIcons` (new first arg).
+- ICON dispatch: pass `unit` (not `aura.unit`), `aura.applications` (not `aura.stacks`), drop `aura.dispelType` arg.
+- BAR dispatch (line 295): swap `aura.stacks` → `aura.applications`.
+- RECTANGLE dispatch (line 358): swap `aura.stacks` → `aura.applications`.
+- Delete both annotation blocks inside `matchAura` (lines 180–185 and 200–205). Drop the `annotated` local (line 170).
+
+No new files. No other files touched. No changes to `Elements/Auras/Debuffs.lua`, `Externals.lua`, `Defensives.lua`, `Dispellable.lua`, `PrivateAuras.lua`, or `MissingBuffs.lua` — they don't use the annotation pattern.
+
+---
+
+## Verification Model
+
+Matches the FullRefresh varargs plan's model. This is a WoW addon with no test harness. Verification after each task is:
+
+1. **Reload:** User runs `/reload` in-game. No Lua errors in `BugSack`.
+2. **Targeted behavior check:** User confirms the relevant renderer type still works (buffs render after the matching dispatch is updated).
+3. **Final validation** (Task 6): Ghost-aura stress, zero-aura unit, full regression replay, memory A/B.
+
+Each production-code task commits + pushes per `feedback_commit_after_task` (crash protection between reloads).
+
+---
+
+## Task 1: Capture pre-change idle memory baseline
+
+**Why first:** The cf7fabb regression was bisected in an **idle party with Fort+Int active**, not in LFR. The measurement needs to match the regression scenario, not the varargs PR's LFR methodology. This captures the per-second GC growth rate that Option C is expected to collapse.
+
+**Files:** None modified. Data capture only.
+
+- [ ] **Step 1: Confirm branch state**
+
+Run: `git status && git log --oneline -3`
+Expected: clean tree (unless the varargs PR branch is still open with uncommitted validation results — in which case, finish that first). HEAD should be at or past `df00aa8 Correct Buffs annotation spec`.
+
+- [ ] **Step 2: Ask user to run idle baseline**
+
+User instructions (deliver to user):
+```
+Before making changes, I need a fresh idle-party memory baseline that
+matches the cf7fabb regression scenario (not LFR).
+
+1. Log in on a character in a party of 5 (any spec, any class).
+2. Confirm Fortitude and Intellect buffs are active on you. Nothing
+   else — no consumables, no world buffs, no combat buffs.
+3. /reload to get a clean Lua heap.
+4. Stand idle (no combat, no movement) for 5 seconds to let things settle.
+5. Run these two commands back-to-back:
+   /run print(string.format('%.1f KB', collectgarbage('count')))
+   /framed memdiag 30
+6. While the 30-second memdiag runs, also paste a second collectgarbage
+   reading at the end:
+   /run print(string.format('%.1f KB', collectgarbage('count')))
+
+Paste everything here: the two collectgarbage readings plus the full
+memdiag output.
+
+We're looking for:
+- Per-second delta between the two collectgarbage readings
+  (idle growth rate)
+- event:UNIT_AURA bucket total
+- Any Buffs.lua rows in the memdiag output
+```
+
+- [ ] **Step 3: Record baseline values**
+
+When user pastes output, record four values for the Task 7 comparison:
+- `collectgarbage('count')` at T=0 (KB)
+- `collectgarbage('count')` at T=30s (KB)
+- Per-second idle growth rate: `(T30 - T0) / 30` KB/s
+- `event:UNIT_AURA` total from memdiag (KB over 30s)
+- Any `Buffs.lua` / `matchAura` rows in the per-function breakdown (if surfaced)
+
+Save as a conversation note (no file edit). These feed the PR body in Task 8.
+
+- [ ] **Step 4: No commit**
+
+Data capture — nothing to commit.
+
+---
+
+## Task 2: Update ICONS path (Icons.lua signature + Buffs.lua caller)
+
+**Why this order:** The ICONS path involves a signature change (`SetIcons(auraList)` → `SetIcons(unit, auraList)`), which is the highest-risk edit in this plan. Doing it first catches any breakage before other changes can mask it. All intermediate states are safe — `matchAura` is still annotating, and after this task, Icons.lua reads from the new `unit` param (same value as the annotated `aura.unit`, just sourced differently). No behavioral change.
+
+**Files:**
+- Modify: `Elements/Indicators/Icons.lua`
+- Modify: `Elements/Auras/Buffs.lua` (ICONS dispatch only)
+
+- [ ] **Step 1: Update `Icons.lua` LuaDoc and signature**
+
+Locate the existing LuaDoc + signature at lines 15–17 of `Elements/Indicators/Icons.lua`:
+
+```lua
+--- Fill icons from the pool with aura data and lay them out.
+--- @param auraList table Array of { spellID, icon, duration, expirationTime, stacks, dispelType }
+function IconsMethods:SetIcons(auraList)
+```
+
+Replace with:
+
+```lua
+--- Fill icons from the pool with aura data and lay them out.
+--- @param unit string Unit token passed through to Icon:SetSpell for GetAuraDuration lookup
+--- @param auraList table Array of { auraInstanceID, spellId, icon, duration, expirationTime, applications }
+function IconsMethods:SetIcons(unit, auraList)
+```
+
+The `@param auraList` field list is rewritten to reflect what's actually read inside the loop post-change: `auraInstanceID`, `spellId`, `icon`, `duration`, `expirationTime`, `applications`. Drops `stacks` (renamed to its Blizzard-native name) and `dispelType` (dead per Task 3).
+
+- [ ] **Step 2: Update `Icons.lua` body — the `icon:SetSpell` call**
+
+Locate the existing `icon:SetSpell` call inside the loop (around lines 73–82):
+
+```lua
+		icon:SetSpell(
+			aura.unit,
+			aura.auraInstanceID,
+			aura.spellId,
+			aura.icon,
+			aura.duration,
+			aura.expirationTime,
+			aura.stacks,
+			aura.dispelType
+		)
+```
+
+Replace with:
+
+```lua
+		icon:SetSpell(
+			unit,
+			aura.auraInstanceID,
+			aura.spellId,
+			aura.icon,
+			aura.duration,
+			aura.expirationTime,
+			aura.applications
+		)
+```
+
+Three edits in this block: `aura.unit` → `unit` (the new param), `aura.stacks` → `aura.applications`, and the `aura.dispelType` line removed entirely (along with the preceding comma on `aura.stacks`).
+
+- [ ] **Step 3: Update the only caller in `Elements/Auras/Buffs.lua`**
+
+Locate the ICONS dispatch at Buffs.lua:253:
+
+```lua
+				renderer:SetIcons(list)
+```
+
+Replace with:
+
+```lua
+				renderer:SetIcons(unit, list)
+```
+
+The `unit` local is already captured in the outer closure (`function element:Update(event, unit, updateInfo)` — verify by reading a few lines up). No new local needed.
+
+- [ ] **Step 4: Request user reload + ICONS render check**
+
+User instructions:
+```
+Icons.lua now takes unit as its first parameter and reads aura.applications
+instead of aura.stacks. The dispelType argument is gone.
+
+Please:
+
+1. /reload
+2. Target yourself and confirm buffs rendered by ICONS-type indicators
+   display correctly:
+   - Icons appear in the right spots
+   - Stack counts show on stackable buffs (e.g., a trinket proc)
+   - Duration rings / cooldown sweeps animate
+3. Check BugSack for any Lua errors.
+
+If you don't know which of your indicators is ICONS-type: look at any
+"My Buffs" row or default buff indicator — most buff indicators default
+to ICONS. If in doubt, /framed config and check the type field.
+```
+
+Expected: ICONS indicators render identically. No errors. At this point `matchAura` is still annotating — so `aura.unit`, `aura.stacks`, `aura.dispelType` still exist on the data; we just stopped reading two of them in this path.
+
+- [ ] **Step 5: Commit + push**
+
+```bash
+git add Elements/Indicators/Icons.lua Elements/Auras/Buffs.lua
+git commit -m "$(cat <<'EOF'
+refactor(indicators): route Icons through unit param + applications
+
+Changes Icons:SetIcons signature to accept unit as the first parameter,
+reads aura.applications in place of aura.stacks, and drops the
+aura.dispelType argument (dead in Icon:SetSpell body). Buffs.lua's
+ICONS dispatch updated to pass unit; no other callers exist.
+
+Intermediate step toward dropping Buffs.lua matchAura's AuraData
+mutation. Readers migrate renderer-by-renderer before the mutation
+itself is deleted.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+git push origin working-testing
+```
+
+---
+
+## Task 3: Update ICON path (Icon.lua drops dispelType + Buffs.lua ICON dispatch)
+
+**Files:**
+- Modify: `Elements/Indicators/Icon.lua` (signature + LuaDoc)
+- Modify: `Elements/Auras/Buffs.lua` (ICON dispatch block)
+
+Both callers of `Icon:SetSpell` (`Icons.lua:73` was already updated in Task 2 to pass 7 args; `Buffs.lua:263` is updated below) land in this task so the signature change and its callers stay atomic.
+
+- [ ] **Step 1: Update `Icon.lua` LuaDoc and signature**
+
+Locate the LuaDoc + signature at lines 21–30 of `Elements/Indicators/Icon.lua`:
+
+```lua
+--- Set the displayed spell/aura data on this icon.
+--- @param unit string|nil Unit token
+--- @param auraInstanceID number|nil Aura instance ID
+--- @param spellID number
+--- @param iconTexture number|string Texture ID or path
+--- @param duration number Duration in seconds (may be a secret value)
+--- @param expirationTime number Expiration GetTime() value (may be a secret value)
+--- @param stacks number Stack count
+--- @param dispelType string|nil Dispel/debuff type ('Magic', 'Curse', etc.)
+function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, duration, expirationTime, stacks, dispelType)
+```
+
+Replace with:
+
+```lua
+--- Set the displayed spell/aura data on this icon.
+--- @param unit string|nil Unit token
+--- @param auraInstanceID number|nil Aura instance ID
+--- @param spellID number
+--- @param iconTexture number|string Texture ID or path
+--- @param duration number Duration in seconds (may be a secret value)
+--- @param expirationTime number Expiration GetTime() value (may be a secret value)
+--- @param stacks number Stack count
+function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, duration, expirationTime, stacks)
+```
+
+Drops the `--- @param dispelType` LuaDoc line and the `, dispelType` parameter. The body (408 lines below) never reads `dispelType` — verified dead.
+
+**Note on the `stacks` parameter name:** Icon.lua's `SetSpell` still takes a parameter called `stacks` (not `applications`) because the parameter is a local name inside Icon.lua — its caller reads `aura.applications` and passes it in, and the Icon internals continue to call it `stacks`. Renaming the parameter is a separate cosmetic concern, out of scope here.
+
+- [ ] **Step 2: Update ICON dispatch in `Buffs.lua`**
+
+Locate the ICON dispatch at Buffs.lua:260–275:
+
+```lua
+		elseif(rendererType == C.IndicatorType.ICON) then
+			local aura = matchedPool[idx]
+			if(aura) then
+				renderer:SetSpell(
+					aura.unit,
+					aura.auraInstanceID,
+					aura.spellId,
+					aura.icon,
+					aura.duration,
+					aura.expirationTime,
+					aura.stacks,
+					aura.dispelType
+				)
+			else
+				renderer:Clear()
+			end
+```
+
+Replace the `renderer:SetSpell(...)` call with:
+
+```lua
+				renderer:SetSpell(
+					unit,
+					aura.auraInstanceID,
+					aura.spellId,
+					aura.icon,
+					aura.duration,
+					aura.expirationTime,
+					aura.applications
+				)
+```
+
+Three edits: `aura.unit` → `unit` (closure local), `aura.stacks` → `aura.applications`, `aura.dispelType` argument removed (along with the trailing comma on the `aura.stacks` line).
+
+- [ ] **Step 3: Request user reload + ICON render check**
+
+User instructions:
+```
+Icon.lua's SetSpell signature now drops the unused dispelType parameter.
+Buffs.lua's ICON dispatch passes unit + applications, no dispelType.
+
+Please:
+
+1. /reload
+2. Find or create an ICON-type buff indicator — typically a
+   "single icon" display for a specific spell (not ICONS, not BAR).
+   If you're unsure: /framed config and look for indicators with
+   type = "Icon" (singular).
+3. Confirm the icon renders, shows stack count if the tracked buff
+   stacks, and the cooldown ring animates.
+4. Check BugSack.
+
+If you don't have an ICON-type buff indicator configured, skip the
+render check — the signature change is validated by Task 2's ICONS
+render (Icons.lua:73 now calls SetSpell with the new 7-arg form).
+```
+
+Expected: no errors. ICON indicators (if any are configured) render correctly. The dispelType removal has no visible effect because Icon.lua never read it.
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add Elements/Indicators/Icon.lua Elements/Auras/Buffs.lua
+git commit -m "$(cat <<'EOF'
+refactor(indicators): drop dead dispelType param from Icon:SetSpell
+
+Icon:SetSpell declared dispelType in its signature but never read the
+value in its 408-line body. Both callers (Icons.lua inside SetIcons,
+Buffs.lua ICON dispatch) updated to match the new 7-arg arity; the
+Buffs.lua ICON dispatch also switches to unit closure local and
+aura.applications in the same commit.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+git push origin working-testing
+```
+
+---
+
+## Task 4: Swap remaining `aura.stacks` readers (BAR / RECTANGLE / BARS-via-Bars.lua)
+
+**Files:**
+- Modify: `Elements/Indicators/Bars.lua` (BARS internal read, inside `Bars:SetBars` loop)
+- Modify: `Elements/Auras/Buffs.lua` (BAR dispatch + RECTANGLE dispatch)
+
+Three tiny 1-line substitutions, all semantically identical (`aura.stacks` → `aura.applications`). Combined in one task because the risk is minimal and the validator (reload + render check) applies to all three uniformly.
+
+- [ ] **Step 1: `Bars.lua` — BARS internal read**
+
+Locate lines 39–41 of `Elements/Indicators/Bars.lua` (inside the `for i = 1, count do` loop in `BarsMethods:SetBars`):
+
+```lua
+		if(aura.stacks) then
+			bar:SetStacks(aura.stacks)
+		end
+```
+
+Replace with:
+
+```lua
+		if(aura.applications) then
+			bar:SetStacks(aura.applications)
+		end
+```
+
+- [ ] **Step 2: `Buffs.lua` — BAR dispatch (line 295)**
+
+Locate the BAR dispatch at Buffs.lua:295:
+
+```lua
+				if(aura.stacks) then renderer:SetStacks(aura.stacks) end
+```
+
+Replace with:
+
+```lua
+				if(aura.applications) then renderer:SetStacks(aura.applications) end
+```
+
+- [ ] **Step 3: `Buffs.lua` — RECTANGLE dispatch (line 358)**
+
+Locate the RECTANGLE dispatch at Buffs.lua:358:
+
+```lua
+				if(aura.stacks) then renderer:SetStacks(aura.stacks) end
+```
+
+Replace with:
+
+```lua
+				if(aura.applications) then renderer:SetStacks(aura.applications) end
+```
+
+**Important:** Buffs.lua has TWO lines that look identical — one at :295 (BAR) and one at :358 (RECTANGLE). Both need replacing. Use an `Edit` tool call with `replace_all: true` on `if(aura.stacks) then renderer:SetStacks(aura.stacks) end`, OR make two separate edits with context lines to disambiguate. Verify afterward with `rg 'aura\.stacks' Elements/Auras/Buffs.lua` — should return zero hits.
+
+- [ ] **Step 4: Request user reload + BAR / RECTANGLE / BARS render check**
+
+User instructions:
+```
+All remaining aura.stacks readers now use aura.applications. Three
+changes, three renderer types covered: BAR (single-bar), BARS (multi-
+bar grid), RECTANGLE.
+
+Please:
+
+1. /reload
+2. Confirm each renderer type you have configured still displays stack
+   counts correctly. A quick way to trigger a stackable buff: eat food
+   (stacks to 10), or use a stackable trinket.
+3. If you have a BARS (multi-bar) configuration, confirm stack text
+   shows on individual bars in that grid.
+4. If you have a RECTANGLE indicator (less common), confirm its
+   stack count displays.
+5. Check BugSack.
+
+If any of these indicator types aren't configured on your setup, skip
+them — the substitution is trivially correct (aura.applications is
+Blizzard's native name for the same integer value that annotation
+was copying into aura.stacks).
+```
+
+Expected: stack counts render identically. No errors. `matchAura` is still annotating at this point — `aura.stacks` still exists on the data, we just stopped reading it anywhere.
+
+- [ ] **Step 5: Commit + push**
+
+```bash
+git add Elements/Indicators/Bars.lua Elements/Auras/Buffs.lua
+git commit -m "$(cat <<'EOF'
+refactor(indicators): read aura.applications for stack counts
+
+Swaps the three remaining aura.stacks reader sites to aura.applications:
+Bars.lua:39 (BARS internal loop), Buffs.lua:295 (BAR dispatch), and
+Buffs.lua:358 (RECTANGLE dispatch). applications is the Blizzard-native
+name for the same integer; stacks was a Framed-owned annotation that
+this PR is removing. The annotation itself stays in place for one more
+commit to keep this change trivially verifiable.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+git push origin working-testing
+```
+
+---
+
+## Task 5: Delete the annotation blocks in `matchAura`
+
+**Files:**
+- Modify: `Elements/Auras/Buffs.lua` (two annotation blocks in `matchAura` + one unused local)
+
+This is the payoff task — the mutation itself is eliminated. After Tasks 2, 3, 4 migrated every reader to sourcing data from Blizzard-native fields / closure params, the annotations are dead writes.
+
+- [ ] **Step 1: Delete the `annotated` local**
+
+Locate the `annotated = false` initialization inside `matchAura` (around line 170 of `Elements/Auras/Buffs.lua`):
+
+```lua
+		local function matchAura(auraData)
+			local spellId = auraData.spellId
+			if(not F.IsValueNonSecret(spellId)) then return end
+
+			local sourceUnit = auraData.sourceUnit
+			local annotated = false
+```
+
+Remove the `local annotated = false` line. Final form:
+
+```lua
+		local function matchAura(auraData)
+			local spellId = auraData.spellId
+			if(not F.IsValueNonSecret(spellId)) then return end
+
+			local sourceUnit = auraData.sourceUnit
+```
+
+- [ ] **Step 2: Delete the first annotation block (spell-lookup branch, lines 178–185)**
+
+Locate the block inside the spell-lookup branch of `matchAura`:
+
+```lua
+				if(passesCastByFilter(sourceUnit, ind._castBy)) then
+					-- Annotate auraData with renderer-expected field names
+					-- (non-conflicting keys: auraData has no .stacks/.dispelType/.unit)
+					if(not annotated) then
+						auraData.unit      = unit
+						auraData.stacks    = auraData.applications
+						auraData.dispelType = auraData.dispelName
+						annotated = true
+					end
+					if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
+```
+
+Delete the annotation block (the `-- Annotate auraData...` comment plus the `if(not annotated) ... end` block — 8 lines total), leaving:
+
+```lua
+				if(passesCastByFilter(sourceUnit, ind._castBy)) then
+					if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
+```
+
+- [ ] **Step 3: Delete the second annotation block (trackAll branch, lines 200–205)**
+
+Locate the block inside the trackAll loop:
+
+```lua
+			if(passesCastByFilter(sourceUnit, ind._castBy)) then
+				if(not annotated) then
+					auraData.unit      = unit
+					auraData.stacks    = auraData.applications
+					auraData.dispelType = auraData.dispelName
+					annotated = true
+				end
+				if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
+```
+
+Delete the `if(not annotated) ... end` block (6 lines), leaving:
+
+```lua
+			if(passesCastByFilter(sourceUnit, ind._castBy)) then
+				if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
+```
+
+- [ ] **Step 4: Verify no stale readers remain**
+
+Run: `rg 'aura(Data)?\.(unit|stacks|dispelType)' Elements/Auras/Buffs.lua Elements/Indicators/`
+
+Expected output: zero hits in any of these files. If anything matches, a reader was missed — stop and investigate before reloading. (The spec's `docs/superpowers/specs/` match should still appear in unrelated grep runs — fine, docs only.)
+
+- [ ] **Step 5: Request user reload + full-config render check**
+
+User instructions:
+```
+Mutation is gone. matchAura now leaves every AuraData table untouched
+(no more .unit, .stacks, .dispelType writes). This is the commit the
+memory regression fix hinges on.
+
+Please:
+
+1. /reload
+2. Walk through each renderer type you have configured and confirm it
+   still renders correctly:
+   - ICONS  (most buff indicators default here)
+   - ICON   (single-icon, less common)
+   - BAR    (single bar)
+   - BARS   (multi-bar grid)
+   - RECTANGLE (rare)
+3. Target yourself, a party/raid member, and at least one friendly
+   unit with a diverse set of buffs.
+4. Confirm stack counts show where expected.
+5. Confirm cooldown animations work.
+6. Check BugSack.
+
+If anything renders wrong: the previous tasks missed a reader. Stop
+and report — I'll find it before any other changes.
+```
+
+Expected: all buff rendering unchanged. No errors. This is the behavioral parity check that says "we successfully removed the mutation without removing any information consumers needed."
+
+- [ ] **Step 6: Commit + push**
+
+```bash
+git add Elements/Auras/Buffs.lua
+git commit -m "$(cat <<'EOF'
+refactor(buffs): stop mutating AuraData tables in matchAura
+
+Deletes both annotation blocks inside matchAura (plus the unused
+'annotated' local). Framed no longer writes .unit, .stacks, or
+.dispelType onto Blizzard's AuraData tables. Every downstream reader
+was migrated in prior commits to source these values from
+aura.applications (native) and the unit closure local.
+
+Fixes the suspected retention mechanism behind the cf7fabb idle
+party/raid memory regression: with the widened HELPFUL filter, every
+Fort/Int/cosmetic/consumable buff previously flowed through matchAura
+every UNIT_AURA tick and got three new keys written. Removing the
+mutation eliminates that allocation pattern and the cross-consumer
+aliasing hazard on the shared entry.aura reference in the classified
+path.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+git push origin working-testing
+```
+
+---
+
+## Task 6: In-game validation pass
+
+**Files:** None modified. Behavioral validation, matching the spec's Test Gate.
+
+- [ ] **Step 1: Ghost-aura stress**
+
+User instructions:
+```
+Ghost-aura stress test (verifies the mutation removal didn't break
+cross-unit state):
+
+1. Target yourself — note the buffs showing.
+2. /tar party1 (or any party/raid member with different buffs).
+3. Switch back to /tar player.
+4. Repeat target-swap several times while buffs are refreshing.
+5. Watch for: buffs from another unit bleeding onto yours, missing
+   buffs that should be there, duplicated buffs, or stack count
+   corruption.
+
+Expected: every target swap shows the correct unit's buffs with no
+bleed, no ghosting, and correct stack counts. Mutation removal can't
+introduce ghost-aura bugs (the mutation was never the mechanism
+preventing them), but this is the standard validator for any AuraState
+or Buffs change and inherits from the #144 audit gate.
+```
+
+- [ ] **Step 2: Mixed-renderer party/raid test**
+
+User instructions:
+```
+Render correctness across indicator types:
+
+1. Confirm your party has a mix of buffs: Fort, Int, at least one
+   stackable proc buff (e.g., a trinket), and a Rejuvenation-style
+   HoT if a druid is around. If you have a custom indicator tracking
+   spell 774 (Rejuv) per your SavedVariables, confirm it displays.
+2. For each party member, verify all configured indicators render.
+3. If you can swap to Arena or Boss preset mid-session, do so and
+   confirm those layouts render correctly.
+
+Expected: every renderer type displays every tracked buff correctly,
+including stack counts on stackable buffs. No errors.
+```
+
+- [ ] **Step 3: Regression replay with other addons**
+
+User instructions:
+```
+Full regression replay (0.7.20 pool revert signature check):
+
+1. /reload with MPlusQOL / AbilityTimeline / WeakAuras loaded.
+2. Enter combat (any target, any fight — dummy works).
+3. Let buffs apply, stack, refresh, expire.
+4. Exit combat.
+5. Target chains: /tar, /tar target, /tar targettarget.
+6. Check BugSack for any errors — especially `attempt to compare
+   number with nil` or nil-text errors from other addons (those were
+   the 0.7.20 shared-state bleed signature).
+
+Expected: zero BugSack errors across the full sequence. Removing a
+mutation cannot introduce cross-addon taint — but verifying it's the
+merge gate.
+```
+
+- [ ] **Step 4: No commit**
+
+Validation task. If any regression surfaces, file a fix task and re-validate before moving to Task 7.
+
+---
+
+## Task 7: Capture post-change idle measurement + compute A/B delta
+
+**Files:** None modified. Data capture + analysis.
+
+- [ ] **Step 1: Request post-change idle measurement**
+
+User instructions:
+```
+Final measurement — post-change idle memory in the same scenario as
+Task 1's baseline.
+
+Same setup:
+1. Same character, same party of 5 (or at least same party composition
+   as close as possible — if the specific party members have rotated,
+   that's fine, just note it).
+2. Fortitude + Intellect active. Nothing else.
+3. /reload.
+4. Stand idle for 5 seconds.
+5. Run the same commands:
+   /run print(string.format('%.1f KB', collectgarbage('count')))
+   /framed memdiag 30
+   (wait 30s)
+   /run print(string.format('%.1f KB', collectgarbage('count')))
+
+Paste everything here.
+```
+
+- [ ] **Step 2: Compute A/B delta**
+
+Compare post-change output to Task 1 baseline. Record:
+
+| Metric | Pre | Post | Delta |
+|---|---|---|---|
+| `collectgarbage('count')` at T=0 | | | — |
+| `collectgarbage('count')` at T=30s | | | — |
+| Idle growth rate (KB/s) | | | |
+| `event:UNIT_AURA` total (30s) | | | |
+| `Buffs.lua` / `matchAura` rows (if surfaced) | | | |
+
+**Merge criterion per the spec:** direction, not magnitude. The idle growth rate should collapse toward 0.8.12's baseline. If growth is substantially lower (or flat), Option C landed the fix. If growth persists at similar magnitude, the retention mechanism is elsewhere — next step is Option A (restore `buffFilterMode` as explicit config), filed as a follow-up issue. Either way, this PR still ships because the mutation removal is also the fix for the pre-existing aliasing hazard documented in `docs/superpowers/plans/2026-04-22-b3-buffs-classified.md:84`.
+
+If party composition drifted between Task 1 and this measurement, note it in the PR body. The idle-growth metric is relatively composition-insensitive as long as the active buff set is the same (Fort + Int), but large group-size differences can matter.
+
+- [ ] **Step 3: No commit**
+
+Analysis task. Findings flow into the PR body in Task 8.
+
+---
+
+## Task 8: Push branch + create PR
+
+**Files:** None modified locally.
+
+- [ ] **Step 1: Confirm the varargs PR has landed first**
+
+Per the branch strategy chosen in brainstorming (Option A — land varargs first, then Option C as follow-up for clean A/B attribution), the varargs PR should be merged to `working` before this PR opens. Check:
+
+```bash
+gh pr list --state merged --search "varargs FullRefresh" --limit 5
+```
+
+If the varargs PR is NOT yet merged: wait. Don't open this PR until varargs lands, or the MemDiag A/B for this change mixes two allocation sources.
+
+If the varargs PR is merged:
+
+```bash
+git fetch origin
+git log --oneline origin/working..working-testing
+```
+
+Expected: shows the four commits from Tasks 2, 3, 4, 5 (ICONS, ICON, BAR/RECTANGLE/BARS substitutions, mutation delete). Plus the two spec commits (`1f48247`, `df00aa8`) if those haven't already been swept up by the varargs PR's merge into `working`.
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create --base working --head working-testing --title "refactor(buffs): stop mutating AuraData tables in matchAura" --body "$(cat <<'EOF'
+## Summary
+
+Eliminates the three Framed-owned annotations written onto Blizzard's `AuraData` tables inside `Buffs.lua`'s `matchAura` (`.unit`, `.stacks`, `.dispelType`). Every downstream reader now sources these values from their native Blizzard fields (`aura.applications`) or from the existing `unit` closure local. The dead `dispelType` parameter is removed from `Icon:SetSpell` entirely.
+
+Option C from the cf7fabb regression triage. Separate PR from the varargs work (#155 item 3) to keep MemDiag A/B attribution clean between the two allocation sources.
+
+## Motivation
+
+**Memory regression (primary).** `cf7fabb` widened the helpful-aura query from `HELPFUL|RAID_IN_COMBAT` to plain `HELPFUL` whenever any enabled buff indicator has a non-empty `spells` list. With the wider filter, Fort / Int / cosmetic / consumable buffs that Blizzard previously stripped server-side now flow through `matchAura` every `UNIT_AURA` tick — and every one gets three new keys written onto it. The user's SavedVariables had custom indicators tracking Rejuvenation (`spells = { 774 }`) on party frames, triggering the widened filter. Bisect (cf7fabb vs its parent on the same idle-party scenario) pinned the regression here.
+
+**Aliasing hazard (pre-existing).** In the classified path, `entry.aura` is the same `AuraData` reference shared across consumers — Framed's in-place mutation leaked Framed-owned keys onto a shared object. Removing the mutation removes the aliasing risk, independent of whether it also fully collapses the regression.
+
+## Design
+
+Spec: `docs/superpowers/specs/2026-04-22-buffs-annotation-cleanup-design.md`
+
+Scope (5 reader sites across 3 files):
+- `Icons.lua` — `SetIcons` gains `unit` parameter, reads `aura.applications`, drops `dispelType` arg
+- `Icon.lua` — `SetSpell` signature drops dead `dispelType` parameter
+- `Bars.lua` — internal `BARS` loop reads `aura.applications`
+- `Buffs.lua` — ICON / BAR / RECTANGLE dispatches read `unit` + `aura.applications`; mutation deleted
+
+## Idle memory A/B (party of 5, Fort + Int, 30 s idle)
+
+<!-- Fill in from Task 1 + Task 7 -->
+
+| Metric | Pre | Post | Delta |
+|---|---|---|---|
+| `collectgarbage('count')` at T=0 | | | |
+| `collectgarbage('count')` at T=30s | | | |
+| Idle growth rate (KB/s) | | | |
+| `event:UNIT_AURA` total | | | |
+
+**Merge criterion:** direction, not magnitude. Idle growth should collapse toward 0.8.12 baseline. If it doesn't, the retention mechanism is elsewhere and Option A (restore `buffFilterMode` as explicit config) is the follow-up — tracked separately. This PR ships regardless because the mutation removal is also the pre-existing aliasing-hazard fix.
+
+## Test plan
+
+- [x] ICONS render correct with new `unit` parameter (Task 2)
+- [x] ICON render correct with dropped `dispelType` param (Task 3)
+- [x] BAR / BARS / RECTANGLE stack counts render via `aura.applications` (Task 4)
+- [x] All five renderer types render correctly after mutation deleted (Task 5)
+- [x] Ghost-aura stress — no cross-unit bleed on target swaps (Task 6)
+- [x] Mixed-renderer party/raid render correctness (Task 6)
+- [x] Regression replay with MPlusQOL / AbilityTimeline / WeakAuras — zero BugSack errors (Task 6)
+- [x] Idle-party A/B captured (Task 7)
+
+## Out of scope
+
+- **Option A (restore `buffFilterMode` as explicit config).** Separate future PR if Option C alone doesn't collapse the regression. Tracked per the spec's References section.
+- **Debuffs / Externals / Defensives / Dispellable / PrivateAuras / MissingBuffs.** They don't use the annotation pattern.
+- **BorderIcon widget.** It legitimately reads `dispelType` and is used by other elements; this PR doesn't touch it.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Backfill A/B table from Task 7 findings**
+
+Edit the PR after creation to fill the placeholder table:
+
+```bash
+gh pr edit <pr-number> --body "$(cat <<'EOF'
+... (paste full body with A/B table filled in from Task 7) ...
+EOF
+)"
+```
+
+Or via `gh pr view <number> --web`.
+
+- [ ] **Step 4: Report PR URL to user**
+
+Share the PR URL. User reviews → merges `working-testing` → `working` → promotes to `main` on release cadence.
+
+- [ ] **Step 5: File the cf7fabb GitHub issue (if not already filed)**
+
+The spec's `**Issue:** TBD` front-matter entry should now point at a real issue. Create one if none exists:
+
+```bash
+gh issue create --title "Memory regression in idle party/raid introduced by cf7fabb" --body "$(cat <<'EOF'
+## Summary
+
+cf7fabb (`refactor(buffs): derive aura filter from indicator set, drop buffFilterMode`) introduced a measurable idle memory growth rate in party/raid when any buff indicator has a non-empty `spells` list.
+
+## Mechanism
+
+`computeBuffFilter` widens the helpful-aura query from `HELPFUL|RAID_IN_COMBAT` to plain `HELPFUL` whenever any enabled indicator tracks specific spells. With the wider filter, Blizzard's server-side stripping of Fort / Int / cosmetic / consumable / world buffs no longer applies, and those auras flow through Framed's `matchAura` every `UNIT_AURA` tick. Inside `matchAura`, each matched aura was mutated with three Framed-owned keys — suspected retention mechanism.
+
+## Fix
+
+PR #<this-pr>: stop mutating AuraData tables in `matchAura`. Readers migrated to `aura.applications` and the existing `unit` closure local. If idle growth persists after this lands, the follow-up is to restore `buffFilterMode` as explicit user config (Option A).
+
+## Bisect
+
+- Regression first reproduces on cf7fabb (HEAD-solo vs cf7fabb-solo measured identical, so the widened filter is the sole differential).
+- User's SavedVariables had 5 custom indicators with `spells = { 774 }` (Rejuvenation) triggering the widened filter on party frames.
+EOF
+)"
+```
+
+Then edit the spec's header to replace `**Issue:** TBD` with the real issue number, and commit that in a small follow-up:
+
+```bash
+git add docs/superpowers/specs/2026-04-22-buffs-annotation-cleanup-design.md
+git commit -m "Link cf7fabb regression issue in Buffs annotation cleanup spec"
+git push origin working-testing
+```
+
+---
+
+## Notes for the executor
+
+- **Code style:** Tabs for indentation, single quotes for strings, parenthesized conditions (`if(x) then`), `for _, v in next, tbl do` (never `pairs`/`ipairs`). See `CLAUDE.md`.
+- **Symlink:** Framed's addon folder is a symlink to this repo. Edits are live — user just `/reload`s. See `feedback_wow_sync`.
+- **Per-task commits:** Commit + push after every production-code task (2, 3, 4, 5). Crash protection between reloads. See `feedback_commit_after_task`.
+- **No pcall:** No new feature detection introduced here. Don't add `pcall`.
+- **No comments added:** The annotation blocks being deleted include a comment (`-- Annotate auraData with renderer-expected field names...`) — that comment goes away with the blocks. No new comments replace it; the code without mutation is self-explanatory.
+- **Fragile aura indicators:** Per `feedback_aura_indicators_fragile`, never touch indicator rendering without explicit instruction. This plan IS that explicit instruction; executing the tasks as written is authorized. If validation (Task 5 Step 5 or Task 6) surfaces a render break, STOP and report — don't try to patch around it.
+- **Author name:** Commit Co-Authored-By uses `Claude Opus 4.7`. The git user (`jdtoppin` per gitconfig) shows up as Moodibs in published commits per `feedback_author_name`.

--- a/docs/superpowers/plans/2026-04-22-classified-entry-pool.md
+++ b/docs/superpowers/plans/2026-04-22-classified-entry-pool.md
@@ -1,0 +1,581 @@
+# Classified Entry Pool Implementation Plan (#144)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate per-update allocation of classified `{ aura, flags }` wrappers in `Core/AuraState.lua` via a taint-safe, per-instance paired free list.
+
+**Architecture:** Single shared paired pool per `AuraState` instance. Dedicated `acquireClassified` / `releaseClassified` helpers are the only acquire/release paths. Flags table identity stays attached to its wrapper; wipe happens at acquire (lazy). Helpful and harmful entries share one pool. Weak-keyed `F.AuraState._instances` registry enables aggregate observability.
+
+**Tech Stack:** WoW 12.0.x Lua, embedded oUF, Framed AuraState.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-classified-entry-pool-design.md`
+
+**Divergence from spec:** Spec proposed extending `/framed aurastate [unit]` with a pool-size line. That command creates a fresh AuraState (Init.lua:428), so its freelist is always 0 — the extension would be meaningless. Plan uses `/framed memusage` (aggregate) + new `/framed pools` (per-instance breakdown) instead, satisfying the spec's observability intent against real frames.
+
+**Related:** #144 (scope), #155 (measurements), #159 (MemDiag tooling for A/B).
+
+---
+
+## Task 1: Audit classified consumers for stashed references
+
+**Goal:** Pool merge is gated on this passing. Any caller that stashes `entry` or `entry.flags` across a UNIT_AURA must be fixed before the pool lands.
+
+**Files:**
+- Read-only: any file calling `GetHelpfulClassified`, `GetHarmfulClassified`, or `GetClassifiedByInstanceID`
+
+- [ ] **Step 1: Enumerate consumers**
+
+Run:
+```
+grep -rn "GetHelpfulClassified\|GetHarmfulClassified\|GetClassifiedByInstanceID" Elements/ Units/ Widgets/ Preview/
+```
+
+Expected call sites (from prior review — verify none are missing):
+- `Elements/Auras/Buffs.lua`
+- `Elements/Auras/Debuffs.lua`
+- `Elements/Auras/Externals.lua`
+- `Elements/Auras/Defensives.lua`
+- `Elements/Auras/Dispellable.lua`
+- `Elements/Auras/PrivateAuras.lua`
+- `Elements/Auras/MissingBuffs.lua` (accepts either shape via `item.aura or item`)
+
+- [ ] **Step 2: Check each consumer for stashing**
+
+For each file, look for:
+- Assignment of an entry to `self.*` or any non-local state: `self.X = entry`, `self.X[k] = entry`, `frame.Y = entry.flags`
+- Assignment of an entry to a module-level table
+- Any lifetime longer than the immediate iteration loop
+
+The pattern that's safe:
+```lua
+for _, entry in next, auraState:GetHelpfulClassified() do
+    if(entry.flags.isBigDefensive) then
+        -- use entry.aura.*, entry.flags.* inline; never save
+    end
+end
+```
+
+The pattern that's unsafe (hypothetical):
+```lua
+for _, entry in next, auraState:GetHelpfulClassified() do
+    self.currentEntry = entry  -- BAD: stashes ref past iteration
+end
+```
+
+- [ ] **Step 3: Record findings and fix violators**
+
+If any violator exists: fix it *in the same task* by extracting the needed fields inline before the stash, or by storing the `auraInstanceID` + re-resolving via `GetClassifiedByInstanceID` each time. Do not leave violators for a later task — the pool must land on a clean base.
+
+If no violators: write a single-line comment at the top of `Core/AuraState.lua` documenting the audit:
+
+```lua
+-- Classified entries are pooled per-instance. Consumers must not stash
+-- entry or entry.flags across UNIT_AURA — pool reuse silently refills
+-- the wrapper. Audit completed 2026-04-22; all Elements/Auras/* iterate
+-- inline without stashing.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "docs(AuraState): note classified-entry stash invariant for pool (#144)"
+git push origin working-testing
+```
+
+---
+
+## Task 2: Add instance registry and pool field
+
+**Files:**
+- Modify: `Core/AuraState.lua` (near line 4 and around line 456)
+
+- [ ] **Step 1: Add weak-keyed instance registry**
+
+Near the top of `Core/AuraState.lua`, right after `F.AuraState = {}`:
+
+```lua
+local _, Framed = ...
+local F = Framed
+
+F.AuraState = {}
+
+-- Weak-keyed registry so diagnostics can walk live instances without
+-- preventing GC of frames whose AuraState becomes unreferenced.
+F.AuraState._instances = setmetatable({}, { __mode = 'k' })
+```
+
+- [ ] **Step 2: Initialize pool field and register instance in Create**
+
+Modify `F.AuraState.Create` (currently at line 456):
+
+```lua
+function F.AuraState.Create(owner)
+    local inst = setmetatable({
+        _owner = owner,
+        _unit = nil,
+        _initialized = false,
+        _gen = 0,
+        _lastUpdateInfo = nil,
+        _lastUpdateUnit = nil,
+        _helpfulById = {},
+        _helpfulViews = {},
+        _helpfulMatches = {},
+        _helpfulClassifiedById = {},
+        _helpfulClassifiedView = { dirty = true, list = {} },
+        _harmfulById = {},
+        _harmfulViews = {},
+        _harmfulMatches = {},
+        _harmfulClassifiedById = {},
+        _harmfulClassifiedView = { dirty = true, list = {} },
+        _classifiedFreeList = {},
+    }, AuraState)
+    F.AuraState._instances[inst] = true
+    return inst
+end
+```
+
+- [ ] **Step 3: Reload and verify no errors**
+
+In WoW: `/reload`. Confirm no Lua errors at login. Run `/framed aurastate target` and confirm dumps still work.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Core/AuraState.lua
+git commit -m "refactor(AuraState): add instance registry and freelist field (#144)"
+git push origin working-testing
+```
+
+---
+
+## Task 3: Replace classify() with acquireClassified() and wire call sites
+
+**Files:**
+- Modify: `Core/AuraState.lua:18-42` (classify function)
+- Modify: `Core/AuraState.lua:395` (GetHelpfulClassified call site)
+- Modify: `Core/AuraState.lua:416` (GetHarmfulClassified call site)
+- Modify: `Core/AuraState.lua:433` and `445` (GetClassifiedByInstanceID call sites)
+
+- [ ] **Step 1: Replace the module-local `classify` function with `acquireClassified`**
+
+Replace lines 18-42:
+
+```lua
+-- Acquire a classified entry from the per-instance pool (or allocate
+-- fresh if the pool is empty) and fill its flag fields for `aura`.
+--
+-- Tier 1 flags are structural AuraData booleans. Per Blizzard's 12.0.x
+-- changes, isHelpful / isHarmful / isRaid / isNameplateOnly /
+-- isFromPlayerOrPlayerPet are non-secret. isBossAura remains secret on
+-- encounter auras and must be guarded with F.IsValueNonSecret to avoid
+-- tainted boolean tests.
+-- Tier 2 flags use C_UnitAuras filter probes (secret-safe C API).
+local function acquireClassified(pool, unit, aura, isHelpful)
+    local id = aura.auraInstanceID
+    local prefix = isHelpful and 'HELPFUL' or 'HARMFUL'
+
+    local entry = pool[#pool]
+    if(entry) then
+        pool[#pool] = nil
+        wipe(entry.flags)
+    else
+        entry = { flags = {} }
+    end
+
+    entry.aura = aura
+
+    local flags = entry.flags
+    flags.isHelpful         = aura.isHelpful         or false
+    flags.isHarmful         = aura.isHarmful         or false
+    flags.isRaid            = aura.isRaid            or false
+    flags.isBossAura        = F.IsValueNonSecret(aura.isBossAura) and aura.isBossAura or false
+    flags.isFromPlayerOrPet = aura.isFromPlayerOrPlayerPet or false
+
+    flags.isExternalDefensive = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|EXTERNAL_DEFENSIVE') == false
+    flags.isImportant         = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|IMPORTANT')          == false
+    flags.isPlayerCast        = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|PLAYER')             == false
+    flags.isBigDefensive      = isHelpful
+                                and IsAuraFilteredOutByInstanceID(unit, id, 'HELPFUL|BIG_DEFENSIVE') == false
+                                or false
+    flags.isRaidDispellable   = not isHelpful
+                                and IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|RAID_PLAYER_DISPELLABLE') == false
+                                or false
+    flags.isRaidInCombat      = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|RAID_IN_COMBAT') == false
+
+    return entry
+end
+```
+
+- [ ] **Step 2: Wire `GetHelpfulClassified` to use the pool**
+
+Modify line 395 area:
+
+Current:
+```lua
+for id, aura in next, self._helpfulById do
+    local entry = self._helpfulClassifiedById[id]
+    if(not entry) then
+        entry = classify(self._unit, aura, true)
+        self._helpfulClassifiedById[id] = entry
+    end
+    view.list[#view.list + 1] = entry
+end
+```
+
+Replace with:
+```lua
+for id, aura in next, self._helpfulById do
+    local entry = self._helpfulClassifiedById[id]
+    if(not entry) then
+        entry = acquireClassified(self._classifiedFreeList, self._unit, aura, true)
+        self._helpfulClassifiedById[id] = entry
+    end
+    view.list[#view.list + 1] = entry
+end
+```
+
+- [ ] **Step 3: Wire `GetHarmfulClassified` to use the pool**
+
+Modify line 416 area — symmetric:
+```lua
+for id, aura in next, self._harmfulById do
+    local entry = self._harmfulClassifiedById[id]
+    if(not entry) then
+        entry = acquireClassified(self._classifiedFreeList, self._unit, aura, false)
+        self._harmfulClassifiedById[id] = entry
+    end
+    view.list[#view.list + 1] = entry
+end
+```
+
+- [ ] **Step 4: Wire both `GetClassifiedByInstanceID` call sites**
+
+Current lines 433 and 445:
+```lua
+entry = classify(self._unit, aura, true)
+```
+```lua
+entry = classify(self._unit, aura, false)
+```
+
+Replace with:
+```lua
+entry = acquireClassified(self._classifiedFreeList, self._unit, aura, true)
+```
+```lua
+entry = acquireClassified(self._classifiedFreeList, self._unit, aura, false)
+```
+
+- [ ] **Step 5: Reload and smoke test**
+
+In WoW:
+- `/reload`
+- `/framed aurastate target` on a unit with live auras — classifications should match pre-change behavior
+- Cast a buff on yourself, observe it appears in Buffs element correctly
+- Take damage from a debuff, observe it appears in Debuffs element correctly
+- Target-swap a few times — no aura flicker or misclassification
+
+At this point the pool is being *acquired from* but never *released to* (Task 4), so `_classifiedFreeList` stays empty in practice. That's intentional — the acquire path is testable in isolation before wiring release.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Core/AuraState.lua
+git commit -m "refactor(AuraState): route classify() through per-instance pool (#144)"
+git push origin working-testing
+```
+
+---
+
+## Task 4: Wire releaseClassified into Invalidate and Reset paths
+
+**Files:**
+- Modify: `Core/AuraState.lua` (add `releaseClassified` helper)
+- Modify: `Core/AuraState.lua:111-117` (Reset*Classified methods)
+- Modify: `Core/AuraState.lua:119-125` (Invalidate*Classified methods)
+
+- [ ] **Step 1: Add `releaseClassified` local helper**
+
+Add right after the `acquireClassified` function (near line 60 in the new layout):
+
+```lua
+-- Return a classified entry to the pool. Nils the aura reference so
+-- the underlying AuraData can be GC'd even while the wrapper sits in
+-- the free list; flags contents are left stale until the next acquire
+-- wipes them (lazy — avoids paying wipe cost on entries that never
+-- get reused before session end).
+local function releaseClassified(pool, entry)
+    entry.aura = nil
+    pool[#pool + 1] = entry
+end
+```
+
+- [ ] **Step 2: Update `InvalidateHelpfulClassified` to release**
+
+Current (line 119-121):
+```lua
+function AuraState:InvalidateHelpfulClassified(auraInstanceID)
+    self._helpfulClassifiedById[auraInstanceID] = nil
+end
+```
+
+Replace with:
+```lua
+function AuraState:InvalidateHelpfulClassified(auraInstanceID)
+    local entry = self._helpfulClassifiedById[auraInstanceID]
+    if(entry) then
+        releaseClassified(self._classifiedFreeList, entry)
+        self._helpfulClassifiedById[auraInstanceID] = nil
+    end
+end
+```
+
+- [ ] **Step 3: Update `InvalidateHarmfulClassified` to release**
+
+Symmetric:
+```lua
+function AuraState:InvalidateHarmfulClassified(auraInstanceID)
+    local entry = self._harmfulClassifiedById[auraInstanceID]
+    if(entry) then
+        releaseClassified(self._classifiedFreeList, entry)
+        self._harmfulClassifiedById[auraInstanceID] = nil
+    end
+end
+```
+
+- [ ] **Step 4: Update `ResetHelpfulClassified` to release each entry**
+
+Current (line 111-113):
+```lua
+function AuraState:ResetHelpfulClassified()
+    wipe(self._helpfulClassifiedById)
+end
+```
+
+Replace with:
+```lua
+function AuraState:ResetHelpfulClassified()
+    for id, entry in next, self._helpfulClassifiedById do
+        releaseClassified(self._classifiedFreeList, entry)
+    end
+    wipe(self._helpfulClassifiedById)
+end
+```
+
+- [ ] **Step 5: Update `ResetHarmfulClassified` to release each entry**
+
+Symmetric:
+```lua
+function AuraState:ResetHarmfulClassified()
+    for id, entry in next, self._harmfulClassifiedById do
+        releaseClassified(self._classifiedFreeList, entry)
+    end
+    wipe(self._harmfulClassifiedById)
+end
+```
+
+- [ ] **Step 6: Reload and test the full round-trip**
+
+In WoW:
+- `/reload`
+- Target a unit, observe auras
+- Apply new auras, let some expire, re-target — classified view should update without visual glitches
+- Enter/leave combat several times (fires FullRefresh → Reset*Classified paths)
+- Open `/framed aurastate target`, confirm classifications still accurate
+
+At this point the pool is actually working: acquires pull from the free list when available, releases push entries back on invalidation and reset.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Core/AuraState.lua
+git commit -m "refactor(AuraState): release classified entries to pool on invalidate/reset (#144)"
+git push origin working-testing
+```
+
+---
+
+## Task 5: Add aggregate pool line to /framed memusage
+
+**Files:**
+- Modify: `Init.lua` (extend `/framed memusage` output near line 481)
+
+- [ ] **Step 1: Add aggregate computation and print**
+
+In `Init.lua`, locate the `memusage` command block (around line 456). After the existing "top 10 addons" loop (around line 501), just before the `elseif(cmd == 'casttracker')` branch, insert:
+
+```lua
+-- Classified entry pool aggregate across all live AuraState instances.
+local totalPooled = 0
+local instanceCount = 0
+for instance in next, F.AuraState._instances do
+    instanceCount = instanceCount + 1
+    totalPooled = totalPooled + #instance._classifiedFreeList
+end
+print(('|cff00ccff[Framed/mem]|r aurastate pool: %d entries across %d instances'):format(
+    totalPooled, instanceCount))
+```
+
+- [ ] **Step 2: Reload and verify**
+
+In WoW:
+- `/reload`
+- `/framed memusage` — should print the new line
+- Before combat: expect low numbers (frame init may have released very little)
+- After combat: expect higher numbers as aura churn pushes entries through the pool
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Init.lua
+git commit -m "feat(debug): show classified pool aggregate in /framed memusage (#144)"
+git push origin working-testing
+```
+
+---
+
+## Task 6: Add /framed pools command for per-instance breakdown
+
+**Files:**
+- Modify: `Init.lua` (new command branch + help text)
+
+- [ ] **Step 1: Add `pools` command branch**
+
+In `Init.lua`, insert a new branch after `casttracker` (roughly after line 511), before the `help` branch:
+
+```lua
+elseif(cmd == 'pools') then
+    local rows = {}
+    for instance in next, F.AuraState._instances do
+        local owner = instance._owner
+        local ownerName = owner and owner.GetName and owner:GetName() or '<anon>'
+        local row = {
+            name = ownerName,
+            unit = instance._unit or '?',
+            pooled = #instance._classifiedFreeList,
+            helpful = 0,
+            harmful = 0,
+        }
+        for _ in next, instance._helpfulClassifiedById do
+            row.helpful = row.helpful + 1
+        end
+        for _ in next, instance._harmfulClassifiedById do
+            row.harmful = row.harmful + 1
+        end
+        rows[#rows + 1] = row
+    end
+    table.sort(rows, function(a, b) return a.pooled > b.pooled end)
+    print('|cff00ccff Framed|r classified pool per instance:')
+    print(('  %-32s %-12s %6s %6s %6s'):format('frame', 'unit', 'pooled', 'live+', 'live-'))
+    for _, r in next, rows do
+        print(('  %-32s %-12s %6d %6d %6d'):format(r.name, r.unit, r.pooled, r.helpful, r.harmful))
+    end
+```
+
+- [ ] **Step 2: Add help text entry**
+
+In the `cmd == 'help'` branch (around line 523), add:
+
+```lua
+print('  /framed pools — Dump per-instance classified pool sizes (for #144 diagnostics)')
+```
+
+- [ ] **Step 3: Reload and verify**
+
+In WoW:
+- `/reload`
+- `/framed pools` — should print a table with one row per real frame
+- Numbers should be sensible: live+ and live- bounded by auras on that unit, pooled grows with churn
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Init.lua
+git commit -m "feat(debug): add /framed pools for per-instance classified pool inspection (#144)"
+git push origin working-testing
+```
+
+---
+
+## Task 7: Acceptance gate — MemDiag A/B and test matrix
+
+**Goal:** Validate that the pool actually reduces allocation without regressing correctness or introducing growth pathology.
+
+**No code changes.** If any check fails, root-cause and add a follow-up task before declaring the PR ready.
+
+- [ ] **Step 1: Pre-change MemDiag baseline**
+
+Checkout the parent of the first pool commit (Task 2's commit on `working-testing`):
+
+```bash
+git log --oneline -n 10  # find commit hash BEFORE Task 2's commit
+git checkout <parent-hash>
+```
+
+In WoW:
+- `/reload`
+- Enter LFR, wait for a pull to start (≥15 players visible in raid frames)
+- `/framed memdiag 30`
+- Save the bucket totals + top rows
+
+Return to tip:
+```bash
+git checkout working-testing
+```
+
+- [ ] **Step 2: Post-change MemDiag comparison**
+
+In WoW on comparable LFR content:
+- `/reload`
+- `/framed memdiag 30`
+- Compare to Step 1 numbers
+
+Expected:
+- `AuraState:*` rows (`ApplyUpdateInfo`, `GetHelpfulClassified`, `GetHarmfulClassified`, `GetClassifiedByInstanceID`) drop materially in per-call KB
+- `event:UNIT_AURA` bucket (nests AuraState) drops by comparable amount
+- Total 30 s allocation delta drops toward baseline (Framed share of yoyo shrinks)
+
+If allocation *doesn't* drop: the pool isn't being exercised. Check `/framed pools` — if pooled counts stay at 0, release path is not wired.
+
+- [ ] **Step 3: 0.7.20 regression replay**
+
+Load addons: MPlusQOL, AbilityTimeline, WeakAuras. Enter a 10+ player raid pull.
+
+Check after pull:
+- No `attempt to compare number with nil` errors in BugSack
+- No nil text errors from AceEvent dispatch
+- No missing / stale / ghost aura icons on any unit frame
+
+If any surface: the aliasing audit (Task 1) missed a consumer or an external addon is holding references we didn't expect. Root-cause before proceeding.
+
+- [ ] **Step 4: Growth-bound check**
+
+Run several LFR pulls back-to-back. After each, run `/framed memusage` and note the `aurastate pool` total. Expected: total stabilizes at working-set peak and does not climb monotonically across pulls.
+
+If it climbs without bound across 3+ pulls: freelist is retaining entries beyond reuse — investigate whether Reset paths are missing release, then add a hard cap follow-up if warranted.
+
+- [ ] **Step 5: Verify no ghost auras via audit replay**
+
+One explicit stress case: `/target <friendly>`, apply a buff (e.g., trinket proc), `/cleartarget`, wait 10s for the buff to expire off them, re-target. The formerly-pooled entry for that buff's ID will have been recycled by now — confirm no ghost aura appears on the fresh target.
+
+- [ ] **Step 6: Record findings in the PR body**
+
+When opening the PR for this branch, include in the body:
+- Pre/post MemDiag bucket totals for AuraState:* rows
+- Pool growth observation across multiple pulls
+- Explicit statement that 0.7.20 regression tests passed
+
+No commit for this task.
+
+---
+
+## Checklist self-review
+
+- Task 1 addresses the aliasing audit gate from the spec.
+- Tasks 2–4 implement the pool strictly to spec: per-instance, paired, wipe at acquire, release routed through dedicated helpers.
+- Tasks 5–6 implement the observability surfaces (diverging from spec's `/framed aurastate` note — documented above).
+- Task 7 is the test gate from the spec, operationalized.
+- Every code task ends with a commit + push (user's `feedback_commit_after_task` convention).
+- Every step references exact file paths and shows complete code.
+- No TODOs, no "fill in details", no placeholders.

--- a/docs/superpowers/plans/2026-04-22-fullrefresh-varargs.md
+++ b/docs/superpowers/plans/2026-04-22-fullrefresh-varargs.md
@@ -1,0 +1,531 @@
+# FullRefresh Varargs-Pack Elimination Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Per user preference (`feedback_inline_execution`), Framed plans execute inline rather than subagent-driven.
+
+**Goal:** Eliminate per-`FullRefresh` varargs-pack allocation in `AuraState` by routing HELPFUL and HARMFUL slot lookups through a single reusable per-instance scratch table, reducing the dominant allocation source in Framed's LFR memory yoyo.
+
+**Architecture:** Add a module-local `fillSlots(tbl, ...)` helper that packs vararg returns into a caller-provided table and returns the count. Add a `_slotsScratch = {}` field to each `AuraState` instance. Rewrite the two `{ GetAuraSlots(...) }` call sites in `AuraState:FullRefresh` to use the shared scratch via the helper. The HELPFUL and HARMFUL passes are sequential, so one scratch serves both safely.
+
+**Tech Stack:** Lua (WoW 12.0.x client API), `C_UnitAuras.GetAuraSlots`, `C_UnitAuras.GetAuraDataBySlot`.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-fullrefresh-varargs-design.md`
+
+**Branch:** `working-testing` (Framed's single-workspace convention — no worktree split; PRs merge `working-testing` → `working`).
+
+---
+
+## File Structure
+
+**Modify:** `Core/AuraState.lua`
+- Insert module-local `fillSlots` helper near existing allocation-avoidance helpers (after `releaseClassified`, before `isCompoundUnit`).
+- Add `_slotsScratch = {}` field to the `F.AuraState.Create` instance table (next to `_classifiedFreeList = {}`).
+- Replace HELPFUL varargs-pack + loop inside `AuraState:FullRefresh`.
+- Replace HARMFUL varargs-pack + loop inside `AuraState:FullRefresh`.
+
+No other files touched. No new files created.
+
+---
+
+## Verification Model
+
+This is a WoW addon with no test harness. Verification after each task is:
+1. **Reload:** User runs `/reload` in-game. No Lua errors in `BugSack`.
+2. **Targeted behavior check:** User confirms the affected feature still works (buffs render after HELPFUL rewrite, debuffs render after HARMFUL rewrite, etc.).
+3. **Final validation** (Task 6): Ghost-aura stress, zero-aura unit, regression replay, MemDiag A/B.
+
+Each task commits + pushes per `feedback_commit_after_task` (crash protection between reloads).
+
+---
+
+## Task 1: Capture pre-change MemDiag baseline
+
+**Why first:** The existing baseline from #155 was pre-#160. #160 reduced `Get*Classified` allocation but left `FullRefresh`'s varargs packs untouched. We need a fresh baseline on the current `working-testing` HEAD so the post-change A/B is apples-to-apples.
+
+**Files:** None modified. Data capture only.
+
+- [ ] **Step 1: Confirm branch is clean at current HEAD**
+
+Run: `git status && git log --oneline -1`
+Expected: clean tree, HEAD at `6dea4e1 Revise FullRefresh varargs spec per review feedback` (or later if spec has been amended).
+
+- [ ] **Step 2: Ask user to run baseline MemDiag in LFR**
+
+User instructions (deliver to user):
+```
+Before we make any code changes, I need a fresh baseline MemDiag reading.
+
+1. Queue LFR (any wing — pick whichever pops quickest).
+2. Once you're in and the first pull starts, run: /framed memdiag 30
+3. Wait 30 seconds, then paste the full output here.
+
+We're looking for the AuraState:FullRefresh row's bytes-per-call and total,
+plus the event:UNIT_AURA bucket total. That's what Task 6 will compare against.
+```
+
+- [ ] **Step 3: Record baseline values**
+
+When user pastes output, record three values for the plan's post-change comparison:
+- `AuraState:FullRefresh` — bytes per call, total bytes, call count
+- `event:UNIT_AURA` — total bytes
+- Total `collectgarbage('count')` delta across the 30 s window
+
+Save as a comment on this task in the conversation (no file edit needed).
+
+- [ ] **Step 4: No commit**
+
+Data capture task — nothing to commit.
+
+---
+
+## Task 2: Add `fillSlots` helper and `_slotsScratch` field
+
+**Files:**
+- Modify: `Core/AuraState.lua` (two insertion points)
+
+Both additions are dead code on their own (nothing calls the helper; nothing reads the field). Combining them into one commit avoids having two no-op commits in history while keeping Task 2 small enough to verify with a single reload.
+
+- [ ] **Step 1: Insert `fillSlots` helper after `releaseClassified`**
+
+Locate the existing anchor in `Core/AuraState.lua`:
+```lua
+local function releaseClassified(pool, entry)
+	entry.aura = nil
+	pool[#pool + 1] = entry
+end
+
+-- Compound unit tokens (e.g. 'party2target', 'playertarget', 'focustarget')
+```
+
+Insert the new helper between `end` and the `-- Compound unit tokens` comment, like so:
+
+```lua
+local function releaseClassified(pool, entry)
+	entry.aura = nil
+	pool[#pool + 1] = entry
+end
+
+-- Pack GetAuraSlots varargs into `tbl` without allocating a fresh pack table.
+-- Returns the count, which callers MUST use as the iteration bound (not #tbl).
+-- Position 1 holds the continuation token; real slot IDs start at index 2.
+-- The tail loop nils any residual entries from a prior call where the aura
+-- count was higher, keeping `tbl` a proper sequence across reuses.
+local function fillSlots(tbl, ...)
+	local n = select('#', ...)
+	for i = 1, n do
+		tbl[i] = select(i, ...)
+	end
+	for i = n + 1, #tbl do
+		tbl[i] = nil
+	end
+	return n
+end
+
+-- Compound unit tokens (e.g. 'party2target', 'playertarget', 'focustarget')
+```
+
+Use tabs for indentation (per `CLAUDE.md` code style — aligns with oUF).
+
+- [ ] **Step 2: Add `_slotsScratch` field to `F.AuraState.Create`**
+
+Locate the existing `Create` instance-table literal in `Core/AuraState.lua`:
+
+```lua
+function F.AuraState.Create(owner)
+	local inst = setmetatable({
+		_owner = owner,
+		...
+		_classifiedFreeList = {},
+	}, AuraState)
+```
+
+Add `_slotsScratch = {},` immediately after `_classifiedFreeList = {},`:
+
+```lua
+		_classifiedFreeList = {},
+		_slotsScratch = {},
+	}, AuraState)
+```
+
+- [ ] **Step 3: Request user reload**
+
+User instructions:
+```
+I've added the fillSlots helper and _slotsScratch field. Both are
+dead code for now (no call sites yet), so this reload just confirms
+the file parses cleanly.
+
+Please /reload and let me know if BugSack shows any Lua errors.
+```
+
+Expected: no errors. The helper is defined but never called; the field is set but never read.
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add Core/AuraState.lua
+git commit -m "refactor(AuraState): add fillSlots helper and _slotsScratch field (#155)
+
+Module-local fillSlots packs GetAuraSlots varargs into a caller-provided
+table without allocating a fresh pack per call. _slotsScratch is a
+per-instance reusable scratch table. Both unused until FullRefresh
+call sites are rewritten in the next commits.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+git push origin working-testing
+```
+
+---
+
+## Task 3: Rewrite HELPFUL call site in `FullRefresh`
+
+**Files:**
+- Modify: `Core/AuraState.lua` (HELPFUL block inside `AuraState:FullRefresh`)
+
+- [ ] **Step 1: Locate the HELPFUL block**
+
+Search for the exact anchor in `Core/AuraState.lua`:
+```lua
+	local helpfulResults = { GetAuraSlots(unit, 'HELPFUL') }
+	for i = 2, #helpfulResults do
+		local aura = GetAuraDataBySlot(unit, helpfulResults[i])
+		if(aura and aura.auraInstanceID) then
+			self._helpfulById[aura.auraInstanceID] = aura
+		end
+	end
+```
+
+This block lives inside `AuraState:FullRefresh`. (Line number was 244 pre-Task-2; adding the helper shifts it by ~15 lines — use the code anchor, not the line number.)
+
+- [ ] **Step 2: Replace with scratch + helper call**
+
+Replace the entire HELPFUL block (exact 7 lines shown above) with:
+
+```lua
+	local nHelpful = fillSlots(self._slotsScratch, GetAuraSlots(unit, 'HELPFUL'))
+	for i = 2, nHelpful do
+		local aura = GetAuraDataBySlot(unit, self._slotsScratch[i])
+		if(aura and aura.auraInstanceID) then
+			self._helpfulById[aura.auraInstanceID] = aura
+		end
+	end
+```
+
+Changes: `{ GetAuraSlots(...) }` → `fillSlots(self._slotsScratch, GetAuraSlots(...))`; loop bound `#helpfulResults` → `nHelpful`; index source `helpfulResults[i]` → `self._slotsScratch[i]`. Everything else is identical.
+
+- [ ] **Step 3: Request user reload + buff render check**
+
+User instructions:
+```
+HELPFUL (buffs) path now routes through _slotsScratch via fillSlots.
+Please:
+
+1. /reload
+2. Target yourself (/tar player) or any friendly unit with visible buffs.
+3. Confirm buffs render correctly on the target frame.
+4. Check BugSack for any Lua errors.
+
+If buffs render and no errors: we're good. Report back either way.
+```
+
+Expected: buffs render identically to before; no Lua errors. Behavior is unchanged — same iteration bounds, same data flow, just the scratch substitution.
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add Core/AuraState.lua
+git commit -m "refactor(AuraState): route FullRefresh HELPFUL through _slotsScratch (#155)
+
+Eliminates one of two { GetAuraSlots(...) } varargs packs per FullRefresh
+call. HARMFUL follows in the next commit.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+git push origin working-testing
+```
+
+---
+
+## Task 4: Rewrite HARMFUL call site in `FullRefresh`
+
+**Files:**
+- Modify: `Core/AuraState.lua` (HARMFUL block inside `AuraState:FullRefresh`, immediately after the now-rewritten HELPFUL block)
+
+- [ ] **Step 1: Locate the HARMFUL block**
+
+Search for the exact anchor:
+```lua
+	local harmfulResults = { GetAuraSlots(unit, 'HARMFUL') }
+	for i = 2, #harmfulResults do
+		local aura = GetAuraDataBySlot(unit, harmfulResults[i])
+		if(aura and aura.auraInstanceID) then
+			self._harmfulById[aura.auraInstanceID] = aura
+		end
+	end
+```
+
+- [ ] **Step 2: Replace with scratch + helper call**
+
+Replace the entire HARMFUL block (exact 7 lines shown above) with:
+
+```lua
+	local nHarmful = fillSlots(self._slotsScratch, GetAuraSlots(unit, 'HARMFUL'))
+	for i = 2, nHarmful do
+		local aura = GetAuraDataBySlot(unit, self._slotsScratch[i])
+		if(aura and aura.auraInstanceID) then
+			self._harmfulById[aura.auraInstanceID] = aura
+		end
+	end
+```
+
+The HELPFUL loop above has already finished reading `_slotsScratch` by the time this call executes, so reusing the same scratch is safe (sequential access, no concurrency, no re-entry — `GetAuraSlots` and `GetAuraDataBySlot` are pure C getters with no Lua callbacks).
+
+- [ ] **Step 3: Request user reload + debuff render check**
+
+User instructions:
+```
+HARMFUL (debuffs) path now also routes through _slotsScratch. Both
+FullRefresh varargs packs are eliminated.
+
+Please:
+
+1. /reload
+2. Engage a target dummy or easy mob, apply some debuffs (any DoT, or
+   let the mob swing on you).
+3. Confirm debuffs render correctly on your target frame.
+4. Confirm buffs still render (Task 3 didn't regress).
+5. Check BugSack.
+
+If both buff and debuff display works and no errors: green light.
+```
+
+Expected: both buffs and debuffs render identically to pre-change; no Lua errors.
+
+- [ ] **Step 4: Commit + push**
+
+```bash
+git add Core/AuraState.lua
+git commit -m "refactor(AuraState): route FullRefresh HARMFUL through _slotsScratch (#155)
+
+Second and final { GetAuraSlots(...) } varargs pack eliminated. Both
+HELPFUL and HARMFUL passes now share the per-instance _slotsScratch
+table, accessed sequentially within FullRefresh.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+git push origin working-testing
+```
+
+---
+
+## Task 5: In-game validation pass
+
+**Files:** None modified. Behavioral validation only, matching the test gate in the spec.
+
+- [ ] **Step 1: Ghost-aura stress**
+
+User instructions:
+```
+Ghost-aura stress test (verifies the scratch is properly reset between units):
+
+1. Target yourself — note the buffs showing.
+2. /tar party1 (or any party/raid member with different buffs).
+3. Switch back to /tar player.
+4. Repeat target-swap several times, ideally while buffs are expiring
+   and being refreshed.
+5. Watch for: buffs from another unit bleeding onto yours, missing
+   buffs that should be there, duplicated buffs, or any visual
+   inconsistency.
+
+Expected: buff display matches current unit exactly at every swap.
+Report what you see.
+```
+
+- [ ] **Step 2: Zero-aura unit**
+
+User instructions:
+```
+Zero-aura test (verifies fillSlots handles the no-aura return shape):
+
+1. Find any unit with no active buffs/debuffs — a training dummy that's
+   currently not being hit, or a mob just before engaging.
+2. /tar that unit.
+3. Confirm no Lua errors in BugSack.
+4. If you can find a unit that cleanly shows zero auras: confirm an
+   empty buff/debuff row (or nothing at all) renders without error.
+
+Expected: no errors regardless of what GetAuraSlots returns for the
+no-aura case. The iteration `for i = 2, n` is a no-op for any n ≤ 1.
+```
+
+- [ ] **Step 3: Regression replay**
+
+User instructions:
+```
+Full regression replay:
+
+1. /reload fresh.
+2. Enter combat (any target, any fight).
+3. Exit combat.
+4. Target chains: /tar target, /tar targettarget (compound units —
+   AuraState skips these via isCompoundUnit, but we verify no error).
+5. If you have MPlusQOL / AbilityTimeline / WeakAuras loaded, verify
+   none of them throw `attempt to compare number with nil` or nil-text
+   errors (the 0.7.20 pool regression signature).
+
+Expected: zero BugSack errors across the full sequence.
+```
+
+- [ ] **Step 4: No commit**
+
+Validation task — nothing to commit unless a regression is found. If a regression surfaces, create a new task to fix and re-validate before proceeding.
+
+---
+
+## Task 6: Capture post-change MemDiag and compute A/B delta
+
+**Files:** None modified. Data capture + analysis.
+
+- [ ] **Step 1: Request post-change MemDiag in comparable LFR**
+
+User instructions:
+```
+Final measurement — post-change MemDiag in LFR.
+
+1. Queue LFR again (same wing as Task 1 if possible, to minimize pull-
+   intensity drift).
+2. Once in and the first pull starts, run: /framed memdiag 30
+3. Wait 30 seconds, paste the full output.
+
+If same-wing isn't possible, any comparable 20-man raid environment is
+fine — we'll note the difference when interpreting.
+```
+
+- [ ] **Step 2: Compute the A/B delta**
+
+Compare post-change output to the Task 1 baseline. Record:
+
+| Metric | Pre | Post | Delta |
+|---|---|---|---|
+| `AuraState:FullRefresh` bytes/call | | | |
+| `AuraState:FullRefresh` total | | | |
+| `event:UNIT_AURA` total | | | |
+| Total GC delta (30 s) | | | |
+
+Important caveat per the spec: MemDiag attribution is per-Lua-function, not per-expression. `AuraState:FullRefresh` bytes-per-call covers *everything* in that function including the AuraData tables returned by `GetAuraDataBySlot` (Blizzard-owned, one per slot, out of scope for this PR). The expected delta is the share that belongs to the two eliminated varargs packs — magnitude is informational, direction is the criterion.
+
+If call counts differ significantly (as happened in #160's A/B where post-change had 1.7× more UNIT_AURA events), normalize bytes-per-call and flag non-comparability in the PR body.
+
+- [ ] **Step 3: No commit**
+
+Analysis task — no file changes. Findings flow into the PR body in Task 7.
+
+---
+
+## Task 7: Push branch + create PR
+
+**Files:** None modified locally. Branch push + GitHub PR.
+
+- [ ] **Step 1: Confirm branch is up to date**
+
+Run:
+```bash
+git status
+git log --oneline origin/working-testing..working-testing
+```
+
+Expected: clean tree. Second command shows the three commits from Tasks 2, 3, 4 (helper+field, HELPFUL rewrite, HARMFUL rewrite), already pushed via per-task `git push` calls.
+
+If second command shows commits NOT yet pushed, push them:
+```bash
+git push origin working-testing
+```
+
+- [ ] **Step 2: Verify base branch for PR**
+
+Confirm `working` is the correct PR target (per `project_framed_worktree`: feature PRs go `working-testing` → `working`, then `working` promotes to `main` at release).
+
+Run:
+```bash
+git fetch origin
+git log --oneline origin/working..origin/working-testing
+```
+
+Expected: shows the three commits from this branch that `working` doesn't have yet. If there are unrelated commits mixed in, flag before proceeding.
+
+- [ ] **Step 3: Create PR**
+
+```bash
+gh pr create --base working --head working-testing --title "refactor(AuraState): eliminate FullRefresh varargs-pack allocation (#155 item 3)" --body "$(cat <<'EOF'
+## Summary
+
+Eliminates the two `{ GetAuraSlots(unit, 'HELPFUL') }` / `{ GetAuraSlots(unit, 'HARMFUL') }` varargs packs per `AuraState:FullRefresh` call by routing slot lookups through a single per-instance `_slotsScratch` table via a new `fillSlots(tbl, ...)` module-local helper.
+
+Item 3 from #155's ranked fix list, deferred from #144 to keep that PR's MemDiag attribution clean.
+
+## Design
+
+Spec: `docs/superpowers/specs/2026-04-22-fullrefresh-varargs-design.md`
+
+Key decisions:
+- **One scratch per instance** (not one per direction) — HELPFUL and HARMFUL passes are strictly sequential within `FullRefresh`, so a single shared scratch is safe and simpler.
+- **Tail-clear on reuse** (not full `wipe`) — table is bounded and `n` is already known; walking the whole table every call is wasted work.
+- **Per-instance** (not module-shared) — matches #144's approach; avoids the 0.7.20 revert's shared-state failure mode.
+
+## MemDiag A/B (30 s LFR window)
+
+<!-- Fill in from Task 1 + Task 6 output -->
+
+| Metric | Pre | Post | Delta |
+|---|---|---|---|
+| `AuraState:FullRefresh` bytes/call | | | |
+| `AuraState:FullRefresh` total | | | |
+| `event:UNIT_AURA` total | | | |
+| Total GC delta | | | |
+
+**Caveat:** MemDiag attribution is per-Lua-function, not per-expression. `FullRefresh`'s total covers the AuraData tables returned by `GetAuraDataBySlot` (Blizzard-owned, out of scope) as well as the eliminated varargs packs. Magnitude is informational; direction is the criterion.
+
+## Test plan
+
+- [x] `fillSlots` helper + `_slotsScratch` field added (Task 2 reload clean)
+- [x] HELPFUL call site rewritten, buffs render (Task 3)
+- [x] HARMFUL call site rewritten, debuffs render (Task 4)
+- [x] Ghost-aura stress — no cross-unit bleed on target swaps (Task 5)
+- [x] Zero-aura unit — no errors regardless of `GetAuraSlots` no-aura return shape (Task 5)
+- [x] Regression replay with MPlusQOL / AbilityTimeline / WeakAuras — zero BugSack errors (Task 5)
+- [x] MemDiag A/B captured (Task 6)
+
+## Out of scope (deferred)
+
+- `Elements/Status/StatusText.lua:80` drink-scan varargs pack — cold path, OOC-only (separate issue).
+- `Libs/oUF/elements/auras.lua` call sites — embedded oUF off-limits.
+- Item 2 from #155 — reducing `FullRefresh` call frequency — separate future PR to keep A/B clean.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Backfill MemDiag A/B table from Task 6 findings**
+
+The PR body template has a placeholder `<!-- Fill in from Task 1 + Task 6 output -->` with an empty table. Edit the PR after creation:
+
+```bash
+gh pr edit <pr-number> --body "$(cat <<'EOF'
+... (paste the full body with A/B table filled in from Task 6 Step 2) ...
+EOF
+)"
+```
+
+Or manually via `gh pr view <number> --web` and edit in the browser.
+
+- [ ] **Step 5: Report PR URL to user**
+
+Share the PR URL. The user reviews → merges `working-testing` → `working` → eventually promotes `working` → `main` on release cadence.
+
+---
+
+## Notes for the executor
+
+- **Code style:** Tabs for indentation, single quotes for strings, parenthesized conditions (`if(x) then`), `for _, v in next, tbl do` (never `pairs`/`ipairs`). See `CLAUDE.md`.
+- **Symlink:** Framed's addon folder is a symlink to this repo. Edits are live — user just `/reload`s to pick up changes (no rsync). See `feedback_wow_sync`.
+- **Per-task commits:** Commit + push after every task. Crash protection between reloads. See `feedback_commit_after_task`.
+- **No pcall:** Feature detection via `if C_UnitAuras.GetAuraSlots then`, never `pcall`. This plan doesn't add any new feature detection, but don't introduce `pcall` in the helper.
+- **Comments:** Default to no comments. The one comment in `fillSlots` (Task 2 Step 1) documents the non-obvious contract (callers MUST use returned `n`, not `#tbl`) — that's a WHY, not a WHAT, so it stays.

--- a/docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md
+++ b/docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md
@@ -131,8 +131,11 @@ Existing `self._helpfulById` / `self._harmfulById` stores stay untouched during 
 
 | Tier | Flags | Source | Secret-safe |
 |------|-------|--------|-------------|
-| 1 (passthrough) | `isHelpful`, `isHarmful`, `isRaid`, `isBossAura`, `isFromPlayerOrPet` | `AuraData` structural booleans | Always |
+| 1a (passthrough) | `isHelpful`, `isHarmful`, `isRaid`, `isFromPlayerOrPet` | `AuraData` structural booleans | Always — de-secret'd by Blizzard in 12.0.x |
+| 1b (guarded passthrough) | `isBossAura` | `AuraData` boolean via `F.IsValueNonSecret()` guard | Graceful degrade — secret resolves to `false` |
 | 2 (C probe) | `isExternalDefensive`, `isImportant`, `isPlayerCast`, `isBigDefensive` | `C_UnitAuras.IsAuraFilteredOutByInstanceID(unit, id, filter)` | Always (C-level API) |
+
+**Why `isBossAura` needs the guard:** per Blizzard's 12.0.x API changes, `isHelpful` / `isHarmful` / `isRaid` / `isNameplateOnly` / `isFromPlayerOrPlayerPet` are no longer secret on aura data tables. `isBossAura` remains secret on encounter auras — a bare `or false` on a secret boolean taints the enclosing function. The guard is the minimum defensive read.
 
 **Originally proposed a third tier** (spellID-keyed cache for `isBigDefensive` via `C_UnitAuras.AuraIsBigDefensive`). Dropped because (a) `spellId` is typically secret in combat, and `AuraIsBigDefensive` is not documented to accept secret scalars; (b) the probe alternative is already proven by current Externals.lua. Two tiers keeps single-path and avoids feature-detection branching.
 
@@ -214,13 +217,16 @@ local function classify(unit, aura, isHelpful)
     local id = aura.auraInstanceID
     local prefix = isHelpful and 'HELPFUL' or 'HARMFUL'
 
-    -- Tier 1: structural passthrough (always safe, never secret)
+    -- Tier 1a: derived from caller's filter (never reads a secret field).
+    -- Tier 1b: AuraData booleans guarded with F.IsValueNonSecret — these
+    -- fields can be secret per-aura (e.g. isBossAura on encounter auras),
+    -- so a bare `or false` would taint the classify call. Secret -> false.
     local flags = {
-        isHelpful         = aura.isHelpful or false,
-        isHarmful         = aura.isHarmful or false,
-        isRaid            = aura.isRaid or false,
-        isBossAura        = aura.isBossAura or false,
-        isFromPlayerOrPet = aura.isFromPlayerOrPlayerPet or false,
+        isHelpful         = isHelpful,
+        isHarmful         = not isHelpful,
+        isRaid            = F.IsValueNonSecret(aura.isRaid)                 and aura.isRaid                 or false,
+        isBossAura        = F.IsValueNonSecret(aura.isBossAura)             and aura.isBossAura             or false,
+        isFromPlayerOrPet = F.IsValueNonSecret(aura.isFromPlayerOrPlayerPet) and aura.isFromPlayerOrPlayerPet or false,
     }
 
     -- Tier 2: instance-ID filter probes.
@@ -392,15 +398,18 @@ No cold-start branch leaks to callers.
 
 ### Secret-value invariants
 
-A1 is single-path. The same `classify()` runs for every aura regardless of which fields are secret. No `F.IsValueNonSecret()` branches anywhere in the classification layer.
+A1 is single-path. The same `classify()` runs for every aura; `F.IsValueNonSecret()` appears on exactly one field read (`aura.isBossAura`). No conditional branches change *what* is classified based on secret-ness — the guard is a graceful-degrade wrapper on a single field read.
 
 Why this works cleanly:
 
-- **Tier 1 passthrough:** structural booleans on `AuraData` (`isHelpful`, `isHarmful`, `isRaid`, `isBossAura`, `isFromPlayerOrPlayerPet`) are never secret, regardless of whether other fields on the same AuraData are secret.
-- **Tier 2 probes:** `IsAuraFilteredOutByInstanceID` is explicitly secret-safe per the CLAUDE.md "Secret Values" section.
+- **Tier 1a (passthrough):** `isHelpful`, `isHarmful`, `isRaid`, `isFromPlayerOrPet` are no longer secret per [Patch 12.0.5 API changes](https://warcraft.wiki.gg/wiki/Patch_12.0.5/API_changes): *"The isHelpful, isHarmful, isRaid, isNameplateOnly, and isFromPlayerOrPlayerPet fields on AuraData are no longer secret."* Bare `aura.field or false` is safe.
+- **Tier 1b (guarded passthrough):** `isBossAura` remains secret on encounter auras. Read via `F.IsValueNonSecret(aura.isBossAura) and aura.isBossAura or false`. Secret values resolve to `false`. This is *graceful degradation*, not a split path: a boss-aura still renders; it just won't surface `flags.isBossAura=true` while its field is tainted. No Framed consumer currently reads this flag in a way that breaks on a `false` result.
+- **Tier 2 probes:** `IsAuraFilteredOutByInstanceID` is explicitly secret-safe per the CLAUDE.md "Secret Values" section — pass-through by C API.
 - **`entry.aura`** is a live ref — it carries whatever secret-ness the aura has. Downstream consumers handle via existing `F.IsValueNonSecret()` + secret-safe C-level rendering, exactly as they do today against raw `GetHelpful` results.
 
-The classification layer sits strictly upstream of any secret-value read. The "never split secret/non-secret paths" CLAUDE.md rule is upheld.
+**Why we can't skip the `isBossAura` guard:** empirically (AuraState crash 2026-04-21, error log locals) a single `AuraData` can carry `isHelpful=true` / `isRaid=false` (both non-secret per 12.0.5) alongside `isBossAura=<secret>`. A bare `or false` on the secret field taints the enclosing function. The guard is the minimum defensive read.
+
+The classification layer sits strictly upstream of any secret-value *comparison* or *arithmetic*. The "never split secret/non-secret paths" CLAUDE.md rule is upheld — there is one `classify()` path for every aura on every frame.
 
 ### C API return normalization
 

--- a/docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md
+++ b/docs/superpowers/specs/2026-04-21-unit-aura-fanout-rearchitecture-design.md
@@ -1,7 +1,7 @@
 # UNIT_AURA Fan-Out Rearchitecture Design Spec
 
 **Date:** 2026-04-21
-**Issue:** #115 (parent); #136 (A1), #137-#142 (B1-B6), #143 (C1)
+**Issue:** #115 (parent); #136 (A1), #137-#141 (B1-B5), #143 (C1). #142 (B6 StatusText) dropped from scope — see below.
 **Status:** Approved
 
 ## Summary
@@ -12,7 +12,7 @@ Today's aura elements fall into two classes:
 
 - **Classification-heavy** (Externals, Defensives) — call `IsAuraFilteredOutByInstanceID` directly in their Update paths, up to 5 probes per aura per UNIT_AURA in Externals.
 - **Spell-set-driven** (Buffs, Debuffs, MissingBuffs) — don't do classification themselves, but would benefit from pre-computed flags to simplify `castBy='me'` decisions and dispel-color handling.
-- **Text/status** (StatusText) — registers its own UNIT_AURA handler for Drinking/Food detection; consolidation reduces total UNIT_AURA fan-out count.
+- ~~**Text/status** (StatusText) — registers its own UNIT_AURA handler for Drinking/Food detection.~~ Out of scope: StatusText's aura scan is spellID-name-based (no flag reads) and short-circuits via `InCombatLockdown()` before running, so it contributes zero cost to the combat window this work targets. See "Non-goals for A1" and the B6 drop rationale below.
 
 After this rearchitecture: four probes per aura per classification write, shared across all elements on the same frame (via the existing per-frame `self.FramedAuraState` instance). Target: ≈50% reduction from baseline.
 
@@ -43,11 +43,11 @@ The fix: classify once on the shared per-frame AuraState, expose flags, let elem
 | Tier structure | 2 tiers (passthrough + C probe) | Originally 3 tiers; revised to drop `AuraIsBigDefensive` in favor of probe |
 | Update-path behavior | Always re-classify | Correctness > microperf at UNIT_AURA rate |
 | B-series pacing | Per-element gate | Each element migrates independently; smoke test + merge between |
-| B-series order | B6 → B1 → B2 → B4 → B5 → B3 | Simplest first (smoke); Buffs last (size + #113 retirement) |
+| B-series order | B2 → B1 → B4 → B5 → B3 | B2 is simplest flag consumer (smoke-test); Buffs last (size + #113 retirement). B6 StatusText dropped — see below. |
 | Buffs castBy model | `flags.isPlayerCast` exclusively | Retires #113 over-match workaround silently |
 | Debug surface | `/framed aurastate <unit>` slash | Permanent shipping feature; matches `/framed events` / `/framed config` pattern |
 | Flag-table pooling | Deferred (unpooled in A1) | Prior attempt caused cross-addon taint; conservative retry is a separate issue |
-| Spec structure | Single comprehensive spec | A1 + B1-B6 + C1 share enough design surface to document once |
+| Spec structure | Single comprehensive spec | A1 + B1-B5 + C1 share enough design surface to document once |
 
 ## Prior Work and Dependencies
 
@@ -125,7 +125,7 @@ self._helpfulClassifiedById[instanceID] = {
 
 `isBigDefensive` is always `false` for harmful auras (the `HELPFUL|BIG_DEFENSIVE` filter has no harmful analog). The flag is present on every wrapper for shape stability.
 
-Existing `self._helpfulById` / `self._harmfulById` stores stay untouched during the migration. Each B-issue migrates one element's read path; writes to both stores happen in parallel. After B6 ships, a follow-up collapses the two stores.
+Existing `self._helpfulById` / `self._harmfulById` stores stay untouched during the migration. Each B-issue migrates one element's read path; writes to both stores happen in parallel. After the B-series ships, a follow-up collapses the two stores.
 
 ### Flag lifecycle tiers
 
@@ -158,8 +158,8 @@ AuraState's existing `ensureFresh(unit)` gate catches all three categories.
 ### Non-goals for A1
 
 - No pooling of `flags` tables. (Deferred issue.)
-- No collapse of `_helpfulById` + `_helpfulClassifiedById`. (Follow-up after B6.)
-- No removal of `_helpfulMatches` filter memoization — some filters (e.g., `RAID_IN_COMBAT`) stay in use via `GetHelpful(filter)` post-B6.
+- No collapse of `_helpfulById` + `_helpfulClassifiedById`. (Follow-up after the B-series.)
+- No removal of `_helpfulMatches` filter memoization — some filters (e.g., `RAID_IN_COMBAT`) stay in use via `GetHelpful(filter)` post-B-series.
 - No changes to existing `GetHelpful(filter)` / `GetHarmful(filter)` shape or behavior.
 - No mutation of `AuraData` references.
 - No new event registrations.
@@ -188,7 +188,7 @@ function AuraState:GetClassifiedByInstanceID(instanceID) end
 
 All three run through the existing `EnsureInitialized(self._unit)` generation gate — same semantics as `GetHelpful` / `GetHarmful`.
 
-`GetClassifiedByInstanceID` is the single-entry accessor for elements that hold a spellID-to-instanceID map or process `updateInfo.updatedAuraInstanceIDs` payloads directly. **Primary planned consumer: B3 Buffs (#139)** per-indicator resolution path — the migrated Buffs element resolves indicator-tracked spells to their current wrapper entry in O(1) rather than scanning the full classified array. **B6 StatusText (#142)** is a secondary candidate if its migrated Drinking/Food detection switches from array-scan to delta-payload processing. The API ships in A1 so B-series wiring exists when those migrations land; final call sites are fixed at B-series issue refinement.
+`GetClassifiedByInstanceID` is the single-entry accessor for elements that hold a spellID-to-instanceID map or process `updateInfo.updatedAuraInstanceIDs` payloads directly. **Primary planned consumer: B3 Buffs (#139)** per-indicator resolution path — the migrated Buffs element resolves indicator-tracked spells to their current wrapper entry in O(1) rather than scanning the full classified array. The API ships in A1 so B-series wiring exists when that migration lands; final call sites are fixed at B-series issue refinement.
 
 Unlike `GetHelpful(filter)` which takes a filter string, the classified APIs return all helpful/harmful auras with flags populated. Filter-like narrowing is done by the caller via flag reads: `if(entry.flags.isExternalDefensive)`.
 
@@ -485,7 +485,7 @@ Enter a raid boss encounter mid-auras. On `ENCOUNTER_START`, generation bumps (e
 
 ### B-series acceptance (generic template)
 
-Each of #137-#142 follows:
+Each of #137-#141 follows:
 
 1. **Pre-migration snapshot.** Screenshot the element in 3-4 representative scenarios.
 2. **Migrate** to read `entry.flags.*` or the classified slice instead of element-side probes / separate `GetHelpful(filter)` calls.
@@ -498,12 +498,13 @@ Each of #137-#142 follows:
 
 | Issue | Element | Migration focus | Must-test scenarios |
 |-------|---------|-----------------|---------------------|
-| #142 B6 (first) | `Elements/Status/StatusText.lua` | Event-handler consolidation: consume classified helpful slice for Drinking/Food detection | Drinking food buff appears with correct text/color/timer; no regression in summon-pending, disconnect, AFK, dead, ghost states |
+| #138 B2 (first) | `Elements/Auras/Defensives.lua` | Single BIG_DEFENSIVE probe becomes `flags.isBigDefensive` read + `flags.isPlayerCast` for border-color distinction | Self Divine Shield; Ice Block; Cooldown Aggressive; player-cast border color distinction preserved |
 | #137 B1 | `Elements/Auras/Externals.lua` | Replace 5-probe classification chain with flag reads | Self PWS; external Ironbark; external BoP; IMPORTANT-only non-defensive helpful (still appears); RAID fallback for secret-spellID auras in combat (still hides Rejuvenation out of combat) |
-| #138 B2 | `Elements/Auras/Defensives.lua` | Single BIG_DEFENSIVE probe becomes `flags.isBigDefensive` read | Self Divine Shield; Ice Block; Cooldown Aggressive; player-cast border color distinction preserved |
 | #140 B4 | `Elements/Auras/Debuffs.lua` | Consume classified harmful slice (A1 already includes harmful per Q1) | Dispel-type colorization; boss/role debuff priority; `castBy` filter for harmful |
 | #141 B5 | `Elements/Auras/MissingBuffs.lua` | Consistency migration (spellID-driven, no classification needed) | Missing raid buff surfaces; cast it + confirm it clears |
 | #139 B3 (last) | `Elements/Auras/Buffs.lua` | `castBy='me'` uses `flags.isPlayerCast` (retires #113 over-match fallback); preserve `computeBuffFilter` and per-indicator spellID lookups | `castBy='me'` / `'others'` / `'all'` in combat + out of combat, with indicators with/without spell lists; no regression on border colors, stacks, ordering |
+
+**B6 #142 StatusText dropped from scope.** StatusText registers UNIT_AURA for Drinking/Food detection, but its `checkDrinking` scan short-circuits on `InCombatLockdown()` (StatusText.lua:76) before touching auras. The combat window this work targets is exactly when StatusText doesn't run. Separately, its scan is spellID-name-based (matches `aura.name` against the Food & Drink spell list) — it reads zero of the 9 classification flags, so routing it through `GetHelpfulClassified()` would make it pay the classify() cost for data it discards. Migration to `GetHelpful('HELPFUL')` (existing API) is a valid standalone cleanup but doesn't belong in the classification series. #142 closed as not-needed.
 
 ### B3 Buffs: #113 retirement
 
@@ -530,7 +531,7 @@ C1 is the closing verification pass. Deliverable: a documented report (no code c
 1. **Three profiler snapshots under identical conditions:**
    - S0: pre-A1 baseline (from memory: 0.448ms avg).
    - S1: post-A1, pre-B-series (classification writing, no element reading flags yet).
-   - S2: post-B6 (all elements migrated).
+   - S2: post-B3 (all in-scope elements migrated; B3 Buffs is the last B-issue).
 2. **Three scenarios, 60 seconds each:**
    - Target dummy solo (minimal churn).
    - 5-man M+ dungeon (moderate churn).
@@ -540,7 +541,7 @@ C1 is the closing verification pass. Deliverable: a documented report (no code c
    - `GetAddOnCPUUsage('Framed')` delta over window.
    - UNIT_AURA handler cost per event (profiler or `debugprofilestop`).
    - GC pressure (`collectgarbage('count')` delta over window).
-4. **Visual regression set:** screenshots of 8-12 representative element states, pre-A1 vs post-B6. Archived in the C1 GitHub issue as attachments.
+4. **Visual regression set:** screenshots of 8-12 representative element states, pre-A1 vs post-B3. Archived in the C1 GitHub issue as attachments.
 
 **Success bar:**
 
@@ -576,17 +577,15 @@ A1 itself is rollback-safe: new APIs + debug slash only. Reverting A1 is a non-e
 
 ```
 [#123 stale --> close]
+[#142 B6 StatusText dropped from scope]
 
 A1 (#136 AuraState classify)
   |
   v
-B6 (#142 StatusText) [smoke-test migration]
+B2 (#138 Defensives) [smoke-test migration — smallest flag consumer]
   |
   v
 B1 (#137 Externals)
-  |
-  v
-B2 (#138 Defensives)
   |
   v
 B4 (#140 Debuffs)
@@ -603,15 +602,14 @@ C1 (#143 Benchmark + VR)
 
 ### Locked execution order
 
-1. **Pre-work:** Close #123 as already-implemented.
+1. **Pre-work:** Close #123 as already-implemented; close #142 B6 as out-of-scope (StatusText combat-gated, reads no flags).
 2. **A1 #136** — AuraState classification + debug slash.
-3. **B6 #142** — StatusText (smallest element; validates `entry.flags.*` pattern).
+3. **B2 #138** — Defensives (smallest flag consumer; validates `entry.flags.*` pattern as smoke-test).
 4. **B1 #137** — Externals (highest C-API savings).
-5. **B2 #138** — Defensives (shares logic with Externals).
-6. **B4 #140** — Debuffs (independent of healing-oriented elements).
-7. **B5 #141** — MissingBuffs (complements Buffs, lighter).
-8. **B3 #139** — Buffs (largest; widest user-visible surface; #113 retirement).
-9. **C1 #143** — Benchmark + visual regression.
+5. **B4 #140** — Debuffs (independent of healing-oriented elements).
+6. **B5 #141** — MissingBuffs (complements Buffs, lighter).
+7. **B3 #139** — Buffs (largest; widest user-visible surface; #113 retirement).
+8. **C1 #143** — Benchmark + visual regression.
 
 ### Branch and release discipline
 
@@ -628,7 +626,7 @@ File as new GitHub issues when A1 ships:
 
 - **Flag-table pooling revisit** — conservative retry with bool-typed, wipe-on-release, internal-only pool.
 - **Store consolidation** — collapse `_helpfulById` + `_helpfulClassifiedById` into single classified store. Requires verifying no remaining caller needs raw AuraData without the flag wrapper.
-- **Partial `_helpfulMatches` cleanup** — the four filters that move to flags (`EXTERNAL_DEFENSIVE`, `IMPORTANT`, `PLAYER`, `BIG_DEFENSIVE`) can be stripped from the per-filter memoization path. Filters that stay in use post-B6 (e.g., `RAID_IN_COMBAT` for Buffs' `computeBuffFilter`, `RAID` for Debuffs' raid-filtered path) keep their memoization.
+- **Partial `_helpfulMatches` cleanup** — the four filters that move to flags (`EXTERNAL_DEFENSIVE`, `IMPORTANT`, `PLAYER`, `BIG_DEFENSIVE`) can be stripped from the per-filter memoization path. Filters that stay in use post-B-series (e.g., `RAID_IN_COMBAT` for Buffs' `computeBuffFilter`, `RAID` for Debuffs' raid-filtered path) keep their memoization.
 - **Cache coverage gap analysis** — document structural reasons Framed can't easily match Dander's 0.075ms.
 
 ## Files Touched
@@ -643,16 +641,17 @@ File as new GitHub issues when A1 ships:
   - Write-path additions in `FullRefresh`, `ApplyUpdateInfo` (wipe classified store / invalidate per-ID entries alongside existing filter-match invalidation).
 - `Init.lua` — new `/framed aurastate` case in slash dispatcher.
 
-### B-series (#137 - #142)
+### B-series (#137 - #141)
 
 Each migrates one element's read path:
 
-- `Elements/Status/StatusText.lua` (B6 #142) — event-handler consolidation
+- `Elements/Auras/Defensives.lua` (B2 #138) — single-probe → flag read (smoke-test)
 - `Elements/Auras/Externals.lua` (B1 #137) — probe chain → flag reads
-- `Elements/Auras/Defensives.lua` (B2 #138) — single-probe → flag read
 - `Elements/Auras/Debuffs.lua` (B4 #140) — consume classified harmful slice
 - `Elements/Auras/MissingBuffs.lua` (B5 #141) — consistency migration
 - `Elements/Auras/Buffs.lua` (B3 #139) — castBy via `isPlayerCast`
+
+`Elements/Status/StatusText.lua` (B6 #142) is intentionally omitted — see "B6 dropped" in the per-element scope section above.
 
 ### C1 (#143)
 
@@ -661,7 +660,7 @@ No code changes. Report attached to the GitHub issue.
 ## References
 
 - Parent issue: #115
-- Sub-issues: #136, #137, #138, #139, #140, #141, #142, #143
+- Sub-issues: #136, #137, #138, #139, #140, #141, #143 (#142 closed as out-of-scope)
 - Stale dependency to close: #123
 - Prior art in-repo: `Core/AuraCache.lua` (Aura Cache Design spec, 2026-04-10), `Core/AuraState.lua`
 - Source of truth for filter strings: `/tmp/wow-ui-source/Interface/AddOns/Blizzard_FrameXMLUtil/AuraUtil.lua:158-174`

--- a/docs/superpowers/specs/2026-04-22-buffs-annotation-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-22-buffs-annotation-cleanup-design.md
@@ -1,6 +1,6 @@
 # Buffs AuraData Mutation Elimination Design
 
-**Issue:** TBD (to be filed for the cf7fabb memory-regression in idle party/raid)
+**Issue:** #167 (cf7fabb memory-regression in idle party/raid)
 **Related:** #113 (the "show in both panels when sourceUnit is secret" fix — orthogonal, preserved as-is)
 **Date:** 2026-04-22
 

--- a/docs/superpowers/specs/2026-04-22-buffs-annotation-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-22-buffs-annotation-cleanup-design.md
@@ -1,0 +1,243 @@
+# Buffs AuraData Mutation Elimination Design
+
+**Issue:** TBD (to be filed for the cf7fabb memory-regression in idle party/raid)
+**Related:** #113 (the "show in both panels when sourceUnit is secret" fix — orthogonal, preserved as-is)
+**Date:** 2026-04-22
+
+## Goal
+
+Stop mutating Blizzard's `AuraData` tables inside `Elements/Auras/Buffs.lua`'s `matchAura` closure. Source the same values from their native Blizzard fields (`applications`) and from the existing `unit` closure local. Drop the unused `dispelType` plumbing from the Buffs rendering path entirely.
+
+## Background
+
+Current code annotates every matched helpful aura with three Framed-owned keys:
+
+```lua
+auraData.unit       = unit
+auraData.stacks     = auraData.applications
+auraData.dispelType = auraData.dispelName
+```
+
+Those annotations surface as:
+
+- `aura.unit` — forwarded to `C_UnitAuras.GetAuraDuration(unit, auraInstanceID)` inside `Icon:SetSpell`.
+- `aura.stacks` — forwarded to `Icon:SetStacks` (in the ICON / ICONS dispatches) and to `Bar:SetStacks` (BAR / BARS).
+- `aura.dispelType` — declared in `Icon:SetSpell`'s signature and documented, but **never read** inside its 408-line body. Dead parameter.
+
+The annotation pattern is Buffs-specific. `Debuffs.lua`, `Externals.lua`, `Defensives.lua`, and `Dispellable.lua` already read `auraData.applications` / `auraData.dispelName` directly and never mutate.
+
+### Why we're removing the mutation
+
+Two motivations, stacked:
+
+1. **Memory regression fix.** `cf7fabb` widens the helpful-aura query from `HELPFUL|RAID_IN_COMBAT` to plain `HELPFUL` whenever any enabled indicator has a non-empty `spells` list. With wider filter, Fort / Int / cosmetic / consumable / world buffs that Blizzard previously stripped server-side now flow through `matchAura` every `UNIT_AURA` tick — and every one gets mutated. The user's `SavedVariables` has custom spell lists on party-preset party frames (Rejuvenation tracking, `spells = { 774 }`), which triggered the widening. Bisect pinned the regression to cf7fabb; HEAD-solo vs cf7fabb-solo measured identical. Removing the mutation eliminates the only plausible Lua-invisible retention mechanism (Blizzard-side caching of enlarged `AuraData` tables) without reverting the filter-widening capability.
+
+2. **Pre-existing hazard documented in `docs/superpowers/plans/2026-04-22-b3-buffs-classified.md:84`.** In the classified path, `entry.aura` is the same `AuraData` reference shared across consumers. Framed's in-place mutation leaks Framed-owned keys onto a shared object that any other consumer (present or future) may inspect. Removing the mutation removes the aliasing risk outright.
+
+## Non-Goals
+
+- **Changing filter semantics.** `computeBuffFilter` behavior is untouched. Users with custom spell lists still get the widened filter and non-RAID_IN_COMBAT visibility they opted into.
+- **Option A (restore `buffFilterMode` as explicit config).** Separate future PR if Option C alone doesn't collapse the regression to baseline.
+- **Debuffs / Externals / Defensives / Dispellable.** They don't use the annotation pattern. No changes.
+- **BorderIcon widget.** It legitimately reads `dispelType` and is used by other elements; this PR doesn't touch it.
+
+## Context
+
+### Current call graph
+
+```
+Buffs:Update
+  matchAura(auraData)  -- mutates auraData.unit/.stacks/.dispelType
+    → appends to iconsAurasPool[idx] or matchedPool[idx]
+  dispatch to renderers:
+    ICONS  → Icons:SetIcons(list)          → reads aura.unit, aura.stacks, aura.dispelType
+    ICON   → Icon:SetSpell(unit, ..., stacks, dispelType)  -- dispelType param is dead
+    BAR    → Bar:SetStacks(aura.stacks)
+    BARS   → Bar:SetStacks(aura.stacks)    (per-bar inside Bars:SetBars loop)
+```
+
+### Field equivalence
+
+`AuraData.applications` (Blizzard-native, 12.0+ API) and `auraData.stacks` (Framed annotation) hold the same integer value. `.stacks` is a legacy rename from the pre-`C_UnitAuras` tuple-returning `UnitAura()` era. Embedded oUF already reads `.applications` directly (`Libs/oUF/elements/classpower.lua:117,122,203`).
+
+## Design
+
+### 1. `Elements/Auras/Buffs.lua`
+
+**Delete both annotation blocks** inside `matchAura`:
+
+```lua
+-- before
+if(not annotated) then
+    auraData.unit      = unit
+    auraData.stacks    = auraData.applications
+    auraData.dispelType = auraData.dispelName
+    annotated = true
+end
+```
+
+— appearing once in the spell-lookup branch (lines 180-185) and once in the trackAll branch (lines 200-205). Drop the `annotated` local along with them.
+
+**Update ICON dispatch (lines 260-276):**
+
+```lua
+-- before
+renderer:SetSpell(
+    aura.unit,
+    aura.auraInstanceID,
+    aura.spellId,
+    aura.icon,
+    aura.duration,
+    aura.expirationTime,
+    aura.stacks,
+    aura.dispelType
+)
+
+-- after
+renderer:SetSpell(
+    unit,
+    aura.auraInstanceID,
+    aura.spellId,
+    aura.icon,
+    aura.duration,
+    aura.expirationTime,
+    aura.applications
+)
+```
+
+The `dispelType` argument is dropped entirely (see Icon.lua change below).
+
+**Update ICONS dispatch (line 253):**
+
+```lua
+-- before
+renderer:SetIcons(list)
+
+-- after
+renderer:SetIcons(unit, list)
+```
+
+**Update BAR dispatch (line 295):**
+
+```lua
+-- before
+if(aura.stacks) then renderer:SetStacks(aura.stacks) end
+
+-- after
+if(aura.applications) then renderer:SetStacks(aura.applications) end
+```
+
+**Update BARS dispatch (line 358):** same substitution as BAR.
+
+### 2. `Elements/Indicators/Icons.lua`
+
+**Signature change at line 17:**
+
+```lua
+-- before
+function IconsMethods:SetIcons(auraList)
+
+-- after
+function IconsMethods:SetIcons(unit, auraList)
+```
+
+**Body changes:** inside the `for` loop, change the `icon:SetSpell` call (lines 73-82) to read the `unit` param instead of `aura.unit`, read `aura.applications` instead of `aura.stacks`, and drop the `aura.dispelType` argument:
+
+```lua
+-- before
+icon:SetSpell(
+    aura.unit,
+    aura.auraInstanceID,
+    aura.spellId,
+    aura.icon,
+    aura.duration,
+    aura.expirationTime,
+    aura.stacks,
+    aura.dispelType
+)
+
+-- after
+icon:SetSpell(
+    unit,
+    aura.auraInstanceID,
+    aura.spellId,
+    aura.icon,
+    aura.duration,
+    aura.expirationTime,
+    aura.applications
+)
+```
+
+Also update the LuaDoc comment at line 16 — drop `dispelType` from the `@param auraList` field list.
+
+### 3. `Elements/Indicators/Bars.lua`
+
+**Line 39-40:**
+
+```lua
+-- before
+if(aura.stacks) then
+    bar:SetStacks(aura.stacks)
+end
+
+-- after
+if(aura.applications) then
+    bar:SetStacks(aura.applications)
+end
+```
+
+### 4. `Elements/Indicators/Icon.lua`
+
+**Remove dead parameter at lines 29-30:**
+
+```lua
+-- before
+--- @param dispelType string|nil Dispel/debuff type ('Magic', 'Curse', etc.)
+function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, duration, expirationTime, stacks, dispelType)
+
+-- after
+function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, duration, expirationTime, stacks)
+```
+
+Both callers (`Buffs.lua:263` and `Icons.lua:73`) are updated in this same PR to match the new arity.
+
+## Risk Analysis
+
+**Correctness.** `aura.applications` is the Blizzard-native name for the same integer value Framed renamed to `aura.stacks`. No semantic change. The embedded oUF codebase already reads `.applications` directly for stack-driven logic — confirmed compatible with 12.0+ AuraData.
+
+**Field collision.** `auraData.unit`, `.stacks`, `.dispelType` are Framed-owned annotations. Blizzard's `AuraData` struct doesn't ship those fields, and nothing else in Framed writes them. Deleting the writes also means any speculative reader of those specific keys on a Blizzard `AuraData` table stops finding them — but no such reader exists in the codebase (verified via grep: all reads are in the files listed above, and they're all being updated in this PR).
+
+**`dispelType` cleanup affects other callers?** Icon:SetSpell has exactly two callers (`Buffs.lua:263` and `Icons.lua:73`). Both are updated in this PR. No external plugins depend on the Icon widget signature (Icon.lua is Framed-internal, not part of an exposed API surface).
+
+**Secret-value handling.** `auraData.applications` can be a secret value in combat, same as `.stacks` was. The `renderer:SetStacks` methods already handle secret values correctly (they're C-level calls or Framed widgets that guard via `IsValueNonSecret`). No behavioral change.
+
+**Ghost-aura class of bug.** Removing mutation cannot introduce ghost-aura issues — the mutation was never the mechanism preventing them. Ghost-aura prevention relies on the AuraState classified-entry pool invariants (#144), which this PR doesn't touch.
+
+**Classified-path shared references.** `entry.aura` in the classified path is still the same `AuraData` reference as `_helpfulById[id]`. Post-PR, Framed no longer writes onto that shared object. Any other element reading `entry.aura.applications` / `.dispelName` / the unit-via-parameter path gets clean Blizzard-owned data. Aliasing hazard removed.
+
+**Compound-unit defensiveness.** The outer `Update(self, event, unit, updateInfo)` captures `unit` once. `Icons:SetIcons(unit, list)` receives the same value. If `unit` is a compound token (e.g., mid-retarget transient), `C_UnitAuras.GetAuraDuration(unit, auraInstanceID)` inside `Icon:SetSpell` handles it — same as today.
+
+## Test Gate
+
+**Render correctness (manual):**
+- Solo: player buffs render icons + stack counts for stackable buffs (e.g., a trinket proc).
+- Party: party-member Rejuv (the user's tracked spell 774) renders with correct icon, duration, stack text.
+- Mixed-renderer config: confirm ICONS / ICON / BAR / BARS indicator types all render correctly (user has configs exercising each).
+
+**Memory regression check:**
+- Pre-fix baseline: `/reload` with current HEAD, stand idle in a party with Fort+Int active, record `collectgarbage('count')` every 5 s for 30 s.
+- Post-fix measurement: same conditions, confirm the per-second growth rate collapses toward 0.8.12 baseline. Direction is the criterion; absolute magnitude is informational.
+- If growth persists: the retention mechanism is elsewhere. Next step is Option A (restore explicit `buffFilterMode` config) — separate PR.
+
+**Regression replay:** reload with WeakAuras / MPlusQOL / AbilityTimeline loaded; combat entry + exit + target chains; zero `BugSack` errors.
+
+**Merge criteria:** rendering parity verified, memory A/B shows the expected collapse (or the fallback path to Option A is filed), zero regression errors across the replay.
+
+## References
+
+- `cf7fabb` — the commit that introduced the regression
+- `3890b20` — the independent "show when sourceUnit is secret" fix; unchanged by this PR
+- `#155` — memory-optimization ranked fix list (Option C is a pre-existing hazard from the list, not a numbered item)
+- `docs/superpowers/plans/2026-04-22-b3-buffs-classified.md:84` — prior documentation of the shared-reference hazard
+- `Elements/Auras/Buffs.lua` — current annotation site
+- `Elements/Indicators/Icons.lua` / `Icon.lua` / `Bars.lua` — consumers updated in this PR

--- a/docs/superpowers/specs/2026-04-22-buffs-annotation-cleanup-design.md
+++ b/docs/superpowers/specs/2026-04-22-buffs-annotation-cleanup-design.md
@@ -21,8 +21,16 @@ auraData.dispelType = auraData.dispelName
 Those annotations surface as:
 
 - `aura.unit` — forwarded to `C_UnitAuras.GetAuraDuration(unit, auraInstanceID)` inside `Icon:SetSpell`.
-- `aura.stacks` — forwarded to `Icon:SetStacks` (in the ICON / ICONS dispatches) and to `Bar:SetStacks` (BAR / BARS).
+- `aura.stacks` — forwarded to `Icon:SetStacks` (in the ICON / ICONS dispatches), to `Bar:SetStacks` (BAR / BARS / RECTANGLE dispatches), and directly read inside `Bars:SetBars` and `Icons:SetIcons`.
 - `aura.dispelType` — declared in `Icon:SetSpell`'s signature and documented, but **never read** inside its 408-line body. Dead parameter.
+
+Complete production-code reader inventory (confirmed via `rg 'aura\.(stacks|unit|dispelType)'`):
+
+- `Elements/Indicators/Bars.lua:39-40` — internal read inside `Bars:SetBars` loop
+- `Elements/Indicators/Icons.lua:74, 80, 81` — internal reads inside `Icons:SetIcons` loop
+- `Elements/Auras/Buffs.lua:264, 270, 271` — ICON dispatch (args 1, 7, 8 to `Icon:SetSpell`)
+- `Elements/Auras/Buffs.lua:295` — BAR dispatch (direct `Bar:SetStacks` call)
+- `Elements/Auras/Buffs.lua:358` — RECTANGLE dispatch (direct `Rectangle:SetStacks` call)
 
 The annotation pattern is Buffs-specific. `Debuffs.lua`, `Externals.lua`, `Defensives.lua`, and `Dispellable.lua` already read `auraData.applications` / `auraData.dispelName` directly and never mutate.
 
@@ -50,10 +58,11 @@ Buffs:Update
   matchAura(auraData)  -- mutates auraData.unit/.stacks/.dispelType
     → appends to iconsAurasPool[idx] or matchedPool[idx]
   dispatch to renderers:
-    ICONS  → Icons:SetIcons(list)          → reads aura.unit, aura.stacks, aura.dispelType
-    ICON   → Icon:SetSpell(unit, ..., stacks, dispelType)  -- dispelType param is dead
-    BAR    → Bar:SetStacks(aura.stacks)
-    BARS   → Bar:SetStacks(aura.stacks)    (per-bar inside Bars:SetBars loop)
+    ICONS      → Icons:SetIcons(list)               → internal loop reads aura.unit, aura.stacks, aura.dispelType
+    ICON       → Icon:SetSpell(unit, ..., stacks, dispelType)  -- dispelType param is dead
+    BAR        → Bar:SetStacks(aura.stacks)         (direct read in Buffs.lua:295)
+    BARS       → Bars:SetBars(list)                 → internal loop reads aura.stacks (Bars.lua:39-40)
+    RECTANGLE  → Rectangle:SetStacks(aura.stacks)   (direct read in Buffs.lua:358)
 ```
 
 ### Field equivalence
@@ -117,7 +126,7 @@ renderer:SetIcons(list)
 renderer:SetIcons(unit, list)
 ```
 
-**Update BAR dispatch (line 295):**
+**Update BAR dispatch (Buffs.lua:295):**
 
 ```lua
 -- before
@@ -127,7 +136,9 @@ if(aura.stacks) then renderer:SetStacks(aura.stacks) end
 if(aura.applications) then renderer:SetStacks(aura.applications) end
 ```
 
-**Update BARS dispatch (line 358):** same substitution as BAR.
+**Update RECTANGLE dispatch (Buffs.lua:358):** identical substitution to BAR — `aura.stacks` → `aura.applications`. Uses the same `Rectangle:SetStacks` pattern.
+
+**BARS dispatch (Buffs.lua:313):** no change to Buffs.lua — it already passes `list` to `Bars:SetBars`. The `.stacks` → `.applications` substitution happens inside `Bars.lua` (see §3 below).
 
 ### 2. `Elements/Indicators/Icons.lua`
 

--- a/docs/superpowers/specs/2026-04-22-classified-entry-pool-design.md
+++ b/docs/superpowers/specs/2026-04-22-classified-entry-pool-design.md
@@ -1,0 +1,219 @@
+# AuraState Classified Entry Pool Design
+
+**Issue:** #144
+**Related:** #155 (measurements that validated this target)
+**Date:** 2026-04-22
+
+## Goal
+
+Eliminate per-update allocation of classified aura wrappers (`{ aura, flags }`) and their nested `flags` tables in `AuraState`, the dominant contributor to Framed's 80–93% share of the LFR memory yoyo measured in #155. Do so without reintroducing any of the three failure modes that killed the 0.7.20 pool (`7f21fb4` → `9d3cc54`).
+
+## Non-Goals
+
+Explicit single-PR scope. The following are tracked separately:
+
+- **Item 2 from #155 ranked list:** Reduce `FullRefresh` call frequency. Deferred until post-pool re-measurement.
+- **Item 3 from #155 ranked list:** Avoid `{ GetAuraSlots(...) }` varargs-pack allocation. Deferred for the same reason.
+- **Pool changes to any other data structure** (`_helpfulMatches`, `_helpfulViews`, element-owned `iconsAurasPool`, etc.). Those paths are already allocation-free after the B1–B5 migrations (per #144 "what's already captured").
+
+Bundling any of these in the same PR would muddy the before/after MemDiag attribution on the core change.
+
+## Context
+
+### What allocates today
+
+`Core/AuraState.lua:18-42` — the `classify()` helper:
+
+```lua
+local function classify(unit, aura, isHelpful)
+    local id = aura.auraInstanceID
+    local prefix = isHelpful and 'HELPFUL' or 'HARMFUL'
+
+    local flags = {
+        isHelpful         = aura.isHelpful         or false,
+        ...
+    }
+    flags.isExternalDefensive = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|EXTERNAL_DEFENSIVE') == false
+    ...
+    return { aura = aura, flags = flags }
+end
+```
+
+Every call allocates two tables: the wrapper and the flags table (11 fields, all booleans).
+
+### Call sites
+
+Three entry points into `classify()`:
+
+1. `AuraState:GetHelpfulClassified()` — line 395, called when the classified view list is dirty and a given ID isn't already in `_helpfulClassifiedById`.
+2. `AuraState:GetHarmfulClassified()` — line 416, symmetric.
+3. `AuraState:GetClassifiedByInstanceID()` — lines 433 and 445, covers one-shot classification lookups for a specific instance ID.
+
+### Release points
+
+Four methods drop classified entries today:
+
+- `AuraState:InvalidateHelpfulClassified(id)` — line 119: `self._helpfulClassifiedById[id] = nil`
+- `AuraState:InvalidateHarmfulClassified(id)` — line 123: symmetric
+- `AuraState:ResetHelpfulClassified()` — line 111: `wipe(self._helpfulClassifiedById)`
+- `AuraState:ResetHarmfulClassified()` — line 115: symmetric
+
+All four currently drop references directly; GC reclaims the wrapper and flags.
+
+### Why the 0.7.20 pool broke
+
+Per #144 background, three compounding mistakes:
+
+1. Copied secret fields (`duration`, `expirationTime`, `applications`, `sourceUnit`, `dispelName`) into Framed-owned tables. `wipe()` clears fields but preserves table identity, so reuse served one frame's secret data to another frame's consumer.
+2. Module-level pool shared across frames. Entry `[5]` on `raid3` was the same Lua table reused next tick on `raid14`.
+3. Sort comparator with a module upvalue — safe only if aura updates don't nest.
+
+This design avoids all three.
+
+## Design
+
+### Pool shape
+
+One paired free list per `AuraState` instance:
+
+```lua
+self._classifiedFreeList = {}
+```
+
+Entries on this list are `{ aura = nil, flags = {...} }` wrappers. The flags table identity stays attached to its wrapper across acquire/release cycles (flags is never pooled separately). Helpful and harmful entries share the same free list — they are structurally identical, and splitting by direction adds code with no benefit.
+
+### Acquire
+
+A single helper replaces inline `{ aura = aura, flags = flags }` construction:
+
+```lua
+local function acquireClassified(pool, unit, aura, isHelpful)
+    local entry = pool[#pool]
+    if entry then
+        pool[#pool] = nil
+        wipe(entry.flags)
+    else
+        entry = { flags = {} }
+    end
+    entry.aura = aura
+    -- fill all 11 flags fields into entry.flags (body of existing classify())
+    return entry
+end
+```
+
+Called from all three classify sites. The wipe at acquire time satisfies the "fully cleared before reuse" guardrail lazily — entries released at end of session aren't wiped unnecessarily, and the wipe lives next to the refill, keeping mutation clustered.
+
+### Release
+
+The four methods that currently drop entries must route through a release helper:
+
+```lua
+local function releaseClassified(pool, entry)
+    entry.aura = nil
+    pool[#pool + 1] = entry
+end
+```
+
+- `InvalidateHelpfulClassified(id)` / `InvalidateHarmfulClassified(id)`: if an entry existed, release it before nil-ing the table slot.
+- `ResetHelpfulClassified()` / `ResetHarmfulClassified()`: iterate entries and release each before calling `wipe()` on the by-ID table.
+
+### Scope
+
+Per-`AuraState` instance. `F.AuraState.Create(owner)` initializes `self._classifiedFreeList = {}`. No module-level state, no cross-frame sharing.
+
+### Growth bound
+
+No explicit cap. Natural ceiling is bounded by game physics: ~40 auras/unit × ~25 frames ≈ 1000 entries × ~150 B ≈ ~150 KB absolute worst case across a session. Observability (below) will verify real growth stays well below this. If future measurement shows pathological retention, a hard cap (e.g., 64 per free list) can be added in ~5 lines.
+
+### Observability
+
+Two surfaces:
+
+**Per-frame, on-demand** — extend `/framed aurastate [unit]` output to include:
+
+```
+  classified free list: <N> entries (<M> B est.)
+```
+
+**Aggregate** — add a weak-keyed instance registry:
+
+```lua
+F.AuraState._instances = setmetatable({}, { __mode = 'k' })
+
+function F.AuraState.Create(owner)
+    local inst = setmetatable({...}, AuraState)
+    F.AuraState._instances[inst] = true
+    return inst
+end
+```
+
+`/framed memusage` iterates the registry and prints one aggregate line:
+
+```
+  aurastate free lists: <total> entries across <N> instances
+```
+
+The weak keys ensure that frames which get GC'd don't hold instances alive through the registry.
+
+## Aliasing Risk and the Audit Gate
+
+The guardrails below prevent `AuraState`'s internal state from leaking secret payload data, but they don't prevent a different class of bug: **a consumer that stashes an `entry` or `entry.flags` reference past an `Invalidate*Classified` call will observe silent reuse** (a stashed ref points at the same wrapper, which now holds a different aura's data after re-acquire). This is not a taint issue — it's a correctness issue (ghost auras, wrong-aura display).
+
+The pool is correct only if no consumer stashes classified entries across UNIT_AURA. Therefore:
+
+**Audit gate (Task 0 in the implementation plan):** before introducing the pool, audit every caller of `GetHelpfulClassified`, `GetHarmfulClassified`, and `GetClassifiedByInstanceID`:
+
+- `Elements/Auras/Buffs.lua`
+- `Elements/Auras/Debuffs.lua`
+- `Elements/Auras/Externals.lua`
+- `Elements/Auras/Defensives.lua`
+- `Elements/Auras/Dispellable.lua`
+- `Elements/Auras/PrivateAuras.lua`
+- `Elements/Auras/MissingBuffs.lua`
+- `Elements/Indicators/Icons.lua`
+- `Elements/Indicators/Bars.lua`
+- Any other grep hit on those three method names
+
+Any consumer found to stash `entry` or `entry.flags` beyond the immediate iteration call stack must be fixed to extract the fields it needs inline before control returns. Pool merge is gated on audit pass.
+
+## Implementation Guardrails
+
+(Carried over verbatim from #144 with the aliasing addition.)
+
+- All classified-entry acquire/release goes through dedicated helpers. No inline `{ aura = aura, flags = flags }` construction.
+- `ResetHelpfulClassified`, `ResetHarmfulClassified`, `InvalidateHelpfulClassified`, and `InvalidateHarmfulClassified` release entries to the pool instead of just nil-ing them.
+- `entry.aura` and `entry.flags` are fully cleared before reuse (wipe at acquire time).
+- Pool is per-`AuraState` instance. Never promote to module scope.
+- Pool wrappers hold `auraData` references, never copy secret payload fields into Framed-owned tables.
+- Consumer audit must pass before merge (see above).
+
+## Test Gate
+
+Replay the 0.7.20 failure mode in a representative environment:
+
+- 20-man raid pull with MPlusQOL, AbilityTimeline, and WeakAuras loaded
+- No `attempt to compare number with nil` or nil text errors from external addons
+- No ghost aura presentation when auras are added, updated, removed, or reassigned across units
+
+Plus the new observability surfaces:
+
+- `/framed aurastate target` during combat shows free list size climbing and plateauing, not growing unboundedly
+- `/framed memusage` before and after several LFR pulls shows aggregate free list size bounded by natural ceiling
+
+Plus a MemDiag A/B:
+
+- Pre-change `/framed memdiag 30` in LFR
+- Post-change `/framed memdiag 30` in comparable LFR
+- Expected: `AuraState:*` rows (`ApplyUpdateInfo`, `GetHelpfulClassified`, `GetHarmfulClassified`, `GetClassifiedByInstanceID`) drop materially in per-call KB allocation
+- `event:UNIT_AURA` bucket total (which nests AuraState) drops by a comparable amount
+- Total `collectgarbage('count')` delta over the 30 s window drops toward the non-Framed baseline
+
+Merge criteria: all three test gates pass, audit task in plan is checked off.
+
+## References
+
+- #144 — original scope definition
+- #155 — measurement evidence + ranked fix list
+- #159 — MemDiag tooling used for before/after measurement
+- 0.7.20 incident: `7f21fb4` (pool introduction), `9d3cc54` (revert)
+- `Core/AuraState.lua` — current implementation

--- a/docs/superpowers/specs/2026-04-22-fullrefresh-varargs-design.md
+++ b/docs/superpowers/specs/2026-04-22-fullrefresh-varargs-design.md
@@ -8,7 +8,7 @@
 
 Eliminate per-`FullRefresh` varargs-pack allocation in `AuraState` by reusing per-instance scratch tables. This targets item 3 from the #155 ranked fix list (deferred from #144 to keep the classified-entry-pool PR's MemDiag attribution clean).
 
-Baseline measurement (pre-#160 memdiag, 30 s LFR window): `AuraState:FullRefresh` allocated ~66 MB across the window — the single largest contributor to the UNIT_AURA bucket and the dominant source of Framed's share of the LFR memory yoyo. The two `{ GetAuraSlots(unit, 'HELPFUL') }` / `{ GetAuraSlots(unit, 'HARMFUL') }` varargs packs at `Core/AuraState.lua:244` and `:252` are the full cost — every FullRefresh call allocates and discards two tables holding the continuation token plus up to ~40 integer slot IDs.
+Baseline measurement (pre-#160 memdiag, 30 s LFR window): `AuraState:FullRefresh` allocated ~66 MB across the window — the single largest contributor to the UNIT_AURA bucket. MemDiag's attribution is per-Lua-function, not per-expression, so the 66 MB figure covers *everything* inside `FullRefresh` including the AuraData tables returned by `GetAuraDataBySlot` (Blizzard-owned, one per slot). The two `{ GetAuraSlots(unit, 'HELPFUL') }` / `{ GetAuraSlots(unit, 'HARMFUL') }` varargs packs at `Core/AuraState.lua:244` and `:252` are **a known avoidable allocation inside the highest-cost FullRefresh path** — we eliminate what we can own and re-measure; residual allocation belongs to follow-up work.
 
 ## Non-Goals
 
@@ -43,7 +43,7 @@ for i = 2, #harmfulResults do
 end
 ```
 
-The `{ ... }` varargs-pack idiom creates a fresh table per call. Two packs per `FullRefresh`, one per unit that fires UNIT_AURA; across 53 tracked units in a 20-man LFR pull this is the dominant allocation source.
+The `{ ... }` varargs-pack idiom creates a fresh table per call. Two packs per `FullRefresh`, one per unit that fires UNIT_AURA; across 53 tracked units in a 20-man LFR pull this is a meaningful — and entirely avoidable — allocation source.
 
 ### Why not a module-shared scratch table
 
@@ -51,16 +51,17 @@ The 0.7.20 classified-wrapper pool revert (`7f21fb4` → `9d3cc54`) failed speci
 
 ## Design
 
-### Data — per-instance scratch fields
+### Data — per-instance scratch field
 
-Add two fields to `F.AuraState.Create`, parallel to the `_classifiedFreeList` field added in #144:
+Add one field to `F.AuraState.Create`, parallel to the `_classifiedFreeList` field added in #144:
 
 ```lua
-_helpfulSlots = {},
-_harmfulSlots = {},
+_slotsScratch = {},
 ```
 
-Bounded size: ≤40 auras/unit × ~20 B/slot ≈ ~800 B per scratch × 2 × 53 instances ≈ ~85 KB peak retained. The tradeoff is ~85 KB of persistent memory in exchange for eliminating ~66 MB of allocation churn per 30 s window — three orders of magnitude. No growth bound needed; size is capped by game physics (aura count per unit).
+One scratch is enough because the HELPFUL and HARMFUL passes in `FullRefresh` are strictly sequential — the HELPFUL loop finishes reading `_slotsScratch` before the HARMFUL pass overwrites it. No concurrent access, no re-entry (verified in Risk Analysis below).
+
+Bounded size: ≤40 auras/unit × ~20 B/slot ≈ ~800 B per scratch × 53 instances ≈ ~42 KB peak retained. The tradeoff is ~42 KB of persistent memory in exchange for eliminating the two per-FullRefresh varargs packs. Size is capped by game physics (aura count per unit).
 
 ### Helper — `fillSlots`
 
@@ -71,18 +72,21 @@ Module-local function in `Core/AuraState.lua`:
 -- which callers use as the iteration bound (position 1 is the continuation
 -- token; real slot IDs start at index 2).
 local function fillSlots(tbl, ...)
-    wipe(tbl)
     local n = select('#', ...)
     for i = 1, n do
         tbl[i] = select(i, ...)
+    end
+    for i = n + 1, #tbl do
+        tbl[i] = nil
     end
     return n
 end
 ```
 
-- The leading `wipe` is defensive: clears stale entries from a previous `FullRefresh` where the aura count was higher. Iteration uses the returned `n`, not `#tbl`, so the wipe is insurance against future code that might use length-operator ambiguity.
+- The fill loop overwrites `tbl[1..n]` in place. The second loop nils the tail (`n+1..#tbl`) if a prior call stored more entries than this one. Since the fill loop keeps the array contiguous, `#tbl` is a well-defined sequence length each call — no hole-ambiguity.
+- We tail-clear rather than full-wipe because the table is bounded and `n` is already known; walking the whole table every call is wasted work.
 - `select(i, ...)` in a loop is formally O(N²) but N ≤ 40 → ≤1,600 internal operations → single-digit microseconds per call. Not worth optimizing.
-- Returns count `n` so callers use it as the iteration bound.
+- Returns count `n` so callers use it as the iteration bound (not `#tbl`).
 
 ### Call-site rewrite
 
@@ -99,16 +103,24 @@ for i = 2, #helpfulResults do
 end
 
 -- after
-local nHelpful = fillSlots(self._helpfulSlots, GetAuraSlots(unit, 'HELPFUL'))
+local nHelpful = fillSlots(self._slotsScratch, GetAuraSlots(unit, 'HELPFUL'))
 for i = 2, nHelpful do
-    local aura = GetAuraDataBySlot(unit, self._helpfulSlots[i])
+    local aura = GetAuraDataBySlot(unit, self._slotsScratch[i])
     if(aura and aura.auraInstanceID) then
         self._helpfulById[aura.auraInstanceID] = aura
     end
 end
+
+local nHarmful = fillSlots(self._slotsScratch, GetAuraSlots(unit, 'HARMFUL'))
+for i = 2, nHarmful do
+    local aura = GetAuraDataBySlot(unit, self._slotsScratch[i])
+    if(aura and aura.auraInstanceID) then
+        self._harmfulById[aura.auraInstanceID] = aura
+    end
+end
 ```
 
-Symmetric for `HARMFUL`. No behavioral change — same iteration bounds, same data flow, just no allocation.
+The HARMFUL `fillSlots` call can safely overwrite `_slotsScratch` because the HELPFUL loop has fully completed its reads before the HARMFUL pass begins. No behavioral change — same iteration bounds, same data flow, just no allocation.
 
 ### Scope
 
@@ -122,7 +134,7 @@ None added. The change is small, the measurement approach is already in place fr
 
 **Re-entry.** `GetAuraSlots` and `GetAuraDataBySlot` are pure C getters with no Lua callbacks. `FullRefresh` cannot recursively call itself or another `FullRefresh` on the same instance during its execution. Per-instance scratch eliminates cross-instance re-entry concerns regardless — even if some future code path triggered re-entry on a *different* instance, each instance has its own scratch.
 
-**Hole semantics.** The leading `wipe` before fill guarantees no stale indices. We iterate using the returned `n` (not `#tbl`), so Lua's length-operator ambiguity on tables with holes is irrelevant even without the wipe.
+**Hole semantics.** `fillSlots` always writes `tbl[1..n]` contiguously and tail-clears `tbl[n+1..prev_n]` to nil, so the table remains a proper sequence every call. `#tbl` is well-defined across calls, and callers iterate using the returned `n` (not `#tbl`), which is the definitive bound regardless.
 
 **Secret values.** `GetAuraSlots` returns integer slot IDs — non-secret. `GetAuraDataBySlot` is where secrets enter the system, and that call path is unchanged by this PR. No new secret-value handling required.
 
@@ -132,9 +144,9 @@ None added. The change is small, the measurement approach is already in place fr
 
 Parallels #144's validation approach:
 
-- **MemDiag A/B.** Pre-change `/framed memdiag 30` in LFR; post-change `/framed memdiag 30` in comparable LFR. Expected: `AuraState:FullRefresh` bytes-per-call collapses from ~31 KB/call to near-zero; `event:UNIT_AURA` bucket total drops by a comparable amount; total `collectgarbage('count')` delta over the 30 s window drops materially toward the non-Framed baseline.
-- **Ghost-aura stress.** Target-swap, let buffs expire, re-target — verify no stale aura state carried across refreshes. Scratch tables are overwritten every call plus defensively wiped, so this should be a no-op check.
-- **Zero-aura unit.** Point target at a dummy with no auras, confirm no Lua errors. `select('#', ...) = 1` (just the continuation token), loop at `for i = 2, 1` runs zero times, wipe clears any residual.
+- **MemDiag A/B.** Pre-change `/framed memdiag 30` in LFR; post-change `/framed memdiag 30` in comparable LFR. Expected: `AuraState:FullRefresh` bytes-per-call drops measurably (by whatever share of its allocation belongs to the two varargs packs; residual allocation from `GetAuraDataBySlot` return tables is expected and out of scope); `event:UNIT_AURA` bucket total drops by a proportional amount; total `collectgarbage('count')` delta over the 30 s window trends toward the non-Framed baseline. Direction is the criterion — magnitude is informational.
+- **Ghost-aura stress.** Target-swap, let buffs expire, re-target — verify no stale aura state carried across refreshes. `_slotsScratch` is overwritten-and-tail-cleared each call, so this should be a no-op check.
+- **Zero-aura unit.** Point target at a dummy with no auras, confirm no Lua errors. The invariant we rely on (not the exact return shape of `GetAuraSlots`): for any `n ≤ 1`, the iteration `for i = 2, n` in `FullRefresh` runs zero times, and `fillSlots` tail-clears any residual slots from prior calls. No assumption baked in about whether the no-aura case returns just a continuation token, returns nothing, or some other shape.
 - **Regression replay.** Reload with WeakAuras/MPlusQOL/AbilityTimeline loaded, combat entry/exit, target chains. Zero `BugSack` errors. No `attempt to compare number with nil` or nil-text errors from external addons.
 
 Merge criteria: MemDiag A/B shows the expected collapse, zero regression errors across the replay, ghost-aura and zero-aura checks pass.

--- a/docs/superpowers/specs/2026-04-22-fullrefresh-varargs-design.md
+++ b/docs/superpowers/specs/2026-04-22-fullrefresh-varargs-design.md
@@ -1,0 +1,148 @@
+# AuraState FullRefresh Varargs-Pack Elimination Design
+
+**Issue:** #155 (item 3 from ranked fix list)
+**Related:** #144 / PR #160 (classified entry pool — established per-instance pooling pattern this reuses)
+**Date:** 2026-04-22
+
+## Goal
+
+Eliminate per-`FullRefresh` varargs-pack allocation in `AuraState` by reusing per-instance scratch tables. This targets item 3 from the #155 ranked fix list (deferred from #144 to keep the classified-entry-pool PR's MemDiag attribution clean).
+
+Baseline measurement (pre-#160 memdiag, 30 s LFR window): `AuraState:FullRefresh` allocated ~66 MB across the window — the single largest contributor to the UNIT_AURA bucket and the dominant source of Framed's share of the LFR memory yoyo. The two `{ GetAuraSlots(unit, 'HELPFUL') }` / `{ GetAuraSlots(unit, 'HARMFUL') }` varargs packs at `Core/AuraState.lua:244` and `:252` are the full cost — every FullRefresh call allocates and discards two tables holding the continuation token plus up to ~40 integer slot IDs.
+
+## Non-Goals
+
+Explicitly out of scope for this PR:
+
+- **`Elements/Status/StatusText.lua:80` drink scan.** Uses the same `{ C_UnitAuras.GetAuraSlots(unit, 'HELPFUL') }` idiom, but is OOC-only (`InCombatLockdown()` guard). Cold path, separate issue. (User noted a suspicion it may still fire in combat under feign-death — flagged as a separate investigation.)
+- **`Libs/oUF/elements/auras.lua` call sites.** Embedded oUF is off-limits per the `feedback_no_ouf_mods` convention — fixes must hoist to the Framed layer.
+- **Item 2 from #155 — reducing `FullRefresh` call frequency.** Separate future PR. Bundling would muddy the before/after MemDiag attribution of this change.
+- **Any new diagnostic command.** `/framed memdiag` and `/framed memusage` (already in place) produce the signal we need.
+
+## Context
+
+### What allocates today
+
+`Core/AuraState.lua:244-258`:
+
+```lua
+local helpfulResults = { GetAuraSlots(unit, 'HELPFUL') }
+for i = 2, #helpfulResults do
+    local aura = GetAuraDataBySlot(unit, helpfulResults[i])
+    if(aura and aura.auraInstanceID) then
+        self._helpfulById[aura.auraInstanceID] = aura
+    end
+end
+
+local harmfulResults = { GetAuraSlots(unit, 'HARMFUL') }
+for i = 2, #harmfulResults do
+    local aura = GetAuraDataBySlot(unit, harmfulResults[i])
+    if(aura and aura.auraInstanceID) then
+        self._harmfulById[aura.auraInstanceID] = aura
+    end
+end
+```
+
+The `{ ... }` varargs-pack idiom creates a fresh table per call. Two packs per `FullRefresh`, one per unit that fires UNIT_AURA; across 53 tracked units in a 20-man LFR pull this is the dominant allocation source.
+
+### Why not a module-shared scratch table
+
+The 0.7.20 classified-wrapper pool revert (`7f21fb4` → `9d3cc54`) failed specifically because module-level shared state served one frame's data to another frame's consumer mid-iteration. Applying the same mistake to the slots scratch would produce identical ghost-aura pathologies. Per-instance scratch is the correct pattern and matches the approach locked in by #144.
+
+## Design
+
+### Data — per-instance scratch fields
+
+Add two fields to `F.AuraState.Create`, parallel to the `_classifiedFreeList` field added in #144:
+
+```lua
+_helpfulSlots = {},
+_harmfulSlots = {},
+```
+
+Bounded size: ≤40 auras/unit × ~20 B/slot ≈ ~800 B per scratch × 2 × 53 instances ≈ ~85 KB peak retained. The tradeoff is ~85 KB of persistent memory in exchange for eliminating ~66 MB of allocation churn per 30 s window — three orders of magnitude. No growth bound needed; size is capped by game physics (aura count per unit).
+
+### Helper — `fillSlots`
+
+Module-local function in `Core/AuraState.lua`:
+
+```lua
+-- Pack GetAuraSlots varargs into `tbl` without allocating. Returns the count,
+-- which callers use as the iteration bound (position 1 is the continuation
+-- token; real slot IDs start at index 2).
+local function fillSlots(tbl, ...)
+    wipe(tbl)
+    local n = select('#', ...)
+    for i = 1, n do
+        tbl[i] = select(i, ...)
+    end
+    return n
+end
+```
+
+- The leading `wipe` is defensive: clears stale entries from a previous `FullRefresh` where the aura count was higher. Iteration uses the returned `n`, not `#tbl`, so the wipe is insurance against future code that might use length-operator ambiguity.
+- `select(i, ...)` in a loop is formally O(N²) but N ≤ 40 → ≤1,600 internal operations → single-digit microseconds per call. Not worth optimizing.
+- Returns count `n` so callers use it as the iteration bound.
+
+### Call-site rewrite
+
+In `AuraState:FullRefresh` (lines 244–258):
+
+```lua
+-- before
+local helpfulResults = { GetAuraSlots(unit, 'HELPFUL') }
+for i = 2, #helpfulResults do
+    local aura = GetAuraDataBySlot(unit, helpfulResults[i])
+    if(aura and aura.auraInstanceID) then
+        self._helpfulById[aura.auraInstanceID] = aura
+    end
+end
+
+-- after
+local nHelpful = fillSlots(self._helpfulSlots, GetAuraSlots(unit, 'HELPFUL'))
+for i = 2, nHelpful do
+    local aura = GetAuraDataBySlot(unit, self._helpfulSlots[i])
+    if(aura and aura.auraInstanceID) then
+        self._helpfulById[aura.auraInstanceID] = aura
+    end
+end
+```
+
+Symmetric for `HARMFUL`. No behavioral change — same iteration bounds, same data flow, just no allocation.
+
+### Scope
+
+Per-`AuraState` instance. No module-level state, no cross-frame sharing. Matches the #144 pattern exactly.
+
+### Observability
+
+None added. The change is small, the measurement approach is already in place from #144, and an A/B on `AuraState:FullRefresh` bytes-per-call is the definitive signal. A `/framed scratch` equivalent command would report bounded per-instance sizes with no actionable meaning.
+
+## Risk Analysis
+
+**Re-entry.** `GetAuraSlots` and `GetAuraDataBySlot` are pure C getters with no Lua callbacks. `FullRefresh` cannot recursively call itself or another `FullRefresh` on the same instance during its execution. Per-instance scratch eliminates cross-instance re-entry concerns regardless — even if some future code path triggered re-entry on a *different* instance, each instance has its own scratch.
+
+**Hole semantics.** The leading `wipe` before fill guarantees no stale indices. We iterate using the returned `n` (not `#tbl`), so Lua's length-operator ambiguity on tables with holes is irrelevant even without the wipe.
+
+**Secret values.** `GetAuraSlots` returns integer slot IDs — non-secret. `GetAuraDataBySlot` is where secrets enter the system, and that call path is unchanged by this PR. No new secret-value handling required.
+
+**Ghost-aura class of bug (from #144 audit gate).** Not applicable here. The scratch table holds integer slot IDs, not classified-wrapper references. Downstream consumers receive `auraData` (from `GetAuraDataBySlot`) directly and don't stash references to the scratch itself. The only way a stale slot ID could matter is if iteration read past `n`, which we explicitly bound.
+
+## Test Gate
+
+Parallels #144's validation approach:
+
+- **MemDiag A/B.** Pre-change `/framed memdiag 30` in LFR; post-change `/framed memdiag 30` in comparable LFR. Expected: `AuraState:FullRefresh` bytes-per-call collapses from ~31 KB/call to near-zero; `event:UNIT_AURA` bucket total drops by a comparable amount; total `collectgarbage('count')` delta over the 30 s window drops materially toward the non-Framed baseline.
+- **Ghost-aura stress.** Target-swap, let buffs expire, re-target — verify no stale aura state carried across refreshes. Scratch tables are overwritten every call plus defensively wiped, so this should be a no-op check.
+- **Zero-aura unit.** Point target at a dummy with no auras, confirm no Lua errors. `select('#', ...) = 1` (just the continuation token), loop at `for i = 2, 1` runs zero times, wipe clears any residual.
+- **Regression replay.** Reload with WeakAuras/MPlusQOL/AbilityTimeline loaded, combat entry/exit, target chains. Zero `BugSack` errors. No `attempt to compare number with nil` or nil-text errors from external addons.
+
+Merge criteria: MemDiag A/B shows the expected collapse, zero regression errors across the replay, ghost-aura and zero-aura checks pass.
+
+## References
+
+- #155 — measurement evidence + ranked fix list
+- #144 / PR #160 — classified entry pool (established per-instance pooling pattern, confirmed MemDiag methodology)
+- #159 — MemDiag tooling
+- 0.7.20 incident: `7f21fb4` (pool introduction), `9d3cc54` (revert)
+- `Core/AuraState.lua` — current implementation

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -10,7 +10,10 @@ set -eu
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
-staged=$(git diff --cached --name-only --diff-filter=ACMR -z -- '*.lua' ':!Libs/**')
+# Newline-delimited: POSIX command substitution strips NULs from `-z`
+# output, which would collapse filenames into one. Filenames in this
+# repo don't contain newlines, so newline-delimiting is safe.
+staged=$(git diff --cached --name-only --diff-filter=ACMR -- '*.lua' ':!Libs/**')
 
 if [ -z "$staged" ]; then
 	exit 0
@@ -22,4 +25,5 @@ if ! command -v luacheck >/dev/null 2>&1; then
 	exit 0
 fi
 
-printf '%s' "$staged" | xargs -0 luacheck --config .luacheckrc
+# tr newline→NUL keeps xargs -0 portable across GNU and BSD (BSD has no -d).
+printf '%s' "$staged" | tr '\n' '\0' | xargs -0 luacheck --config .luacheckrc

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Framed pre-commit hook — runs luacheck on staged Lua files.
+#
+# Install via: tools/install-hooks.sh
+# Source of truth lives at tools/hooks/pre-commit; .git/hooks/pre-commit
+# is a symlink to it so edits here take effect immediately.
+
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+staged=$(git diff --cached --name-only --diff-filter=ACMR -z -- '*.lua' ':!Libs/**')
+
+if [ -z "$staged" ]; then
+	exit 0
+fi
+
+if ! command -v luacheck >/dev/null 2>&1; then
+	echo "pre-commit: luacheck not found — skipping lint check."
+	echo "pre-commit: install via 'brew install luacheck' or 'luarocks install luacheck'."
+	exit 0
+fi
+
+printf '%s' "$staged" | xargs -0 luacheck --config .luacheckrc

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Install Framed's tracked git hooks into .git/hooks/ as symlinks.
+# Re-run after cloning or after pulling new hook changes.
+
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+install_hook() {
+	name=$1
+	src="tools/hooks/$name"
+	dst=".git/hooks/$name"
+
+	if [ ! -f "$src" ]; then
+		echo "error: $src not found"
+		exit 1
+	fi
+
+	chmod +x "$src"
+
+	if [ -e "$dst" ] && [ ! -L "$dst" ]; then
+		echo "warning: $dst exists and is not a symlink; backing up to $dst.bak"
+		mv "$dst" "$dst.bak"
+	fi
+
+	ln -sf "../../$src" "$dst"
+	echo "installed: $dst -> $src"
+}
+
+install_hook pre-commit


### PR DESCRIPTION
## Summary

Promotes accumulated `working-testing` state to `main`. Spans the full post-`v0.8.13-alpha` development window. CHANGELOG + version bump + About-card regen intentionally **not yet done** — will follow in a separate prep commit before merge.

### Features
- **Pinned Frames** — always-visible slot system with role-grouped assignment, edit-mode integration, hover gear for reassignment, LiveUpdate routing, master enable toggle, placeholder overlays
- **Overview / Onboarding** — in-addon tour modal with page registry, Welcome / Layouts / Edit Mode / Settings Cards / Indicators / Defensives pages, progress rail, minimize pip, auto-show on first login after wizard
- **Backups** (replaces Profiles) — versioned snapshots with corruption handling, row actions (load/delete/rename/export), import-as-snapshot flow, sourceVersion tagging, automatic snapshots on login/pre-import, combat-guarded operations

### UNIT_AURA fan-out rearchitecture (#115)
- AuraState classification pipeline (A1)
- Element migrations: Externals (B1, #137), Defensives (B2, #138), Buffs (B3, #139), Debuffs (B4, #140), MissingBuffs (B5, #141)
- `isRaidInCombat` / `isRaidDispellable` flags via `IsAuraFilteredOutByInstanceID`
- Relaxed `isRaidInCombat` gate to prefix-based probe

### Performance work (#144 / #155 / #167)
- **Classified entry pool (#144)** — per-instance freelist for `{ aura, flags }` wrappers, release on invalidate/reset
- **FullRefresh varargs elimination (#155 item 3)** — `fillSlots` + `_slotsScratch` replacing `{ GetAuraSlots(...) }` packs on HELPFUL + HARMFUL
- **cf7fabb regression chain (#167)**: stop AuraData mutation in matchAura, drop dead `dispelType` param from `Icon:SetSpell`, route Icons through unit param + applications, hoist matchAura out of Update closure, always-gate on `isRaidInCombat` (drops `computeBuffFilter`)
- **MemDiag profiler** — `/framed memdiag [seconds]` allocation profiler with broadened OnUpdate coverage, periodic re-walk, ancestor labeling, tool self-cost accounting

### 12.0.5 compatibility
- `AddPrivateAuraAnchor` `isContainer` field
- Encounter-boundary aura cache invalidation (#123)
- `UnitIsUnit` compound-token guards (#122)

### Settings / Edit Mode polish
- Aura panel refactor, Frame Preview feature (#95)
- Card grid Settings panels, consolidated appearance options
- Edit-mode catcher + sibling-shield fixes, pinned EditCache routing
- Various preview and live-update correctness fixes

## Test plan

- [ ] `/reload` in a standard 5-man party — no Lua errors at login, combat entry/exit, or retarget
- [ ] `/framed memdiag 30` in combat — baseline allocation stays within expected envelope (~8-11 MB / 30s under full combat aura churn)
- [ ] Pinned Frames — configure a slot, reassign via hover gear, drag in edit mode, leave/disband group clears slots
- [ ] Overview modal — triggers on first login post-wizard, minimize pip + Escape both minimize, all pages render
- [ ] Backups — save current as snapshot, rename, delete, load, export row, import-as-snapshot with version mismatch warnings
- [ ] UNIT_AURA path coverage — confirm Externals / Defensives / Buffs / Debuffs / MissingBuffs all render correctly across player/party/target/focus/boss frames
- [ ] 12.0.5 PrivateAuras — confirm no errors when encountering private auras (boss encounters)
- [ ] Settings — navigate all cards, edit values, confirm LiveUpdate applies without requiring `/reload`

🤖 Generated with [Claude Code](https://claude.com/claude-code)