### PR TITLE
Promote: aurastate split/bitmap + combat-lockdown fixes

### DIFF
--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -25,16 +25,18 @@ local IsAuraFilteredOutByInstanceID = C_UnitAuras and C_UnitAuras.IsAuraFiltered
 -- Acquire a classified entry from the per-instance pool (or allocate
 -- fresh if the pool is empty) and fill its flag fields for `aura`.
 --
+-- Split into polarity-specific variants (#173): each branch probes
+-- only the filter flags that semantically apply to its polarity, and
+-- explicitly zeroes the inapplicable ones so `entry.flags` has a
+-- uniform shape regardless of helpful/harmful origin.
+--
 -- Tier 1 flags are structural AuraData booleans. Per Blizzard's 12.0.x
 -- changes, isHelpful / isHarmful / isRaid / isNameplateOnly /
 -- isFromPlayerOrPlayerPet are non-secret. isBossAura remains secret on
 -- encounter auras and must be guarded with F.IsValueNonSecret to avoid
 -- tainted boolean tests.
 -- Tier 2 flags use C_UnitAuras filter probes (secret-safe C API).
-local function acquireClassified(pool, unit, aura, isHelpful)
-	local id = aura.auraInstanceID
-	local prefix = isHelpful and 'HELPFUL' or 'HARMFUL'
-
+local function acquireStructural(pool, aura)
 	local entry = pool[#pool]
 	if(entry) then
 		pool[#pool] = nil
@@ -52,16 +54,36 @@ local function acquireClassified(pool, unit, aura, isHelpful)
 	flags.isBossAura        = F.IsValueNonSecret(aura.isBossAura) and aura.isBossAura or false
 	flags.isFromPlayerOrPet = aura.isFromPlayerOrPlayerPet or false
 
-	flags.isExternalDefensive = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|EXTERNAL_DEFENSIVE') == false
-	flags.isImportant         = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|IMPORTANT')          == false
-	flags.isPlayerCast        = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|PLAYER')             == false
-	flags.isBigDefensive      = isHelpful
-	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HELPFUL|BIG_DEFENSIVE') == false
-	                            or false
-	flags.isRaidDispellable   = not isHelpful
-	                            and IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|RAID_PLAYER_DISPELLABLE') == false
-	                            or false
-	flags.isRaidInCombat      = IsAuraFilteredOutByInstanceID(unit, id, prefix .. '|RAID_IN_COMBAT') == false
+	return entry, flags, aura.auraInstanceID
+end
+
+-- EXTERNAL_DEFENSIVE and BIG_DEFENSIVE are curated helpful-only filters
+-- (ExternalDefensivesFrame.lua pairs EXTERNAL_DEFENSIVE with HELPFUL;
+-- BIG_DEFENSIVE is a spell whitelist of defensive cooldowns, all buffs).
+local function acquireHelpful(pool, unit, aura)
+	local entry, flags, id = acquireStructural(pool, aura)
+
+	flags.isExternalDefensive = IsAuraFilteredOutByInstanceID(unit, id, 'HELPFUL|EXTERNAL_DEFENSIVE') == false
+	flags.isImportant         = IsAuraFilteredOutByInstanceID(unit, id, 'HELPFUL|IMPORTANT')          == false
+	flags.isPlayerCast        = IsAuraFilteredOutByInstanceID(unit, id, 'HELPFUL|PLAYER')             == false
+	flags.isBigDefensive      = IsAuraFilteredOutByInstanceID(unit, id, 'HELPFUL|BIG_DEFENSIVE')      == false
+	flags.isRaidInCombat      = IsAuraFilteredOutByInstanceID(unit, id, 'HELPFUL|RAID_IN_COMBAT')     == false
+	flags.isRaidDispellable   = false
+
+	return entry
+end
+
+-- RAID_PLAYER_DISPELLABLE is harmful-only (Blizzard: "Auras with a dispel
+-- type the player can dispel" — dispelling applies to debuffs).
+local function acquireHarmful(pool, unit, aura)
+	local entry, flags, id = acquireStructural(pool, aura)
+
+	flags.isImportant         = IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|IMPORTANT')               == false
+	flags.isPlayerCast        = IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|PLAYER')                  == false
+	flags.isRaidDispellable   = IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|RAID_PLAYER_DISPELLABLE') == false
+	flags.isRaidInCombat      = IsAuraFilteredOutByInstanceID(unit, id, 'HARMFUL|RAID_IN_COMBAT')          == false
+	flags.isExternalDefensive = false
+	flags.isBigDefensive      = false
 
 	return entry
 end
@@ -466,7 +488,7 @@ function AuraState:GetHelpfulClassified()
 	for id, aura in next, self._helpfulById do
 		local entry = self._helpfulClassifiedById[id]
 		if(not entry) then
-			entry = acquireClassified(self._classifiedFreeList, self._unit, aura, true)
+			entry = acquireHelpful(self._classifiedFreeList, self._unit, aura)
 			self._helpfulClassifiedById[id] = entry
 		end
 		view.list[#view.list + 1] = entry
@@ -487,7 +509,7 @@ function AuraState:GetHarmfulClassified()
 	for id, aura in next, self._harmfulById do
 		local entry = self._harmfulClassifiedById[id]
 		if(not entry) then
-			entry = acquireClassified(self._classifiedFreeList, self._unit, aura, false)
+			entry = acquireHarmful(self._classifiedFreeList, self._unit, aura)
 			self._harmfulClassifiedById[id] = entry
 		end
 		view.list[#view.list + 1] = entry
@@ -504,7 +526,7 @@ function AuraState:GetClassifiedByInstanceID(auraInstanceID)
 
 	local aura = self._helpfulById[auraInstanceID]
 	if(aura) then
-		entry = acquireClassified(self._classifiedFreeList, self._unit, aura, true)
+		entry = acquireHelpful(self._classifiedFreeList, self._unit, aura)
 		self._helpfulClassifiedById[auraInstanceID] = entry
 		return entry
 	end
@@ -516,7 +538,7 @@ function AuraState:GetClassifiedByInstanceID(auraInstanceID)
 
 	aura = self._harmfulById[auraInstanceID]
 	if(aura) then
-		entry = acquireClassified(self._classifiedFreeList, self._unit, aura, false)
+		entry = acquireHarmful(self._classifiedFreeList, self._unit, aura)
 		self._harmfulClassifiedById[auraInstanceID] = entry
 		return entry
 	end

--- a/Core/AuraState.lua
+++ b/Core/AuraState.lua
@@ -484,6 +484,8 @@ function AuraState:GetHelpfulClassified()
 
 	view.dirty = false
 	wipe(view.list)
+	wipe(view.presentById)
+	wipe(view.presentByName)
 
 	for id, aura in next, self._helpfulById do
 		local entry = self._helpfulClassifiedById[id]
@@ -492,9 +494,27 @@ function AuraState:GetHelpfulClassified()
 			self._helpfulClassifiedById[id] = entry
 		end
 		view.list[#view.list + 1] = entry
+
+		local sid  = aura.spellId
+		local name = aura.name
+		if(F.IsValueNonSecret(sid))  then view.presentById[sid]    = entry end
+		if(F.IsValueNonSecret(name)) then view.presentByName[name] = entry end
 	end
 
 	return view.list
+end
+
+-- Look up a helpful classified entry by spellId (with an optional name
+-- fallback). Returns the entry or nil. Piggybacks on the presence maps
+-- populated during GetHelpfulClassified's rebuild, so the amortized
+-- cost is O(1) per lookup: first caller pays for the classified scan;
+-- subsequent lookups against the same unchanged view are hash hits.
+-- Used by MissingBuffs where the iteration is inverted (small fixed
+-- set of tracked spells vs. the full aura list).
+function AuraState:FindHelpfulBySpellId(spellId, name)
+	self:GetHelpfulClassified()
+	local view = self._helpfulClassifiedView
+	return view.presentById[spellId] or (name and view.presentByName[name])
 end
 
 function AuraState:GetHarmfulClassified()
@@ -561,7 +581,7 @@ function F.AuraState.Create(owner)
 		_helpfulViews = {},
 		_helpfulMatches = {},
 		_helpfulClassifiedById = {},
-		_helpfulClassifiedView = { dirty = true, list = {} },
+		_helpfulClassifiedView = { dirty = true, list = {}, presentById = {}, presentByName = {} },
 		_harmfulById = {},
 		_harmfulViews = {},
 		_harmfulMatches = {},

--- a/Elements/Auras/Dispellable.lua
+++ b/Elements/Auras/Dispellable.lua
@@ -127,12 +127,11 @@ local function ensureOverlayPositioned(element)
 
 	local gradHalf = element._overlayGradientHalf
 	if(gradHalf) then
-		gradHalf:SetPoint('BOTTOMLEFT', 1, 1)
+		-- Anchor top edge to overlayFrame's vertical midpoint (LEFT = left
+		-- edge, middle height). Height tracks the parent automatically, so
+		-- later wrapper resizes can't leave a stale baked height behind.
+		gradHalf:SetPoint('TOPLEFT', element._overlayFrame, 'LEFT', 1, 0)
 		gradHalf:SetPoint('BOTTOMRIGHT', -1, 1)
-		local parent = gradHalf:GetParent()
-		if(parent) then
-			gradHalf:SetHeight((parent:GetHeight() or 20) * 0.5)
-		end
 	end
 
 	local solidCur = element._overlaySolidCurrent

--- a/Elements/Auras/MissingBuffs.lua
+++ b/Elements/Auras/MissingBuffs.lua
@@ -195,19 +195,33 @@ local function Update(self, event, unit, updateInfo)
 			auraState:EnsureInitialized(unit)
 		end
 	end
-	local auras = auraState and auraState:GetHelpfulClassified()
-		or C_UnitAuras.GetUnitAuras(unit, 'HELPFUL')
+	-- Primary path uses AuraState's presence maps (O(1) per tracked spell).
+	-- Fallback path fetches raw auras and falls back to the linear scan
+	-- helper — only reachable if F.AuraState was never wired up.
+	local auras
+	if(not auraState) then
+		auras = C_UnitAuras.GetUnitAuras(unit, 'HELPFUL')
+	end
 
 	for _, spellId in next, BUFF_ORDER do
 		local providingClass = RAID_BUFFS[spellId]
 		local slot = slots[spellId]
 		if(not slot) then break end
 
+		local present
+		if(providingClass and groupClasses[providingClass]) then
+			if(auraState) then
+				present = auraState:FindHelpfulBySpellId(spellId, ensureCached(spellId))
+			else
+				present = auraListHasBuff(auras, spellId)
+			end
+		end
+
 		-- Skip non-player buffs on NPCs — can't reliably detect them
 		if(isNpc and providingClass ~= playerClass) then
 			slot.bi:Hide()
 			if(slot.glow:IsActive()) then slot.glow:Stop() end
-		elseif(providingClass and groupClasses[providingClass] and not auraListHasBuff(auras, spellId)) then
+		elseif(providingClass and groupClasses[providingClass] and not present) then
 			-- Missing buff from a class in the group — show and reposition
 			slot.bi.icon:SetTexture(iconCache[spellId])
 			slot.bi:ClearAllPoints()

--- a/Settings/MainFrame.lua
+++ b/Settings/MainFrame.lua
@@ -192,12 +192,16 @@ function Settings.CreateMainFrame()
 
 	-- ── ESC closes the window ─────────────────────────────────
 	frame:EnableKeyboard(true)
-	frame:SetPropagateKeyboardInput(true)
+	if(not InCombatLockdown()) then
+		frame:SetPropagateKeyboardInput(true)
+	end
 	frame:SetScript('OnKeyDown', function(self, key)
 		if(key == 'ESCAPE') then
-			self:SetPropagateKeyboardInput(false)
+			if(not InCombatLockdown()) then
+				self:SetPropagateKeyboardInput(false)
+			end
 			Widgets.FadeOut(self)
-		else
+		elseif(not InCombatLockdown()) then
 			self:SetPropagateKeyboardInput(true)
 		end
 	end)

--- a/Units/StyleBuilder.lua
+++ b/Units/StyleBuilder.lua
@@ -6,6 +6,22 @@ local Widgets = F.Widgets
 F.StyleBuilder = {}
 
 -- ============================================================
+-- Deferred RegisterForClicks queue
+-- RegisterForClicks is protected; calling it on a SecureGroupHeader
+-- child during combat triggers ADDON_ACTION_BLOCKED (issue #165).
+-- Defer to PLAYER_REGEN_ENABLED when locked down.
+-- ============================================================
+
+local pendingRegisterClicks = {}
+
+F.EventBus:Register('PLAYER_REGEN_ENABLED', function()
+	for frame in next, pendingRegisterClicks do
+		pendingRegisterClicks[frame] = nil
+		frame:RegisterForClicks('AnyUp')
+	end
+end, 'StyleBuilder.RegisterClicksQueue')
+
+-- ============================================================
 -- Power Color Overrides
 -- Blizzard's PowerBarColor.MANA is pure blue (0,0,1) which has
 -- very low perceived luminance and is nearly invisible on thin
@@ -133,8 +149,13 @@ function F.StyleBuilder.Apply(self, unit, config, unitType)
 	-- Store unit type for live config lookups
 	self._framedUnitType = unitType
 
-	-- Register for all mouse button clicks (WoW 10.0+ defaults to LeftButtonUp only)
-	self:RegisterForClicks('AnyUp')
+	-- Register for all mouse button clicks (WoW 10.0+ defaults to LeftButtonUp only).
+	-- Protected call — defer if locked down (issue #165).
+	if(InCombatLockdown()) then
+		pendingRegisterClicks[self] = true
+	else
+		self:RegisterForClicks('AnyUp')
+	end
 
 	-- Unit tooltip on hover
 	self:SetScript('OnEnter', function(frame)


### PR DESCRIPTION
Closes #173.

Promotion PR bundling 5 commits from `working-testing`. Two themes:

## AuraState perf

### `ff28e6b` Split acquireClassified (#173)

- `acquireClassified(pool, unit, aura, isHelpful)` → `acquireHelpful` + `acquireHarmful`
- Shared `acquireStructural(pool, aura)` returns `(entry, flags, id)` for Tier 1 setup; polarity-specific variants handle Tier 2 probes
- Inapplicable flags explicitly zeroed (`false`) so `entry.flags` shape stays uniform across polarities
- 4 call sites updated: `GetHelpfulClassified`, `GetHarmfulClassified`, `GetClassifiedByInstanceID` (×2 branches)

#### Verification against wow-ui-source

| Flag | Polarity | Source |
|---|---|---|
| EXTERNAL_DEFENSIVE | Helpful-only | `Blizzard_BuffFrame/ExternalDefensivesFrame.lua:27` — Blizzard pairs with `Helpful` |
| BIG_DEFENSIVE | Helpful-only (de facto) | `C_UnitAuras.AuraIsBigDefensive(spellID)` — curated defensive-cooldown spell whitelist, all buffs |
| RAID_PLAYER_DISPELLABLE | Harmful-only | `Blizzard_FrameXMLUtil/AuraUtil.lua:171` — Blizzard comment: *"Auras with a dispel type the player can dispel"* |
| IMPORTANT, PLAYER, RAID_IN_COMBAT | Both | No restrictive Blizzard comment; both polarities retained |

#### Net effect

- **Per harmful aura:** 1 eliminated probe (`HARMFUL|EXTERNAL_DEFENSIVE` always returned false — curated helpful filter)
- **Per helpful aura:** no probe change, but `isRaidDispellable` branch eliminated (previously `not isHelpful and probe() or false`)
- Pre-existing polarity gates (`isBigDefensive`, `isRaidDispellable`) now implicit in function choice rather than runtime `isHelpful`/`not isHelpful` conditionals

Probes are C-level (`IsAuraFilteredOutByInstanceID`), so savings are CPU frame-time, not Lua heap. Won't show in `/framed memdiag`.

### `d02d4b7` Helpful presence maps for FindHelpfulBySpellId

MissingBuffs inverts the usual aura iteration pattern: it walks a small fixed set of tracked raid buffs (`BUFF_ORDER`, ~6) against the full helpful aura list (~5-15) per UNIT_AURA via linear scan — O(B × K). Populate `presentById` / `presentByName` hash maps on the helpful classified view during the rebuild already running in `GetHelpfulClassified`, and expose `AuraState:FindHelpfulBySpellId` as the O(1) accessor. MissingBuffs switches its primary path; the `auraListHasBuff` fallback stays for the defensive `F.AuraState`-unavailable case.

- Map build is secret-value guarded via `F.IsValueNonSecret`, matching `acquireStructural`'s discipline
- Presence maps hold classified entry references so future consumers (tracked-CD uptime indicators, encounter debuff reminders) can read `entry.flags` / `entry.aura` alongside presence without a second lookup
- Net: ~4× algorithmic reduction on MissingBuffs Update hot path

## Combat-lockdown fixes

- `1e45d93` — Anchor `GRADIENT_HALF` overlay instead of baking `SetHeight` in dispellable indicator (#163)
- `feddfa2` — Defer `RegisterForClicks` when combat-locked in StyleBuilder (#165)
- `26e0e09` — Guard `SetPropagateKeyboardInput` against combat lockdown in Settings main frame

## Test plan

AuraState split (#173) — verified in prior review pass:
- [x] `/reload` clean at login
- [x] `/framed aurastate player` — HELPFUL and HARMFUL lists populate with expected active-flag names
- [x] `/framed aurastate <tank>` during pull — external defensive (BoS/PI/Ironbark) shows `external-defensive player-cast`; self big-defensive (Divine Shield) shows `big-defensive player-cast`
- [x] **Externals element** — party healer casts PI/BoS on tank, icon renders
- [x] **Defensives element** — self Divine Shield / Ice Block / Ardent Defender, icon renders
- [x] **Buffs element (in combat)** — self HoTs render; **out of combat** — flasks/food render
- [x] **Debuffs element** — boss dots render; dispellable mode shows magic debuffs; important mode shows priority debuffs
- [x] Target-dummy aura churn (2–3 defensive pops) — no stale flag leak visible in `/framed aurastate`

New in this bundle:
- [x] **MissingBuffs bitmap** — drop/recast a tracked raid buff (e.g., PW:F) on a raid member, icon appears/disappears within one UNIT_AURA cycle; NPC party members (delves) only show missing indicators for buffs the player provides
- [x] **Settings in combat** — open `/framed` window during combat and interact, no ADDON_ACTION_BLOCKED errors; ESC still fades the window
- [x] **StyleBuilder in combat** — click operations on frames while combat-locked don't error; operations deferred queue correctly after combat ends
- [x] **Dispellable indicator** — GRADIENT_HALF overlay positions correctly on frames of various sizes

## Files

- `Core/AuraState.lua` — split acquire + presence maps + FindHelpfulBySpellId
- `Elements/Auras/MissingBuffs.lua` — switch primary path to FindHelpfulBySpellId
- `Settings/MainFrame.lua` — combat guard
- (dispellable + StyleBuilder diffs from their respective commits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)