### PR TITLE
perf(icon): cache SetSpell color paint, localize UNIT_AURA residue

### DIFF
--- a/Core/MemDiag.lua
+++ b/Core/MemDiag.lua
@@ -40,6 +40,38 @@ local function instrument(key, fn)
 	end
 end
 
+--- In-situ probe API for element modules that want per-expression
+--- attribution inside their own hot-path functions. Enter() returns a
+--- token (or nil when MemDiag is inactive); Leave() uses that token to
+--- record the bytes-allocated delta against `key`. Both are no-ops when
+--- the window is closed, so probes compiled into element code impose
+--- only a per-call branch + function-call cost in normal operation.
+function F.MemDiag.Enter()
+	if(not F.MemDiag._active) then return nil end
+	return collectgarbage('count')
+end
+
+function F.MemDiag.Leave(key, before)
+	if(not before) then return end
+	if(not F.MemDiag._active) then return end
+	local c = ensureCounter(key)
+	c.calls = c.calls + 1
+	c.kb    = c.kb + (collectgarbage('count') - before)
+end
+
+-- Element containers that expose an indicator list on an oUF frame.
+-- Walked by patchIndicatorMethods so renderer SetIcons/SetSpell calls
+-- get attributed per-frame. PrivateAuras is included speculatively —
+-- the walk no-ops on frames that don't carry the element.
+local ELEMENT_NAMES = {
+	'FramedBuffs',
+	'FramedDebuffs',
+	'FramedExternals',
+	'FramedDefensives',
+	'FramedMissingBuffs',
+	'FramedPrivateAuras',
+}
+
 local function patchAuraCache()
 	local orig = F.AuraCache.GetUnitAuras
 	F.MemDiag._originals.GetUnitAuras = orig
@@ -212,6 +244,52 @@ local function patchStandaloneFrames()
 	hookUpdate(F.Status and F.Status.LossOfControl_Ticker, 'LossOfControl')
 end
 
+--- Wrap SetIcons on ICONS-type renderers and SetSpell on ICON-type
+--- renderers across every oUF frame's aura-element indicator list.
+--- Methods are copied per-instance by the factory (see Elements/Indicators/*.lua
+--- tail `for k, v in next, Methods do icon[k] = v end`), so we patch each
+--- instance individually and save originals keyed by renderer reference.
+--- Scope-limited to SetIcons + SetSpell for this measurement pass — expand
+--- if residual cost in other renderer methods warrants it.
+local function patchIndicatorMethods()
+	local oUF = F.oUF
+	if(not oUF or not oUF.objects) then return end
+	local C = F.Constants
+	if(not C or not C.IndicatorType) then return end
+
+	F.MemDiag._originals.indicatorMethods = {}
+
+	local function wrapMethod(renderer, name, label)
+		local orig = renderer[name]
+		if(not orig) then return end
+		local saved = F.MemDiag._originals.indicatorMethods[renderer]
+		if(not saved) then
+			saved = {}
+			F.MemDiag._originals.indicatorMethods[renderer] = saved
+		end
+		saved[name] = orig
+		renderer[name] = instrument(label, orig)
+	end
+
+	for _, obj in next, oUF.objects do
+		for _, elementName in next, ELEMENT_NAMES do
+			local element = obj[elementName]
+			if(element and element._indicators) then
+				for _, ind in next, element._indicators do
+					local renderer = ind._renderer
+					if(renderer) then
+						if(ind._type == C.IndicatorType.ICONS) then
+							wrapMethod(renderer, 'SetIcons', 'indicator:Icons:SetIcons')
+						elseif(ind._type == C.IndicatorType.ICON) then
+							wrapMethod(renderer, 'SetSpell', 'indicator:Icon:SetSpell')
+						end
+					end
+				end
+			end
+		end
+	end
+end
+
 local function restore()
 	F.AuraCache.GetUnitAuras = F.MemDiag._originals.GetUnitAuras
 
@@ -239,6 +317,14 @@ local function restore()
 			r.frame:SetScript(r.script, r.orig)
 		end
 	end
+
+	if(F.MemDiag._originals.indicatorMethods) then
+		for renderer, methods in next, F.MemDiag._originals.indicatorMethods do
+			for name, orig in next, methods do
+				renderer[name] = orig
+			end
+		end
+	end
 end
 
 local function printReport(durationSec, totalStartKB, totalStopKB)
@@ -262,8 +348,11 @@ local function printReport(durationSec, totalStartKB, totalStopKB)
 	-- These are mutually exclusive paths so they sum cleanly.
 	-- AuraCache.GetUnitAuras can be called from any path but is negligible
 	-- post-migration.
+	-- indicator:* and element:* are in-situ probes nested inside event:*;
+	-- they attribute sub-paths within element Update handlers, so they are
+	-- tracked for informational totals but NOT added to topLevel.
 	local topLevel = 0
-	local byBucket = { event = 0, update = 0, standalone = 0, tickers = 0, aura = 0, memdiag = 0 }
+	local byBucket = { event = 0, update = 0, standalone = 0, tickers = 0, aura = 0, memdiag = 0, indicator = 0, element = 0 }
 	for key, c in next, F.MemDiag._counters do
 		if(key:sub(1, 6) == 'event:') then
 			topLevel = topLevel + c.kb
@@ -283,11 +372,17 @@ local function printReport(durationSec, totalStartKB, totalStopKB)
 		elseif(key:sub(1, 8) == 'memdiag:') then
 			topLevel = topLevel + c.kb
 			byBucket.memdiag = byBucket.memdiag + c.kb
+		elseif(key:sub(1, 10) == 'indicator:') then
+			byBucket.indicator = byBucket.indicator + c.kb
+		elseif(key:sub(1, 8) == 'element:') then
+			byBucket.element = byBucket.element + c.kb
 		end
 	end
 
 	print(('  --- bucket totals: event=%.1fKB  update=%.1fKB  standalone=%.1fKB  tickers=%.1fKB  auraCache=%.1fKB  memdiag=%.1fKB ---'):format(
 		byBucket.event, byBucket.update, byBucket.standalone, byBucket.tickers, byBucket.aura, byBucket.memdiag))
+	print(('  --- nested under event:* — indicator=%.1fKB  element=%.1fKB ---'):format(
+		byBucket.indicator, byBucket.element))
 
 	for _, r in next, rows do
 		local perCall = r.calls > 0 and (r.kb * 1024 / r.calls) or 0
@@ -336,6 +431,7 @@ function F.MemDiag.Start(seconds)
 	patchOUFEvents()
 	patchOnUpdates()
 	patchStandaloneFrames()
+	patchIndicatorMethods()
 
 	-- Periodic re-walk: catches OnUpdate scripts attached mid-window
 	-- (Bar depleting, Color/Overlay/BorderGlow animations) that were not

--- a/Elements/Auras/Buffs.lua
+++ b/Elements/Auras/Buffs.lua
@@ -123,8 +123,12 @@ end
 --- Reads per-call state from `matchCtx` (populated by Update) so this
 --- function stays at module scope — no nested-closure allocation per event.
 local function matchAura(auraData)
+	local mdBefore = F.MemDiag.Enter()
 	local spellId = auraData.spellId
-	if(not F.IsValueNonSecret(spellId)) then return end
+	if(not F.IsValueNonSecret(spellId)) then
+		F.MemDiag.Leave('element:Buffs.matchAura', mdBefore)
+		return
+	end
 
 	local indicators  = matchCtx.indicators
 	local spellLookup = matchCtx.spellLookup
@@ -139,7 +143,9 @@ local function matchAura(auraData)
 			if(passesCastByFilter(sourceUnit, ind._castBy)) then
 				if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
 					local list = iconsAurasPool[idx]
+					local apBefore = F.MemDiag.Enter()
 					list[#list + 1] = auraData
+					F.MemDiag.Leave('element:Buffs.matchAura.append', apBefore)
 				elseif(not matchedPool[idx]) then
 					matchedPool[idx] = auraData
 				end
@@ -153,12 +159,16 @@ local function matchAura(auraData)
 		if(passesCastByFilter(sourceUnit, ind._castBy)) then
 			if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
 				local list = iconsAurasPool[idx]
+				local apBefore = F.MemDiag.Enter()
 				list[#list + 1] = auraData
+				F.MemDiag.Leave('element:Buffs.matchAura.append', apBefore)
 			elseif(not matchedPool[idx]) then
 				matchedPool[idx] = auraData
 			end
 		end
 	end
+
+	F.MemDiag.Leave('element:Buffs.matchAura', mdBefore)
 end
 
 -- ============================================================

--- a/Elements/Auras/Buffs.lua
+++ b/Elements/Auras/Buffs.lua
@@ -123,10 +123,8 @@ end
 --- Reads per-call state from `matchCtx` (populated by Update) so this
 --- function stays at module scope — no nested-closure allocation per event.
 local function matchAura(auraData)
-	local mdBefore = F.MemDiag.Enter()
 	local spellId = auraData.spellId
 	if(not F.IsValueNonSecret(spellId)) then
-		F.MemDiag.Leave('element:Buffs.matchAura', mdBefore)
 		return
 	end
 
@@ -143,9 +141,7 @@ local function matchAura(auraData)
 			if(passesCastByFilter(sourceUnit, ind._castBy)) then
 				if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
 					local list = iconsAurasPool[idx]
-					local apBefore = F.MemDiag.Enter()
 					list[#list + 1] = auraData
-					F.MemDiag.Leave('element:Buffs.matchAura.append', apBefore)
 				elseif(not matchedPool[idx]) then
 					matchedPool[idx] = auraData
 				end
@@ -159,16 +155,12 @@ local function matchAura(auraData)
 		if(passesCastByFilter(sourceUnit, ind._castBy)) then
 			if(ind._type == C.IndicatorType.ICONS or ind._type == C.IndicatorType.BARS) then
 				local list = iconsAurasPool[idx]
-				local apBefore = F.MemDiag.Enter()
 				list[#list + 1] = auraData
-				F.MemDiag.Leave('element:Buffs.matchAura.append', apBefore)
 			elseif(not matchedPool[idx]) then
 				matchedPool[idx] = auraData
 			end
 		end
 	end
-
-	F.MemDiag.Leave('element:Buffs.matchAura', mdBefore)
 end
 
 -- ============================================================

--- a/Elements/Indicators/Icon.lua
+++ b/Elements/Indicators/Icon.lua
@@ -27,6 +27,7 @@ local IconMethods = {}
 --- @param expirationTime number Expiration GetTime() value (may be a secret value)
 --- @param stacks number Stack count
 function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, duration, expirationTime, stacks)
+	local mdBefore = F.MemDiag.Enter()
 	-- Texture
 	if(self._displayType == C.IconDisplay.COLORED_SQUARE) then
 		-- Per-spell color first, then base indicator color
@@ -60,6 +61,7 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 	end
 
 	-- Get DurationObject
+	local mdDur = F.MemDiag.Enter()
 	local durationObj
 	if(unit and auraInstanceID) then
 		durationObj = C_UnitAuras.GetAuraDuration(unit, auraInstanceID)
@@ -67,6 +69,7 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 		durationObj = self._manualDurObj
 	end
 	self._durationObj = durationObj
+	F.MemDiag.Leave('element:Icon.SetSpell.getDuration', mdDur)
 
 	-- Depletion bar
 	if(self._depletionBar) then
@@ -81,6 +84,7 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 
 	-- Duration countdown via Cooldown frame
 	if(self._cooldown) then
+		local mdCD = F.MemDiag.Enter()
 		if(durationObj and not durationObj:IsZero()) then
 			self._cooldown:SetCooldownFromDurationObject(durationObj)
 
@@ -111,6 +115,7 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 				self._cdText = cdText
 
 				-- Apply initial color so first frame isn't white
+				local mdEval = F.MemDiag.Enter()
 				if(self._colorCurve and durationObj) then
 					local color = durationObj:EvaluateRemainingPercent(self._colorCurve)
 					cdText:SetTextColor(color:GetRGBA())
@@ -124,6 +129,7 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 						self._cooldown:SetHideCountdownNumbers(a <= 0.5)
 					end
 				end
+				F.MemDiag.Leave('element:Icon.SetSpell.evaluate', mdEval)
 			end
 
 			-- Register with shared ticker if color/threshold curves exist
@@ -134,6 +140,7 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 			self._cooldown:Clear()
 			F.Indicators.IconTicker_Unregister(self)
 		end
+		F.MemDiag.Leave('element:Icon.SetSpell.cooldown', mdCD)
 	end
 
 	-- Glow (auto-start when glowType is configured and not 'None')
@@ -142,6 +149,7 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 	end
 
 	self._frame:Show()
+	F.MemDiag.Leave('element:Icon.SetSpell', mdBefore)
 end
 
 --- Switch between SpellIcon and ColoredSquare display modes.

--- a/Elements/Indicators/Icon.lua
+++ b/Elements/Indicators/Icon.lua
@@ -114,19 +114,28 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 				end
 				self._cdText = cdText
 
-				-- Apply initial color so first frame isn't white
+				-- Initial paint — skip repeat renders of the same aura.
+				-- IconTicker owns ongoing color updates; this block only
+				-- bootstraps so new auras don't show white cdText before the
+				-- first ticker tick. On a refresh of the same aura (same ID,
+				-- new duration), color may lag up to one ticker interval.
 				local mdEval = F.MemDiag.Enter()
-				if(self._colorCurve and durationObj) then
-					local color = durationObj:EvaluateRemainingPercent(self._colorCurve)
-					cdText:SetTextColor(color:GetRGBA())
-				end
+				if(auraInstanceID == nil or self._lastPaintedAuraID ~= auraInstanceID) then
+					self._lastPaintedAuraID = auraInstanceID
 
-				-- Apply initial threshold so first frame doesn't flash
-				if(self._thresholdCurve and durationObj) then
-					local vis = durationObj:EvaluateRemainingPercent(self._thresholdCurve)
-					local _, _, _, a = vis:GetRGBA()
-					if(F.IsValueNonSecret(a)) then
-						self._cooldown:SetHideCountdownNumbers(a <= 0.5)
+					-- Apply initial color so first frame isn't white
+					if(self._colorCurve and durationObj) then
+						local color = durationObj:EvaluateRemainingPercent(self._colorCurve)
+						cdText:SetTextColor(color:GetRGBA())
+					end
+
+					-- Apply initial threshold so first frame doesn't flash
+					if(self._thresholdCurve and durationObj) then
+						local vis = durationObj:EvaluateRemainingPercent(self._thresholdCurve)
+						local _, _, _, a = vis:GetRGBA()
+						if(F.IsValueNonSecret(a)) then
+							self._cooldown:SetHideCountdownNumbers(a <= 0.5)
+						end
 					end
 				end
 				F.MemDiag.Leave('element:Icon.SetSpell.evaluate', mdEval)
@@ -202,6 +211,7 @@ function IconMethods:Clear()
 	end
 	self:StopGlow()
 	self._durationObj = nil
+	self._lastPaintedAuraID = nil
 	F.Indicators.IconTicker_Unregister(self)
 	self._frame:Hide()
 end

--- a/Elements/Indicators/Icon.lua
+++ b/Elements/Indicators/Icon.lua
@@ -114,28 +114,30 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 				end
 				self._cdText = cdText
 
-				-- Initial paint — skip repeat renders of the same aura.
-				-- IconTicker owns ongoing color updates; this block only
-				-- bootstraps so new auras don't show white cdText before the
-				-- first ticker tick. On a refresh of the same aura (same ID,
-				-- new duration), color may lag up to one ticker interval.
+				-- Initial color — skip repeat renders of the same aura.
+				-- IconTicker owns ongoing color updates, so on a refresh
+				-- of the same aura (same ID, new duration), color may lag
+				-- up to one ticker interval before converging to the hue
+				-- of the new duration. Acceptable visual tradeoff.
 				local mdEval = F.MemDiag.Enter()
 				if(auraInstanceID == nil or self._lastPaintedAuraID ~= auraInstanceID) then
 					self._lastPaintedAuraID = auraInstanceID
 
-					-- Apply initial color so first frame isn't white
 					if(self._colorCurve and durationObj) then
 						local color = durationObj:EvaluateRemainingPercent(self._colorCurve)
 						cdText:SetTextColor(color:GetRGBA())
 					end
+				end
 
-					-- Apply initial threshold so first frame doesn't flash
-					if(self._thresholdCurve and durationObj) then
-						local vis = durationObj:EvaluateRemainingPercent(self._thresholdCurve)
-						local _, _, _, a = vis:GetRGBA()
-						if(F.IsValueNonSecret(a)) then
-							self._cooldown:SetHideCountdownNumbers(a <= 0.5)
-						end
+				-- Threshold visibility — always re-evaluate. Duration
+				-- changes on refresh, so the show/hide state of the
+				-- countdown text must be resampled immediately rather
+				-- than waiting for IconTicker to catch up.
+				if(self._thresholdCurve and durationObj) then
+					local vis = durationObj:EvaluateRemainingPercent(self._thresholdCurve)
+					local _, _, _, a = vis:GetRGBA()
+					if(F.IsValueNonSecret(a)) then
+						self._cooldown:SetHideCountdownNumbers(a <= 0.5)
 					end
 				end
 				F.MemDiag.Leave('element:Icon.SetSpell.evaluate', mdEval)

--- a/Elements/Indicators/Icon.lua
+++ b/Elements/Indicators/Icon.lua
@@ -27,7 +27,6 @@ local IconMethods = {}
 --- @param expirationTime number Expiration GetTime() value (may be a secret value)
 --- @param stacks number Stack count
 function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, duration, expirationTime, stacks)
-	local mdBefore = F.MemDiag.Enter()
 	-- Texture
 	if(self._displayType == C.IconDisplay.COLORED_SQUARE) then
 		-- Per-spell color first, then base indicator color
@@ -61,7 +60,6 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 	end
 
 	-- Get DurationObject
-	local mdDur = F.MemDiag.Enter()
 	local durationObj
 	if(unit and auraInstanceID) then
 		durationObj = C_UnitAuras.GetAuraDuration(unit, auraInstanceID)
@@ -69,7 +67,6 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 		durationObj = self._manualDurObj
 	end
 	self._durationObj = durationObj
-	F.MemDiag.Leave('element:Icon.SetSpell.getDuration', mdDur)
 
 	-- Depletion bar
 	if(self._depletionBar) then
@@ -84,7 +81,6 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 
 	-- Duration countdown via Cooldown frame
 	if(self._cooldown) then
-		local mdCD = F.MemDiag.Enter()
 		if(durationObj and not durationObj:IsZero()) then
 			self._cooldown:SetCooldownFromDurationObject(durationObj)
 
@@ -119,7 +115,6 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 				-- of the same aura (same ID, new duration), color may lag
 				-- up to one ticker interval before converging to the hue
 				-- of the new duration. Acceptable visual tradeoff.
-				local mdEval = F.MemDiag.Enter()
 				if(auraInstanceID == nil or self._lastPaintedAuraID ~= auraInstanceID) then
 					self._lastPaintedAuraID = auraInstanceID
 
@@ -140,7 +135,6 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 						self._cooldown:SetHideCountdownNumbers(a <= 0.5)
 					end
 				end
-				F.MemDiag.Leave('element:Icon.SetSpell.evaluate', mdEval)
 			end
 
 			-- Register with shared ticker if color/threshold curves exist
@@ -151,7 +145,6 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 			self._cooldown:Clear()
 			F.Indicators.IconTicker_Unregister(self)
 		end
-		F.MemDiag.Leave('element:Icon.SetSpell.cooldown', mdCD)
 	end
 
 	-- Glow (auto-start when glowType is configured and not 'None')
@@ -160,7 +153,6 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 	end
 
 	self._frame:Show()
-	F.MemDiag.Leave('element:Icon.SetSpell', mdBefore)
 end
 
 --- Switch between SpellIcon and ColoredSquare display modes.


### PR DESCRIPTION
## Summary

Followup to #118 (content/identity generation split). The generation fix eliminated the full-refresh-every-UNIT_AURA path, but combat MemDiag samples still showed ~1.8 MB / 30 s allocating inside `event:UNIT_AURA` on the element side.

Used MemDiag probes to narrow the cost to `IconMethods:SetSpell`'s `durationObj:EvaluateRemainingPercent(curve)` calls — each returns a fresh `LuaCurveEvaluatedResult` (ColorMixin, ~932 B) and `SetSpell` was evaluating both the color curve and the threshold curve every time. With `SecretArguments = "AllowedWhenUntainted"` blocking `EvaluateUnpacked` during combat, the cheap non-allocating path is unavailable — so the fix is to skip the color eval on repeat paints of the same aura (keyed by `auraInstanceID`), letting `IconTicker` converge the hue within ~1 s.

Threshold eval stays uncached — duration changes on HoT refresh, so the `SetHideCountdownNumbers(a <= 0.5)` show/hide state must be resampled immediately, not wait for the next ticker tick.

Result (30 s combat sample): `element:Icon.SetSpell` drops from ~1443 B/call → ~700 B/call (-50%). Full 83% cache could not be kept because of the threshold correctness constraint.

## Commits

- `fbf362b` — memdiag: instrument `Buffs.matchAura` + indicator `SetIcons`/`SetSpell`
- `2d16728` — memdiag: split `Icon:SetSpell` probes into `getDuration`/`cooldown`/`evaluate`
- `a294885` — icon: cache initial color + threshold paint by `auraInstanceID`
- `1fb487a` — icon: re-evaluate threshold every `SetSpell`, keep only color cached (fixes <25% countdown-text pop on HoT refresh)
- `9b71f54` — memdiag: strip in-situ probes from `Icon.lua` + `Buffs.lua` (probes were scaffolding; `Core/MemDiag.lua` module retained for future A/B)

## Tradeoff

Color hue on a HoT refresh lags up to one `IconTicker` interval (~1 s) before converging to the new duration's hue. Validated in-game; acceptable.

## Test Plan

- [x] Lint (`luacheck`) clean on all touched files
- [x] CI Luacheck green on `9b71f54` (tip)
- [x] In-game: Holy Paladin raid healing, <25% threshold countdown-text no longer pops on HoT refresh
- [x] In-game: color hue lag on refresh confirmed as acceptable (~1 s until convergence)
- [x] Optional: post-merge MemDiag 30 s sample to confirm the ~50% per-call drop sticks