### PR TITLE
perf(auras): content/identity generation split (#118)

### DIFF
--- a/Core/AuraCache.lua
+++ b/Core/AuraCache.lua
@@ -3,8 +3,16 @@ local F = Framed
 
 F.AuraCache = {}
 
--- Generation counter per unit — bumped on each UNIT_AURA event.
+-- Content generation — bumps on any UNIT_AURA for the unit. Used by
+-- GetUnitAuras() to invalidate filter-result caches when aura set changes.
 local generation = {}
+
+-- Identity generation — bumps only when the unit token may now point at
+-- a different entity (reassignment events) or when existing auraInstanceIDs
+-- are invalidated at encounter boundaries. Used by AuraState to decide
+-- whether a FullRefresh is needed vs. a delta apply.
+-- See issue #118: single-gen approach forced FullRefresh on every UNIT_AURA.
+local identityGeneration = {}
 
 -- Cache keyed by 'unit\0filter' — each entry is { gen = number, result = table }.
 -- Tables are reused across generations to avoid allocation.
@@ -13,10 +21,19 @@ local cache = {}
 -- Pre-computed key strings to avoid per-call string concatenation.
 local keyCache = {}
 
--- Bump generation for a single unit token.
+-- Bump content generation for a single unit token.
 local function bump(unit)
 	if(unit) then
 		generation[unit] = (generation[unit] or 0) + 1
+	end
+end
+
+-- Bump identity generation for a single unit token. Callers should pair
+-- this with bump(unit) when the content also changed (most reassignment
+-- events imply a content change too, since auraInstanceIDs are re-keyed).
+local function bumpIdentity(unit)
+	if(unit) then
+		identityGeneration[unit] = (identityGeneration[unit] or 0) + 1
 	end
 end
 
@@ -41,57 +58,86 @@ eventFrame:RegisterEvent('NAME_PLATE_UNIT_REMOVED')
 
 eventFrame:SetScript('OnEvent', function(_, event, arg1)
 	if(event == 'UNIT_AURA') then
+		-- Content-only: auras changed on the same entity. No identity bump —
+		-- AuraState should take its delta path, not FullRefresh.
 		bump(arg1)
 	elseif(event == 'PLAYER_TARGET_CHANGED') then
 		bump('target')
 		bump('targettarget')
+		bumpIdentity('target')
+		bumpIdentity('targettarget')
 	elseif(event == 'PLAYER_FOCUS_CHANGED') then
 		bump('focus')
 		bump('focustarget')
+		bumpIdentity('focus')
+		bumpIdentity('focustarget')
 	elseif(event == 'UNIT_TARGET') then
 		-- arg1 = unit whose target changed; the subunit token (e.g.,
 		-- 'targettarget' when arg1 == 'target') now points somewhere new.
 		if(arg1) then
 			bump(arg1 .. 'target')
+			bumpIdentity(arg1 .. 'target')
 		end
 	elseif(event == 'GROUP_ROSTER_UPDATE') then
 		for i = 1, 4 do
 			bump('party' .. i)
 			bump('partypet' .. i)
+			bumpIdentity('party' .. i)
+			bumpIdentity('partypet' .. i)
 		end
 		for i = 1, 40 do
 			bump('raid' .. i)
 			bump('raidpet' .. i)
+			bumpIdentity('raid' .. i)
+			bumpIdentity('raidpet' .. i)
 		end
 	elseif(event == 'ARENA_OPPONENT_UPDATE') then
 		for i = 1, 5 do
 			bump('arena' .. i)
 			bump('arenapet' .. i)
+			bumpIdentity('arena' .. i)
+			bumpIdentity('arenapet' .. i)
 		end
 	elseif(event == 'INSTANCE_ENCOUNTER_ENGAGE_UNIT') then
 		for i = 1, 8 do
 			bump('boss' .. i)
+			bumpIdentity('boss' .. i)
 		end
 	elseif(event == 'ENCOUNTER_START' or event == 'ENCOUNTER_END') then
 		-- 12.0.5 re-randomizes aura instance IDs on encounter boundaries.
-		-- Bump every tracked unit so the next read refreshes from the
-		-- game's aura list instead of trusting pre-boundary IDs.
+		-- Bump both content and identity on every tracked unit so the next
+		-- read refreshes from the game's aura list instead of trusting
+		-- pre-boundary IDs. GUID doesn't change here, so the identity bump
+		-- is the only signal AuraState has to discard its auraInstanceID
+		-- keyed caches.
 		for unit in next, generation do
 			bump(unit)
+			bumpIdentity(unit)
 		end
 	elseif(event == 'NAME_PLATE_UNIT_ADDED' or event == 'NAME_PLATE_UNIT_REMOVED') then
 		bump(arg1)
+		bumpIdentity(arg1)
 	end
 end)
 
---- Current generation counter for a unit token. Bumped whenever cached
---- data for that token may be stale (UNIT_AURA or token reassignment).
---- Consumers that hold their own cache can compare against this to
---- detect when they need to invalidate.
+--- Current content generation counter for a unit token. Bumped on every
+--- UNIT_AURA for that unit. Consumers caching filter results (e.g.
+--- GetUnitAuras below) compare against this to detect stale results.
 --- @param unit string
 --- @return number
 function F.AuraCache.GetGeneration(unit)
 	return generation[unit] or 0
+end
+
+--- Current identity generation counter for a unit token. Bumped only on
+--- reassignment events (token now points at a different entity) or on
+--- encounter boundaries (auraInstanceID re-randomization). Consumers that
+--- hold auraInstanceID-keyed state compare against this to decide whether
+--- to full-refresh vs. apply a delta. See #118.
+--- @param unit string
+--- @return number
+function F.AuraCache.GetIdentityGeneration(unit)
+	return identityGeneration[unit] or 0
 end
 
 --- Drop-in replacement for C_UnitAuras.GetUnitAuras(unit, filter).

--- a/Core/AuraCache.lua
+++ b/Core/AuraCache.lua
@@ -45,6 +45,7 @@ local eventFrame = CreateFrame('Frame')
 -- Exposed for diagnostics (Core/MemDiag.lua hooks OnEvent here).
 F.AuraCache._eventFrame = eventFrame
 eventFrame:RegisterEvent('UNIT_AURA')
+eventFrame:RegisterEvent('UNIT_PET')
 eventFrame:RegisterEvent('PLAYER_TARGET_CHANGED')
 eventFrame:RegisterEvent('PLAYER_FOCUS_CHANGED')
 eventFrame:RegisterEvent('UNIT_TARGET')
@@ -61,6 +62,24 @@ eventFrame:SetScript('OnEvent', function(_, event, arg1)
 		-- Content-only: auras changed on the same entity. No identity bump —
 		-- AuraState should take its delta path, not FullRefresh.
 		bump(arg1)
+	elseif(event == 'UNIT_PET') then
+		-- arg1 = owner unit; derive the corresponding pet token. UnitGUID
+		-- returns secret strings for pet tokens in combat, so we can't use
+		-- a GUID snapshot as a fallback — this event is the sole signal
+		-- that a pet token now points at a different entity.
+		local petUnit
+		if(arg1 == 'player') then
+			petUnit = 'pet'
+		elseif(arg1) then
+			local prefix, n = arg1:match('^(%a+)(%d+)$')
+			if(prefix == 'party' or prefix == 'raid' or prefix == 'arena') then
+				petUnit = prefix .. 'pet' .. n
+			end
+		end
+		if(petUnit) then
+			bump(petUnit)
+			bumpIdentity(petUnit)
+		end
 	elseif(event == 'PLAYER_TARGET_CHANGED') then
 		bump('target')
 		bump('targettarget')

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -242,7 +242,13 @@ end
 function AuraState:FullRefresh(unit)
 	self._unit = unit
 	self._initialized = true
-	self._gen = F.AuraCache.GetGeneration(unit)
+	self._gen = F.AuraCache.GetIdentityGeneration(unit)
+	-- GUID snapshot as second-line guardrail: catches identity changes
+	-- that bypass the enumerated reassignment events (UNIT_PET, vehicle
+	-- transitions, odd timing). UnitGUID returns nil for unloaded units,
+	-- which is a stable value — first real GUID post-load triggers one
+	-- legitimate FullRefresh. See #118.
+	self._guid = unit and UnitGUID(unit) or nil
 	wipe(self._helpfulById)
 	wipe(self._harmfulById)
 	self:ResetHelpfulMatches()
@@ -275,10 +281,14 @@ function AuraState:FullRefresh(unit)
 end
 
 function AuraState:EnsureInitialized(unit)
-	-- Compare generation from AuraCache, not the token string — the token
-	-- (e.g. 'target') stays identical on retarget even when it now points
-	-- at a different entity. AuraCache bumps generation on reassignment.
-	if(not self._initialized or self._unit ~= unit or self._gen ~= F.AuraCache.GetGeneration(unit)) then
+	-- Identity generation catches enumerated reassignment events and
+	-- encounter-boundary auraInstanceID re-randomization. GUID snapshot
+	-- catches any identity change not covered by an enumerated event.
+	-- Together: belt-and-suspenders against stale auraInstanceID-keyed state.
+	if(not self._initialized
+		or self._unit ~= unit
+		or self._gen  ~= F.AuraCache.GetIdentityGeneration(unit)
+		or self._guid ~= UnitGUID(unit)) then
 		self:FullRefresh(unit)
 	end
 end
@@ -295,7 +305,13 @@ function AuraState:ApplyUpdateInfo(unit, updateInfo)
 		return
 	end
 
-	if(not self._initialized or self._unit ~= unit or self._gen ~= F.AuraCache.GetGeneration(unit)) then
+	-- Identity-stale detection: same as EnsureInitialized. Without this,
+	-- a UNIT_AURA racing an un-dispatched reassignment would apply a delta
+	-- against _helpfulById keyed by auraInstanceIDs from a different entity.
+	if(not self._initialized
+		or self._unit ~= unit
+		or self._gen  ~= F.AuraCache.GetIdentityGeneration(unit)
+		or self._guid ~= UnitGUID(unit)) then
 		self._lastUpdateInfo = updateInfo
 		self._lastUpdateUnit = unit
 		self:FullRefresh(unit)
@@ -524,6 +540,7 @@ function F.AuraState.Create(owner)
 		_unit = nil,
 		_initialized = false,
 		_gen = 0,
+		_guid = nil,
 		_lastUpdateInfo = nil,
 		_lastUpdateUnit = nil,
 		_helpfulById = {},

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -243,12 +243,6 @@ function AuraState:FullRefresh(unit)
 	self._unit = unit
 	self._initialized = true
 	self._gen = F.AuraCache.GetIdentityGeneration(unit)
-	-- GUID snapshot as second-line guardrail: catches identity changes
-	-- that bypass the enumerated reassignment events (UNIT_PET, vehicle
-	-- transitions, odd timing). UnitGUID returns nil for unloaded units,
-	-- which is a stable value — first real GUID post-load triggers one
-	-- legitimate FullRefresh. See #118.
-	self._guid = unit and UnitGUID(unit) or nil
 	wipe(self._helpfulById)
 	wipe(self._harmfulById)
 	self:ResetHelpfulMatches()
@@ -281,14 +275,14 @@ function AuraState:FullRefresh(unit)
 end
 
 function AuraState:EnsureInitialized(unit)
-	-- Identity generation catches enumerated reassignment events and
-	-- encounter-boundary auraInstanceID re-randomization. GUID snapshot
-	-- catches any identity change not covered by an enumerated event.
-	-- Together: belt-and-suspenders against stale auraInstanceID-keyed state.
+	-- Identity generation catches enumerated reassignment events (incl.
+	-- UNIT_PET) and encounter-boundary auraInstanceID re-randomization.
+	-- Can't use UnitGUID as a belt here — it returns secret-value strings
+	-- on pet/nameplate tokens during tainted execution, which would taint
+	-- the comparison. Per CLAUDE.md, no secret/non-secret path splits.
 	if(not self._initialized
 		or self._unit ~= unit
-		or self._gen  ~= F.AuraCache.GetIdentityGeneration(unit)
-		or self._guid ~= UnitGUID(unit)) then
+		or self._gen  ~= F.AuraCache.GetIdentityGeneration(unit)) then
 		self:FullRefresh(unit)
 	end
 end
@@ -310,8 +304,7 @@ function AuraState:ApplyUpdateInfo(unit, updateInfo)
 	-- against _helpfulById keyed by auraInstanceIDs from a different entity.
 	if(not self._initialized
 		or self._unit ~= unit
-		or self._gen  ~= F.AuraCache.GetIdentityGeneration(unit)
-		or self._guid ~= UnitGUID(unit)) then
+		or self._gen  ~= F.AuraCache.GetIdentityGeneration(unit)) then
 		self._lastUpdateInfo = updateInfo
 		self._lastUpdateUnit = unit
 		self:FullRefresh(unit)
@@ -540,7 +533,6 @@ function F.AuraState.Create(owner)
 		_unit = nil,
 		_initialized = false,
 		_gen = 0,
-		_guid = nil,
 		_lastUpdateInfo = nil,
 		_lastUpdateUnit = nil,
 		_helpfulById = {},

--- a/Core/MemDiag.lua
+++ b/Core/MemDiag.lua
@@ -93,13 +93,25 @@ local function patchOUFEvents()
 end
 
 --- Best-effort frame identifier for OnUpdate attribution.
---- Prefers the explicit name, falls back to parent name + class hint.
+--- If the frame is anonymous, walks up ancestors until a named frame is
+--- found so labels like `NamedParent>...@d3` stay attributable even when
+--- several nesting layers are anonymous. Caps the walk to avoid pathological
+--- infinite ancestry chains.
 local function frameLabel(frame, depth)
 	local name = frame:GetName()
 	if(name) then return name end
-	local parent = frame:GetParent()
-	local parentName = parent and parent:GetName() or 'anon'
-	return parentName .. ':anon@d' .. depth
+	local p = frame
+	local hops = 0
+	while(hops < 8) do
+		p = p:GetParent()
+		if(not p) then break end
+		local pname = p:GetName()
+		if(pname) then
+			return pname .. '>anon@d' .. depth .. (hops > 0 and ('/+' .. hops) or '')
+		end
+		hops = hops + 1
+	end
+	return 'anon@d' .. depth
 end
 
 --- Walk a frame tree up to maxDepth levels and apply fn(frame, depth).
@@ -115,30 +127,45 @@ local function walkFrames(frame, depth, maxDepth, fn)
 	end
 end
 
---- Hook OnUpdate scripts on all oUF frames and their descendants up to 3
---- levels deep. Castbars, health bars, and similar per-frame animators
---- typically live 1–2 levels below the unit frame.
-local function patchOnUpdates()
+--- Hook a single frame's current OnUpdate script. Idempotent — skips
+--- frames we've already wrapped (tracked via `_originals.onUpdates`).
+--- Returns true if a new hook was installed.
+local function hookFrameOnUpdate(frame, label)
+	if(F.MemDiag._originals.onUpdates[frame]) then return false end
+	local orig = frame:GetScript('OnUpdate')
+	if(not orig) then return false end
+	F.MemDiag._originals.onUpdates[frame] = orig
+	frame:SetScript('OnUpdate', function(self, elapsed)
+		local before = collectgarbage('count')
+		orig(self, elapsed)
+		local c = ensureCounter('update:' .. label)
+		c.calls = c.calls + 1
+		c.kb    = c.kb + (collectgarbage('count') - before)
+	end)
+	return true
+end
+
+--- Walk all oUF frames + descendants and hook their OnUpdate scripts.
+--- Safe to call repeatedly — `hookFrameOnUpdate` skips already-wrapped
+--- frames. Used both at Start and periodically during the window to
+--- catch dynamically-attached OnUpdates (Bar depleting, Color/Overlay
+--- animations) that escape the initial walk.
+local function walkAndHookOnUpdates()
 	local oUF = F.oUF
 	if(not oUF or not oUF.objects) then return end
 
-	F.MemDiag._originals.onUpdates = {}
 	for _, root in next, oUF.objects do
-		walkFrames(root, 0, 3, function(frame, depth)
-			local orig = frame:GetScript('OnUpdate')
-			if(orig) then
-				local label = frameLabel(frame, depth)
-				F.MemDiag._originals.onUpdates[frame] = orig
-				frame:SetScript('OnUpdate', function(self, elapsed)
-					local before = collectgarbage('count')
-					orig(self, elapsed)
-					local c = ensureCounter('update:' .. label)
-					c.calls = c.calls + 1
-					c.kb    = c.kb + (collectgarbage('count') - before)
-				end)
-			end
+		walkFrames(root, 0, 5, function(frame, depth)
+			hookFrameOnUpdate(frame, frameLabel(frame, depth))
 		end)
 	end
+end
+
+--- Initial OnUpdate hook pass. See walkAndHookOnUpdates for ongoing
+--- coverage of dynamically-attached scripts.
+local function patchOnUpdates()
+	F.MemDiag._originals.onUpdates = {}
+	walkAndHookOnUpdates()
 end
 
 --- Hook known standalone event/update frames that are not in oUF.objects.
@@ -163,7 +190,26 @@ local function patchStandaloneFrames()
 		end)
 	end
 
+	local function hookUpdate(frame, label)
+		if(not frame) then return end
+		local orig = frame:GetScript('OnUpdate')
+		if(not orig) then return end
+		F.MemDiag._originals.standalone[#F.MemDiag._originals.standalone + 1] = {
+			frame = frame, script = 'OnUpdate', orig = orig,
+		}
+		frame:SetScript('OnUpdate', function(self, elapsed)
+			local before = collectgarbage('count')
+			orig(self, elapsed)
+			local c = ensureCounter('standalone-update:' .. label)
+			c.calls = c.calls + 1
+			c.kb    = c.kb + (collectgarbage('count') - before)
+		end)
+	end
+
 	hookEvent(F.AuraCache and F.AuraCache._eventFrame, 'AuraCache')
+	hookUpdate(F.Indicators and F.Indicators.IconTicker_Frame, 'IconTicker')
+	hookUpdate(F.Status and F.Status.CrowdControl_Ticker, 'CrowdControl')
+	hookUpdate(F.Status and F.Status.LossOfControl_Ticker, 'LossOfControl')
 end
 
 local function restore()
@@ -197,7 +243,7 @@ end
 
 local function printReport(durationSec, totalStartKB, totalStopKB)
 	local totalDelta = totalStopKB - totalStartKB
-	print(('|cff00ccff[Framed/memdiag]|r window %.1fs — total allocated %.1f MB (while GC stopped)'):format(
+	print(('|cff00ccff[Framed/memdiag]|r window %.1fs — Framed allocated %.1f MB (GetAddOnMemoryUsage delta, GC stopped)'):format(
 		durationSec, totalDelta / 1024))
 
 	local rows = {}
@@ -211,11 +257,13 @@ local function printReport(durationSec, totalStartKB, totalStopKB)
 
 	-- Unattributed = totalDelta minus the top-level scopes. event:* wraps
 	-- oUF OnEvent dispatch (nests AuraState); update:* wraps per-frame
-	-- OnUpdate; standalone-event:* wraps non-oUF event frames. These are
-	-- mutually exclusive paths so they sum cleanly. AuraCache.GetUnitAuras
-	-- can be called from any path but is negligible post-migration.
+	-- OnUpdate; standalone-event:* wraps non-oUF event frames;
+	-- standalone-update:* wraps non-oUF ticker frames (IconTicker etc.).
+	-- These are mutually exclusive paths so they sum cleanly.
+	-- AuraCache.GetUnitAuras can be called from any path but is negligible
+	-- post-migration.
 	local topLevel = 0
-	local byBucket = { event = 0, update = 0, standalone = 0, aura = 0 }
+	local byBucket = { event = 0, update = 0, standalone = 0, tickers = 0, aura = 0, memdiag = 0 }
 	for key, c in next, F.MemDiag._counters do
 		if(key:sub(1, 6) == 'event:') then
 			topLevel = topLevel + c.kb
@@ -226,14 +274,20 @@ local function printReport(durationSec, totalStartKB, totalStopKB)
 		elseif(key:sub(1, 17) == 'standalone-event:') then
 			topLevel = topLevel + c.kb
 			byBucket.standalone = byBucket.standalone + c.kb
+		elseif(key:sub(1, 18) == 'standalone-update:') then
+			topLevel = topLevel + c.kb
+			byBucket.tickers = byBucket.tickers + c.kb
 		elseif(key == 'AuraCache.GetUnitAuras') then
 			topLevel = topLevel + c.kb
 			byBucket.aura = byBucket.aura + c.kb
+		elseif(key:sub(1, 8) == 'memdiag:') then
+			topLevel = topLevel + c.kb
+			byBucket.memdiag = byBucket.memdiag + c.kb
 		end
 	end
 
-	print(('  --- bucket totals: event=%.1fKB  update=%.1fKB  standalone=%.1fKB  auraCache=%.1fKB ---'):format(
-		byBucket.event, byBucket.update, byBucket.standalone, byBucket.aura))
+	print(('  --- bucket totals: event=%.1fKB  update=%.1fKB  standalone=%.1fKB  tickers=%.1fKB  auraCache=%.1fKB  memdiag=%.1fKB ---'):format(
+		byBucket.event, byBucket.update, byBucket.standalone, byBucket.tickers, byBucket.aura, byBucket.memdiag))
 
 	for _, r in next, rows do
 		local perCall = r.calls > 0 and (r.kb * 1024 / r.calls) or 0
@@ -246,6 +300,15 @@ local function printReport(durationSec, totalStartKB, totalStopKB)
 		'[unattributed: non-hooked paths]',
 		unattributed,
 		totalDelta > 0 and (unattributed / totalDelta * 100) or 0))
+end
+
+--- Read Framed-specific heap usage in KB. Blizzard attributes Lua
+--- allocations to whichever addon's code was on the call stack at
+--- alloc time, so this is the per-addon measurement ElvUI and similar
+--- tools display. UpdateAddOnMemoryUsage refreshes the snapshot.
+local function framedUsageKB()
+	UpdateAddOnMemoryUsage()
+	return GetAddOnMemoryUsage('Framed')
 end
 
 --- Start a measurement window. Stops GC, instruments aura funnels, and
@@ -266,7 +329,7 @@ function F.MemDiag.Start(seconds)
 	collectgarbage('collect')
 	collectgarbage('stop')
 
-	local startKB = collectgarbage('count')
+	local startKB = framedUsageKB()
 
 	patchAuraCache()
 	patchAuraStateMethods()
@@ -274,10 +337,33 @@ function F.MemDiag.Start(seconds)
 	patchOnUpdates()
 	patchStandaloneFrames()
 
+	-- Periodic re-walk: catches OnUpdate scripts attached mid-window
+	-- (Bar depleting, Color/Overlay/BorderGlow animations) that were not
+	-- present at the initial patchOnUpdates sweep. walkAndHookOnUpdates is
+	-- idempotent — already-hooked frames are skipped. Limitation: if a
+	-- hooked frame's script is later replaced with a new fn, we keep
+	-- tracking the old one (rare; noted for follow-up if needed).
+	--
+	-- The walk itself allocates (table-packed GetChildren results), so we
+	-- attribute that cost to a `memdiag:rewalk` counter — keeping it out of
+	-- the [unattributed] bucket so the report still reflects real leaks.
+	local function scheduleRewalk()
+		C_Timer.After(2, function()
+			if(not F.MemDiag._active) then return end
+			local before = collectgarbage('count')
+			walkAndHookOnUpdates()
+			local c = ensureCounter('memdiag:rewalk')
+			c.calls = c.calls + 1
+			c.kb    = c.kb + (collectgarbage('count') - before)
+			scheduleRewalk()
+		end)
+	end
+	scheduleRewalk()
+
 	print(('|cff00ccff[Framed/memdiag]|r started — %ds window, GC stopped'):format(seconds))
 
 	C_Timer.After(seconds, function()
-		local stopKB = collectgarbage('count')
+		local stopKB = framedUsageKB()
 		restore()
 		printReport(seconds, startKB, stopKB)
 

--- a/Elements/Auras/Buffs.lua
+++ b/Elements/Auras/Buffs.lua
@@ -63,27 +63,21 @@ local function defaultGrowForAnchor(parentPoint)
 	return 'RIGHT'
 end
 
--- Derive the element's aura-query filter from its indicator set.
---
--- Only a spell list widens the query to HELPFUL. The list itself is an
--- allowlist — so broadening doesn't leak noise onto the indicator, and
--- tracked IDs become visible regardless of Blizzard's RAID_IN_COMBAT
--- curation. Every other configuration (trackAll, any castBy) keeps
--- HELPFUL|RAID_IN_COMBAT so world/cosmetic/consumable buffs stay
--- filtered out by Blizzard before reaching the indicator.
-local function computeBuffFilter(indicatorConfigs)
-	for _, ind in next, indicatorConfigs do
-		if(ind.enabled ~= false and ind.spells and #ind.spells > 0) then
-			return 'HELPFUL'
-		end
-	end
-	return 'HELPFUL|RAID_IN_COMBAT'
-end
-
 -- Reusable containers — wiped each Update to avoid per-call allocation.
 -- Stores auraData references directly (no copy tables).
 local iconsAurasPool = {} -- [idx] = reusable sub-array of auraData refs
 local matchedPool = {}    -- [idx] = auraData ref or false
+
+-- Shared matcher context: populated by Update before iteration so the
+-- module-level matchAura can read per-call state without being redeclared
+-- as a nested closure each frame. Only one Update runs at a time on the
+-- main thread, so a single shared table is safe.
+local matchCtx = {
+	unit        = nil,
+	indicators  = nil,
+	spellLookup = nil,
+	hasTrackAll = nil,
+}
 
 -- Pre-created sort comparator (sortPriority set before each sort call)
 local sortPriority
@@ -119,6 +113,52 @@ local function passesCastByFilter(sourceUnit, castBy)
 	end
 
 	return true
+end
+
+-- ============================================================
+-- Per-aura matcher
+-- ============================================================
+
+--- Shared per-aura matcher used by both the classified and fallback paths.
+--- Reads per-call state from `matchCtx` (populated by Update) so this
+--- function stays at module scope — no nested-closure allocation per event.
+local function matchAura(auraData)
+	local spellId = auraData.spellId
+	if(not F.IsValueNonSecret(spellId)) then return end
+
+	local indicators  = matchCtx.indicators
+	local spellLookup = matchCtx.spellLookup
+	local hasTrackAll = matchCtx.hasTrackAll
+	local sourceUnit  = auraData.sourceUnit
+
+	-- Check spell-specific indicators
+	local indicatorIndices = spellLookup[spellId]
+	if(indicatorIndices) then
+		for _, idx in next, indicatorIndices do
+			local ind = indicators[idx]
+			if(passesCastByFilter(sourceUnit, ind._castBy)) then
+				if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
+					local list = iconsAurasPool[idx]
+					list[#list + 1] = auraData
+				elseif(not matchedPool[idx]) then
+					matchedPool[idx] = auraData
+				end
+			end
+		end
+	end
+
+	-- Check track-all indicators (empty spells list)
+	for _, idx in next, hasTrackAll do
+		local ind = indicators[idx]
+		if(passesCastByFilter(sourceUnit, ind._castBy)) then
+			if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
+				local list = iconsAurasPool[idx]
+				list[#list + 1] = auraData
+			elseif(not matchedPool[idx]) then
+				matchedPool[idx] = auraData
+			end
+		end
+	end
 end
 
 -- ============================================================
@@ -160,56 +200,22 @@ local function Update(self, event, unit, updateInfo)
 
 	local filter = element._buffFilter
 
-	-- Per-aura matcher shared between classified and fallback paths.
-	-- Captures unit / indicators / spellLookup / hasTrackAll via closure.
-	local function matchAura(auraData)
-		local spellId = auraData.spellId
-		if(not F.IsValueNonSecret(spellId)) then return end
-
-		local sourceUnit = auraData.sourceUnit
-
-		-- Check spell-specific indicators
-		local indicatorIndices = spellLookup[spellId]
-		if(indicatorIndices) then
-			for _, idx in next, indicatorIndices do
-				local ind = indicators[idx]
-				if(passesCastByFilter(sourceUnit, ind._castBy)) then
-					if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
-						local list = iconsAurasPool[idx]
-						list[#list + 1] = auraData
-					elseif(not matchedPool[idx]) then
-						matchedPool[idx] = auraData
-					end
-				end
-			end
-		end
-
-		-- Check track-all indicators (empty spells list)
-		for _, idx in next, hasTrackAll do
-			local ind = indicators[idx]
-			if(passesCastByFilter(sourceUnit, ind._castBy)) then
-				if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
-					local list = iconsAurasPool[idx]
-					list[#list + 1] = auraData
-				elseif(not matchedPool[idx]) then
-					matchedPool[idx] = auraData
-				end
-			end
-		end
-	end
+	-- Publish per-call state into the shared matcher context before
+	-- iterating. matchAura lives at module scope and reads from matchCtx.
+	matchCtx.unit        = unit
+	matchCtx.indicators  = indicators
+	matchCtx.spellLookup = spellLookup
+	matchCtx.hasTrackAll = hasTrackAll
 
 	local classified = auraState and auraState:GetHelpfulClassified()
 
 	if(classified) then
-		-- Classified path returns ALL helpful auras. When computeBuffFilter
-		-- resolved to HELPFUL|RAID_IN_COMBAT (no spell list among indicators),
-		-- gate each entry on flags.isRaidInCombat client-side so cosmetic /
-		-- consumable / world buffs stay filtered out — matching what the
-		-- server-side filter would have done.
-		local narrowFilter = filter == 'HELPFUL|RAID_IN_COMBAT'
-
+		-- Classified path returns ALL helpful auras. Gate each entry on
+		-- flags.isRaidInCombat client-side so cosmetic / consumable / world
+		-- buffs stay filtered out — matching what HELPFUL|RAID_IN_COMBAT
+		-- would have done at the server-side filter level.
 		for _, entry in next, classified do
-			if(not narrowFilter or entry.flags.isRaidInCombat) then
+			if(entry.flags.isRaidInCombat) then
 				matchAura(entry.aura)
 			end
 		end
@@ -562,7 +568,7 @@ local function Rebuild(element, config)
 	element._indicators           = {}
 	element._spellLookup          = {}
 	element._hasTrackAll          = {}
-	element._buffFilter           = computeBuffFilter(config.indicators)
+	element._buffFilter           = 'HELPFUL|RAID_IN_COMBAT'
 
 	local indicators = config.indicators
 	for name, indConfig in next, indicators do
@@ -707,7 +713,7 @@ function F.Elements.Buffs.Setup(self, config)
 		_indicators           = indicators,
 		_spellLookup          = spellLookup,
 		_hasTrackAll          = hasTrackAll,
-		_buffFilter           = computeBuffFilter(config.indicators),
+		_buffFilter           = 'HELPFUL|RAID_IN_COMBAT',
 	}
 
 	container.Rebuild = Rebuild

--- a/Elements/Indicators/IconTicker.lua
+++ b/Elements/Indicators/IconTicker.lua
@@ -20,6 +20,8 @@ local activeCount = 0
 
 tickerFrame:Hide()  -- starts hidden; shown when first icon registers
 
+F.Indicators.IconTicker_Frame = tickerFrame
+
 tickerFrame:SetScript('OnUpdate', function(self, elapsed)
 	self._elapsed = (self._elapsed or 0) + elapsed
 	if(self._elapsed < TICKER_INTERVAL) then return end

--- a/Elements/Status/CrowdControl.lua
+++ b/Elements/Status/CrowdControl.lua
@@ -80,6 +80,9 @@ end
 local tickerFrame = CreateFrame('Frame')
 tickerFrame:Hide()
 
+F.Status = F.Status or {}
+F.Status.CrowdControl_Ticker = tickerFrame
+
 local activeTimers = {}
 
 tickerFrame:SetScript('OnUpdate', function(_, elapsed)

--- a/Elements/Status/LossOfControl.lua
+++ b/Elements/Status/LossOfControl.lua
@@ -180,6 +180,9 @@ end
 local tickerFrame = CreateFrame('Frame')
 tickerFrame:Hide()
 
+F.Status = F.Status or {}
+F.Status.LossOfControl_Ticker = tickerFrame
+
 local activeTimers = {}
 
 tickerFrame:SetScript('OnUpdate', function(_, elapsed)

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -10,7 +10,10 @@ set -eu
 repo_root=$(git rev-parse --show-toplevel)
 cd "$repo_root"
 
-staged=$(git diff --cached --name-only --diff-filter=ACMR -z -- '*.lua' ':!Libs/**')
+# Newline-delimited: POSIX command substitution strips NULs from `-z`
+# output, which would collapse filenames into one. Filenames in this
+# repo don't contain newlines, so newline-delimiting is safe.
+staged=$(git diff --cached --name-only --diff-filter=ACMR -- '*.lua' ':!Libs/**')
 
 if [ -z "$staged" ]; then
 	exit 0
@@ -22,4 +25,5 @@ if ! command -v luacheck >/dev/null 2>&1; then
 	exit 0
 fi
 
-printf '%s' "$staged" | xargs -0 luacheck --config .luacheckrc
+# tr newline→NUL keeps xargs -0 portable across GNU and BSD (BSD has no -d).
+printf '%s' "$staged" | tr '\n' '\0' | xargs -0 luacheck --config .luacheckrc

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Framed pre-commit hook — runs luacheck on staged Lua files.
+#
+# Install via: tools/install-hooks.sh
+# Source of truth lives at tools/hooks/pre-commit; .git/hooks/pre-commit
+# is a symlink to it so edits here take effect immediately.
+
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+staged=$(git diff --cached --name-only --diff-filter=ACMR -z -- '*.lua' ':!Libs/**')
+
+if [ -z "$staged" ]; then
+	exit 0
+fi
+
+if ! command -v luacheck >/dev/null 2>&1; then
+	echo "pre-commit: luacheck not found — skipping lint check."
+	echo "pre-commit: install via 'brew install luacheck' or 'luarocks install luacheck'."
+	exit 0
+fi
+
+printf '%s' "$staged" | xargs -0 luacheck --config .luacheckrc

--- a/tools/install-hooks.sh
+++ b/tools/install-hooks.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Install Framed's tracked git hooks into .git/hooks/ as symlinks.
+# Re-run after cloning or after pulling new hook changes.
+
+set -eu
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+install_hook() {
+	name=$1
+	src="tools/hooks/$name"
+	dst=".git/hooks/$name"
+
+	if [ ! -f "$src" ]; then
+		echo "error: $src not found"
+		exit 1
+	fi
+
+	chmod +x "$src"
+
+	if [ -e "$dst" ] && [ ! -L "$dst" ]; then
+		echo "warning: $dst exists and is not a symlink; backing up to $dst.bak"
+		mv "$dst" "$dst.bak"
+	fi
+
+	ln -sf "../../$src" "$dst"
+	echo "installed: $dst -> $src"
+}
+
+install_hook pre-commit


### PR DESCRIPTION
## Summary

Splits `AuraCache`'s single `generation` counter into `generation` (content-stale, bumps on UNIT_AURA) and `identityGeneration` (identity-stale, bumps only on reassignment events + encounter boundaries). `AuraState` reads `identityGeneration` for its FullRefresh-vs-delta decision, so `ApplyUpdateInfo`'s delta path is finally reachable.

Fixes #118.

## Motivation

Pre-fix, every UNIT_AURA bumped the single counter, so `ApplyUpdateInfo`'s identity check always saw a mismatch and forced `FullRefresh`. Memdiag in LFR combat: ~230 `FullRefresh` calls × ~19 KB = ~4.4 MB / 30s. The delta path below the identity check was unreachable in practice — every UNIT_AURA paid the full-rebuild cost.

## Measurements (LFR combat, 30s window, GC stopped)

|  | Pre-#118 (est.) | Post (this PR) | Delta |
|---|---:|---:|---:|
| `AuraState:FullRefresh` | ~230 calls / ~4.4 MB | **3 calls / 2.1 KB** | **−99.95%** |
| `AuraState:ApplyUpdateInfo` | unreachable | 1023 calls / 340 B per | delta path active |
| `event:UNIT_AURA` (incl. Apply) | — | 716 calls / 3161 B per | baseline for follow-up |

`FullRefresh` now only fires on rare identity-change events (target/focus switch, roster change, encounter boundary, pet reassignment).

## Also in this PR

- **Pet-token taint followup (`af3e746`).** The initial #118 commit added a `UnitGUID(unit)` snapshot as a second-line identity guardrail. `UnitGUID` returns secret-value strings on pet tokens during tainted execution — `self._guid ~= UnitGUID(unit)` tainted immediately on `partypet2`. Dropped the GUID path entirely and filled the identity-change gap by registering `UNIT_PET` in `AuraCache` (handler derives `player→pet`, `partyN→partypetN`, `raidN→raidpetN`, `arenaN→arenapetN`). Per `CLAUDE.md`'s no-secret/non-secret-path-splits rule — guarding with `F.IsValueNonSecret` would have silently skipped the belt on the exact tokens most prone to identity confusion.
- **Pre-commit hook (`a607d6c` + `50cbbbf`).** `tools/hooks/pre-commit` runs `luacheck --config .luacheckrc` on staged `*.lua` outside `Libs/`. Install once per clone via `tools/install-hooks.sh` (symlinks to `.git/hooks/pre-commit`). Follow-up `50cbbbf` fixed a POSIX NUL-stripping bug where command substitution collapsed multi-file staged lists into a single concatenated path.
- **memdiag self-cost (`e8ac882`).** `memdiag:rewalk` now appears as its own attributed line (~1.6 MB / 30s) instead of inflating the `[unattributed]` bucket. Also broadens OnUpdate coverage.
- **Buffs hoist (`8578b34`).** Hoists `matchAura` locals out of the per-call path and always-gates `isRaidInCombat` in the classified path — prep work for downstream element-handler allocation analysis.

## Test Plan

- [x] `luacheck` + `luajit -bl` pass on `AuraCache.lua` and `AuraState.lua`
- [x] LFR combat 30s memdiag confirms `FullRefresh` drop (table above)
- [x] `partypet2` taint error reproduced pre-fix; absent post-fix
- [x] Reviewer spot-check: `UNIT_PET` handler correctly derives pet tokens for `player` / `partyN` / `raidN` / `arenaN`