### PR TITLE
Settings UX + preset transition reliability + memory fixes

### DIFF
--- a/Core/EventBus.lua
+++ b/Core/EventBus.lua
@@ -71,14 +71,30 @@ function EventBus:UnregisterAll(owner)
 end
 
 --- Fire an event, calling all registered callbacks.
+---
+--- Each callback runs in its own protected call so a throw in one
+--- listener doesn't halt the cascade and silently break every listener
+--- registered after it. This is isolation, not suppression — errors
+--- still surface through WoW's standard error handler (BugSack /
+--- BugGrabber / default error frame), exactly as if the callback ran
+--- unprotected. The previous non-isolating implementation caused
+--- silent resize + preset-change cascade failures: a single stale
+--- reference in any listener would stop all subsequent panels from
+--- receiving the event, leaving them "frozen" to future state changes.
+---
 --- @param eventName string The event to fire
 --- @param ... any Arguments passed to callbacks
 function EventBus:Fire(eventName, ...)
 	local listeners = registry[eventName]
 	if(not listeners) then return end
 
+	local errorHandler = geterrorhandler()
 	for id, entry in next, listeners do
-		entry.callback(...)
+		local ok, err = pcall(entry.callback, ...)
+		if(not ok) then
+			errorHandler(('Framed EventBus listener error (event=%s, owner=%s): %s'):format(
+				tostring(eventName), tostring(entry.owner), tostring(err)))
+		end
 	end
 end
 

--- a/Core/MemDiag.lua
+++ b/Core/MemDiag.lua
@@ -1,13 +1,17 @@
 local _, Framed = ...
 local F = Framed
 
--- Diagnostic tool: measure allocation churn in the aura fan-out hot paths.
+-- Diagnostic tool: measure allocation churn AND CPU cost in the aura
+-- fan-out hot paths.
 --
 -- Usage: F.MemDiag.Start(seconds)
 -- Stops GC for the window so any `collectgarbage('count')` rise is pure
 -- allocation (nothing gets freed), wraps each hot funnel to accumulate
--- KB delta + call count, restores originals when the window ends, runs
--- a full collect, and prints a sorted report.
+-- KB delta + ms delta + call count, restores originals when the window
+-- ends, runs a full collect, and prints a sorted report.
+--
+-- ms timing via debugprofilestop() requires /console scriptProfile 1 +
+-- /reload. Without it, the ms column reads 0.
 --
 -- Not for steady-state use — memory climbs for the duration by design.
 
@@ -19,44 +23,56 @@ F.MemDiag = {
 
 local MAX_SECONDS = 30
 
+-- Cache hot builtins as upvalues — instrumentation wrappers call these
+-- on every hot-path invocation, so avoiding the global table lookup
+-- matters for the overhead we're adding to the very code we're measuring.
+local gc_count     = collectgarbage
+local profile_stop = debugprofilestop
+
 local function ensureCounter(key)
 	local c = F.MemDiag._counters[key]
 	if(not c) then
-		c = { calls = 0, kb = 0 }
+		c = { calls = 0, kb = 0, ms = 0 }
 		F.MemDiag._counters[key] = c
 	end
 	return c
 end
 
---- Build a wrapper that records KB-delta + call count for `fn` under `key`.
+--- Build a wrapper that records KB-delta + ms-delta + call count for `fn` under `key`.
 local function instrument(key, fn)
 	return function(...)
-		local before = collectgarbage('count')
+		local beforeKB = gc_count('count')
+		local beforeMS = profile_stop()
 		local a, b, c, d, e, f = fn(...)
 		local c1 = ensureCounter(key)
 		c1.calls = c1.calls + 1
-		c1.kb    = c1.kb + (collectgarbage('count') - before)
+		c1.kb    = c1.kb + (gc_count('count') - beforeKB)
+		c1.ms    = c1.ms + (profile_stop() - beforeMS)
 		return a, b, c, d, e, f
 	end
 end
 
 --- In-situ probe API for element modules that want per-expression
---- attribution inside their own hot-path functions. Enter() returns a
---- token (or nil when MemDiag is inactive); Leave() uses that token to
---- record the bytes-allocated delta against `key`. Both are no-ops when
---- the window is closed, so probes compiled into element code impose
---- only a per-call branch + function-call cost in normal operation.
+--- attribution inside their own hot-path functions. Enter() returns two
+--- tokens (or nils when MemDiag is inactive); Leave() uses those tokens
+--- to record the bytes- and ms-allocated deltas against `key`. Both are
+--- no-ops when the window is closed, so probes compiled into element
+--- code impose only a per-call branch + function-call cost in normal
+--- operation.
 function F.MemDiag.Enter()
-	if(not F.MemDiag._active) then return nil end
-	return collectgarbage('count')
+	if(not F.MemDiag._active) then return nil, nil end
+	return gc_count('count'), profile_stop()
 end
 
-function F.MemDiag.Leave(key, before)
-	if(not before) then return end
+function F.MemDiag.Leave(key, beforeKB, beforeMS)
+	if(not beforeKB) then return end
 	if(not F.MemDiag._active) then return end
 	local c = ensureCounter(key)
 	c.calls = c.calls + 1
-	c.kb    = c.kb + (collectgarbage('count') - before)
+	c.kb    = c.kb + (gc_count('count') - beforeKB)
+	if(beforeMS) then
+		c.ms = c.ms + (profile_stop() - beforeMS)
+	end
 end
 
 -- Element containers that expose an indicator list on an oUF frame.
@@ -114,11 +130,13 @@ local function patchOUFEvents()
 		if(orig) then
 			F.MemDiag._originals.frameEvents[frame] = orig
 			frame:SetScript('OnEvent', function(self, event, ...)
-				local before = collectgarbage('count')
+				local beforeKB = gc_count('count')
+				local beforeMS = profile_stop()
 				orig(self, event, ...)
 				local c = ensureCounter('event:' .. (event or '?'))
 				c.calls = c.calls + 1
-				c.kb    = c.kb + (collectgarbage('count') - before)
+				c.kb    = c.kb + (gc_count('count') - beforeKB)
+				c.ms    = c.ms + (profile_stop() - beforeMS)
 			end)
 		end
 	end
@@ -132,6 +150,15 @@ end
 local function frameLabel(frame, depth)
 	local name = frame:GetName()
 	if(name) then return name end
+
+	-- GetDebugName surfaces Blizzard's internal hierarchical name (e.g.
+	-- 'FramedPartyHeaderUnitButton1.HealPredictionBar') even for anonymous
+	-- frames. Not available on all versions, so guard with a check.
+	if(frame.GetDebugName) then
+		local debugName = frame:GetDebugName()
+		if(debugName and debugName ~= '') then return debugName end
+	end
+
 	local p = frame
 	local hops = 0
 	while(hops < 8) do
@@ -168,36 +195,63 @@ local function hookFrameOnUpdate(frame, label)
 	if(not orig) then return false end
 	F.MemDiag._originals.onUpdates[frame] = orig
 	frame:SetScript('OnUpdate', function(self, elapsed)
-		local before = collectgarbage('count')
+		local beforeKB = gc_count('count')
+		local beforeMS = profile_stop()
 		orig(self, elapsed)
 		local c = ensureCounter('update:' .. label)
 		c.calls = c.calls + 1
-		c.kb    = c.kb + (collectgarbage('count') - before)
+		c.kb    = c.kb + (gc_count('count') - beforeKB)
+		c.ms    = c.ms + (profile_stop() - beforeMS)
 	end)
 	return true
 end
 
---- Walk all oUF frames + descendants and hook their OnUpdate scripts.
---- Safe to call repeatedly — `hookFrameOnUpdate` skips already-wrapped
---- frames. Used both at Start and periodically during the window to
---- catch dynamically-attached OnUpdates (Bar depleting, Color/Overlay
---- animations) that escape the initial walk.
-local function walkAndHookOnUpdates()
+--- One-time catalog walk: descend oUF.objects once, record every reachable
+--- frame + its label into _trackedFrames, and hook any OnUpdate scripts
+--- present at that moment.
+---
+--- Labels are computed (and GetDebugName called) exactly once per frame
+--- here and cached for the rest of the window — subsequent rewalks reuse
+--- the cached label without re-walking the parent chain.
+local function walkAndCatalogFrames()
 	local oUF = F.oUF
 	if(not oUF or not oUF.objects) then return end
 
+	local tracked = F.MemDiag._originals.trackedFrames
 	for _, root in next, oUF.objects do
 		walkFrames(root, 0, 5, function(frame, depth)
-			hookFrameOnUpdate(frame, frameLabel(frame, depth))
+			if(not tracked[frame]) then
+				local label = frameLabel(frame, depth)
+				tracked[frame] = label
+				hookFrameOnUpdate(frame, label)
+			end
 		end)
 	end
 end
 
---- Initial OnUpdate hook pass. See walkAndHookOnUpdates for ongoing
---- coverage of dynamically-attached scripts.
+--- Cheap rewalk: iterate the cached frame set and hook any OnUpdate that
+--- appeared since last pass. No tree traversal, no table packing, no
+--- label recomputation. Pure GetScript probe per tracked frame.
+---
+--- Limitation: frames created after Start are not in the cache and won't
+--- be caught. Acceptable — Framed spawns frames at addon load, not in
+--- combat, so new-frame emergence inside a 30s window is vanishingly rare.
+local function rewalkCachedFrames()
+	local tracked = F.MemDiag._originals.trackedFrames
+	local hooked  = F.MemDiag._originals.onUpdates
+	for frame, label in next, tracked do
+		if(not hooked[frame]) then
+			hookFrameOnUpdate(frame, label)
+		end
+	end
+end
+
+--- Initial OnUpdate hook pass. Populates the tracked-frame cache used by
+--- subsequent rewalks.
 local function patchOnUpdates()
-	F.MemDiag._originals.onUpdates = {}
-	walkAndHookOnUpdates()
+	F.MemDiag._originals.onUpdates     = {}
+	F.MemDiag._originals.trackedFrames = {}
+	walkAndCatalogFrames()
 end
 
 --- Hook known standalone event/update frames that are not in oUF.objects.
@@ -214,11 +268,13 @@ local function patchStandaloneFrames()
 			frame = frame, script = 'OnEvent', orig = orig,
 		}
 		frame:SetScript('OnEvent', function(self, event, ...)
-			local before = collectgarbage('count')
+			local beforeKB = gc_count('count')
+			local beforeMS = profile_stop()
 			orig(self, event, ...)
 			local c = ensureCounter('standalone-event:' .. label .. ':' .. (event or '?'))
 			c.calls = c.calls + 1
-			c.kb    = c.kb + (collectgarbage('count') - before)
+			c.kb    = c.kb + (gc_count('count') - beforeKB)
+			c.ms    = c.ms + (profile_stop() - beforeMS)
 		end)
 	end
 
@@ -230,11 +286,13 @@ local function patchStandaloneFrames()
 			frame = frame, script = 'OnUpdate', orig = orig,
 		}
 		frame:SetScript('OnUpdate', function(self, elapsed)
-			local before = collectgarbage('count')
+			local beforeKB = gc_count('count')
+			local beforeMS = profile_stop()
 			orig(self, elapsed)
 			local c = ensureCounter('standalone-update:' .. label)
 			c.calls = c.calls + 1
-			c.kb    = c.kb + (collectgarbage('count') - before)
+			c.kb    = c.kb + (gc_count('count') - beforeKB)
+			c.ms    = c.ms + (profile_stop() - beforeMS)
 		end)
 	end
 
@@ -334,14 +392,15 @@ local function printReport(durationSec, totalStartKB, totalStopKB)
 
 	local rows = {}
 	for key, c in next, F.MemDiag._counters do
-		rows[#rows + 1] = { key = key, calls = c.calls, kb = c.kb }
+		rows[#rows + 1] = { key = key, calls = c.calls, kb = c.kb, ms = c.ms or 0 }
 	end
-	table.sort(rows, function(a, b) return a.kb > b.kb end)
+	table.sort(rows, function(a, b) return a.ms > b.ms end)
 
-	print('|cff00ccff[Framed/memdiag]|r per-hook (sorted by bytes allocated):')
+	print('|cff00ccff[Framed/memdiag]|r per-hook (sorted by ms spent):')
 	print('  note: event:* totals nest AuraState:* costs — do not sum both')
+	print('  note: ms column is 0 unless /console scriptProfile 1 + /reload')
 
-	-- Unattributed = totalDelta minus the top-level scopes. event:* wraps
+	-- Unattributed KB = totalDelta minus the top-level scopes. event:* wraps
 	-- oUF OnEvent dispatch (nests AuraState); update:* wraps per-frame
 	-- OnUpdate; standalone-event:* wraps non-oUF event frames;
 	-- standalone-update:* wraps non-oUF ticker frames (IconTicker etc.).
@@ -351,50 +410,61 @@ local function printReport(durationSec, totalStartKB, totalStopKB)
 	-- indicator:* and element:* are in-situ probes nested inside event:*;
 	-- they attribute sub-paths within element Update handlers, so they are
 	-- tracked for informational totals but NOT added to topLevel.
-	local topLevel = 0
-	local byBucket = { event = 0, update = 0, standalone = 0, tickers = 0, aura = 0, memdiag = 0, indicator = 0, element = 0 }
+	local topLevelKB = 0
+	local topLevelMS = 0
+	local bKB = { event = 0, update = 0, standalone = 0, tickers = 0, aura = 0, memdiag = 0, indicator = 0, element = 0 }
+	local bMS = { event = 0, update = 0, standalone = 0, tickers = 0, aura = 0, memdiag = 0, indicator = 0, element = 0 }
 	for key, c in next, F.MemDiag._counters do
+		local ms = c.ms or 0
 		if(key:sub(1, 6) == 'event:') then
-			topLevel = topLevel + c.kb
-			byBucket.event = byBucket.event + c.kb
+			topLevelKB = topLevelKB + c.kb; topLevelMS = topLevelMS + ms
+			bKB.event = bKB.event + c.kb;    bMS.event = bMS.event + ms
 		elseif(key:sub(1, 7) == 'update:') then
-			topLevel = topLevel + c.kb
-			byBucket.update = byBucket.update + c.kb
+			topLevelKB = topLevelKB + c.kb; topLevelMS = topLevelMS + ms
+			bKB.update = bKB.update + c.kb;  bMS.update = bMS.update + ms
 		elseif(key:sub(1, 17) == 'standalone-event:') then
-			topLevel = topLevel + c.kb
-			byBucket.standalone = byBucket.standalone + c.kb
+			topLevelKB = topLevelKB + c.kb; topLevelMS = topLevelMS + ms
+			bKB.standalone = bKB.standalone + c.kb; bMS.standalone = bMS.standalone + ms
 		elseif(key:sub(1, 18) == 'standalone-update:') then
-			topLevel = topLevel + c.kb
-			byBucket.tickers = byBucket.tickers + c.kb
+			topLevelKB = topLevelKB + c.kb; topLevelMS = topLevelMS + ms
+			bKB.tickers = bKB.tickers + c.kb; bMS.tickers = bMS.tickers + ms
 		elseif(key == 'AuraCache.GetUnitAuras') then
-			topLevel = topLevel + c.kb
-			byBucket.aura = byBucket.aura + c.kb
+			topLevelKB = topLevelKB + c.kb; topLevelMS = topLevelMS + ms
+			bKB.aura = bKB.aura + c.kb;      bMS.aura = bMS.aura + ms
 		elseif(key:sub(1, 8) == 'memdiag:') then
-			topLevel = topLevel + c.kb
-			byBucket.memdiag = byBucket.memdiag + c.kb
+			topLevelKB = topLevelKB + c.kb; topLevelMS = topLevelMS + ms
+			bKB.memdiag = bKB.memdiag + c.kb; bMS.memdiag = bMS.memdiag + ms
 		elseif(key:sub(1, 10) == 'indicator:') then
-			byBucket.indicator = byBucket.indicator + c.kb
+			bKB.indicator = bKB.indicator + c.kb; bMS.indicator = bMS.indicator + ms
 		elseif(key:sub(1, 8) == 'element:') then
-			byBucket.element = byBucket.element + c.kb
+			bKB.element = bKB.element + c.kb; bMS.element = bMS.element + ms
 		end
 	end
 
-	print(('  --- bucket totals: event=%.1fKB  update=%.1fKB  standalone=%.1fKB  tickers=%.1fKB  auraCache=%.1fKB  memdiag=%.1fKB ---'):format(
-		byBucket.event, byBucket.update, byBucket.standalone, byBucket.tickers, byBucket.aura, byBucket.memdiag))
-	print(('  --- nested under event:* — indicator=%.1fKB  element=%.1fKB ---'):format(
-		byBucket.indicator, byBucket.element))
+	print(('  --- KB by bucket: event=%.1f  update=%.1f  standalone=%.1f  tickers=%.1f  auraCache=%.1f  memdiag=%.1f ---'):format(
+		bKB.event, bKB.update, bKB.standalone, bKB.tickers, bKB.aura, bKB.memdiag))
+	print(('  --- ms by bucket: event=%.1f  update=%.1f  standalone=%.1f  tickers=%.1f  auraCache=%.1f  memdiag=%.1f ---'):format(
+		bMS.event, bMS.update, bMS.standalone, bMS.tickers, bMS.aura, bMS.memdiag))
+	print(('  --- nested under event:* — indicator KB=%.1f/ms=%.1f  element KB=%.1f/ms=%.1f ---'):format(
+		bKB.indicator, bMS.indicator, bKB.element, bMS.element))
 
+	-- Per-call μs is (ms*1000)/calls — kept in μs to avoid the "0.00 ms/call"
+	-- degenerate case that hides real cost on high-frequency hot paths.
 	for _, r in next, rows do
-		local perCall = r.calls > 0 and (r.kb * 1024 / r.calls) or 0
-		print(('  %-48s  %6d calls  %8.1f KB  (%.0f B/call)'):format(
-			r.key, r.calls, r.kb, perCall))
+		local bPerCall  = r.calls > 0 and (r.kb * 1024 / r.calls) or 0
+		local usPerCall = r.calls > 0 and (r.ms * 1000    / r.calls) or 0
+		print(('  %-48s  %6d calls  %8.1f ms  %8.1f KB  (%.0f μs/call, %.0f B/call)'):format(
+			r.key, r.calls, r.ms, r.kb, usPerCall, bPerCall))
 	end
 
-	local unattributed = totalDelta - topLevel
+	local unattributedKB = totalDelta - topLevelKB
 	print(('  %-48s                 %8.1f KB  (%.0f%%)'):format(
-		'[unattributed: non-hooked paths]',
-		unattributed,
-		totalDelta > 0 and (unattributed / totalDelta * 100) or 0))
+		'[unattributed KB: non-hooked paths]',
+		unattributedKB,
+		totalDelta > 0 and (unattributedKB / totalDelta * 100) or 0))
+	print(('  %-48s                 %8.1f ms  (top-level sum; compare to AddonProfiler Framed Total)'):format(
+		'[top-level ms total]',
+		topLevelMS))
 end
 
 --- Read Framed-specific heap usage in KB. Blizzard attributes Lua
@@ -434,23 +504,28 @@ function F.MemDiag.Start(seconds)
 	patchIndicatorMethods()
 
 	-- Periodic re-walk: catches OnUpdate scripts attached mid-window
-	-- (Bar depleting, Color/Overlay/BorderGlow animations) that were not
-	-- present at the initial patchOnUpdates sweep. walkAndHookOnUpdates is
-	-- idempotent — already-hooked frames are skipped. Limitation: if a
-	-- hooked frame's script is later replaced with a new fn, we keep
-	-- tracking the old one (rare; noted for follow-up if needed).
+	-- (Bar depleting, Color/Overlay/BorderGlow animations, glow effects)
+	-- that were not present at the initial patchOnUpdates sweep.
 	--
-	-- The walk itself allocates (table-packed GetChildren results), so we
-	-- attribute that cost to a `memdiag:rewalk` counter — keeping it out of
-	-- the [unattributed] bucket so the report still reflects real leaks.
+	-- rewalkCachedFrames iterates only the frame set collected during the
+	-- initial catalog walk — no tree traversal, no table packing, no
+	-- GetDebugName recomputation. Per-tick cost is ~one GetScript probe
+	-- per tracked frame. Still attributed to `memdiag:rewalk` so the
+	-- report reflects remaining self-cost.
+	--
+	-- Limitation: frames created after Start are not in the cache and
+	-- won't be caught. Acceptable — Framed spawns frames at addon load,
+	-- not in combat, so new-frame emergence inside a 30s window is rare.
 	local function scheduleRewalk()
 		C_Timer.After(2, function()
 			if(not F.MemDiag._active) then return end
-			local before = collectgarbage('count')
-			walkAndHookOnUpdates()
+			local beforeKB = gc_count('count')
+			local beforeMS = profile_stop()
+			rewalkCachedFrames()
 			local c = ensureCounter('memdiag:rewalk')
 			c.calls = c.calls + 1
-			c.kb    = c.kb + (collectgarbage('count') - before)
+			c.kb    = c.kb + (gc_count('count') - beforeKB)
+			c.ms    = c.ms + (profile_stop() - beforeMS)
 			scheduleRewalk()
 		end)
 	end

--- a/Elements/Auras/MissingBuffs.lua
+++ b/Elements/Auras/MissingBuffs.lua
@@ -32,7 +32,7 @@ local DEFAULT_CONFIG = {
 	growDirection = 'LEFT',
 	spacing       = 2,
 	frameLevel    = 2,
-	glowType      = 'Pixel',
+	glowType      = 'Proc',
 	glowColor     = { 1, 0.82, 0, 1 },
 	anchor        = { 'TOPRIGHT', nil, 'TOPLEFT', -2, 0 },
 }

--- a/Elements/Auras/PrivateAuras.lua
+++ b/Elements/Auras/PrivateAuras.lua
@@ -28,25 +28,31 @@ local function RegisterAnchors(element, unit)
 	-- AddPrivateAuraAnchor throws on a nil unitToken.
 	if(not unit) then return end
 	local iconSize = element._iconSize
+	-- SetScale on scaledAnchor cascades through Blizzard's InboundContainerFrameMixin
+	-- to the Duration FontString (fixed FontObject, no anchor-level override). Icon
+	-- width/height are pre-divided by scale so the icon renders at iconSize visually
+	-- after the scale cascade; only the duration text shrinks or grows.
+	local scale = element._durationScale
 	for idx = 1, #element._pool do
 		local slot = element._pool[idx]
+		slot.scaledAnchor:SetScale(scale)
 		if(slot.anchorID) then
 			C_UnitAuras.RemovePrivateAuraAnchor(slot.anchorID)
 		end
 		slot.anchorID = C_UnitAuras.AddPrivateAuraAnchor({
 			unitToken            = unit,
 			auraIndex            = idx,
-			parent               = slot.frame,
+			parent               = slot.scaledAnchor,
 			showCountdownFrame   = true,
 			showCountdownNumbers = true,
 			isContainer          = false,
 			iconInfo             = {
-				iconWidth   = iconSize,
-				iconHeight  = iconSize,
+				iconWidth   = iconSize / scale,
+				iconHeight  = iconSize / scale,
 				borderScale = -100,
 				iconAnchor  = {
 					point         = 'CENTER',
-					relativeTo    = slot.frame,
+					relativeTo    = slot.scaledAnchor,
 					relativePoint = 'CENTER',
 					offsetX       = 0,
 					offsetY       = 0,
@@ -220,16 +226,24 @@ oUF:AddElement('FramedPrivateAuras', Update, Enable, Disable)
 function F.Elements.PrivateAuras.Setup(self, config)
 	config = config or {}
 
-	-- Create a pool of anchor frames, one per auraIndex slot
+	-- Create a pool of anchor frames, one per auraIndex slot.
+	-- `frame` participates in LayoutPool at scale 1 so spacing math works.
+	-- `scaledAnchor` is an inner overlay whose SetScale cascades through
+	-- Blizzard's InboundContainerFrameMixin to the PrivateAura's Duration
+	-- FontString — the only way to influence that font size, since Blizzard
+	-- uses a fixed FontObject with no anchor-level override.
 	local pool = {}
 	for idx = 1, config.maxDisplayed do
 		local frame = CreateFrame('Frame', nil, self)
-		pool[idx] = { frame = frame, anchorID = nil }
+		local scaledAnchor = CreateFrame('Frame', nil, frame)
+		scaledAnchor:SetAllPoints(frame)
+		pool[idx] = { frame = frame, scaledAnchor = scaledAnchor, anchorID = nil }
 	end
 
 	local element = {
 		_pool           = pool,
 		_iconSize       = config.iconSize,
+		_durationScale  = config.durationScale,
 		_showDispelType = config.showDispelType,
 		_anchorID       = nil,
 		Rebuild         = Rebuild,

--- a/Presets/AuraDefaults.lua
+++ b/Presets/AuraDefaults.lua
@@ -159,6 +159,7 @@ function F.AuraDefaults.Solo(debuffSize, debuffMax)
 		privateAuras = {
 			enabled        = false,
 			iconSize       = 16,
+			durationScale  = 1,
 			maxDisplayed   = 3,
 			orientation    = 'RIGHT',
 			showDispelType = true,
@@ -172,7 +173,7 @@ function F.AuraDefaults.Solo(debuffSize, debuffMax)
 			anchor        = { 'BOTTOMRIGHT', nil, 'BOTTOMRIGHT', -2, 16 },
 			growDirection = 'LEFT',
 			spacing       = 1,
-			glowType      = 'Pixel',
+			glowType      = 'Proc',
 			glowColor     = { 1, 0.8, 0, 1 },
 		},
 		lossOfControl = {
@@ -260,6 +261,7 @@ function F.AuraDefaults.Minimal()
 		privateAuras = {
 			enabled        = false,
 			iconSize       = 14,
+			durationScale  = 1,
 			maxDisplayed   = 3,
 			orientation    = 'RIGHT',
 			showDispelType = true,
@@ -273,7 +275,7 @@ function F.AuraDefaults.Minimal()
 			anchor        = { 'BOTTOMRIGHT', nil, 'BOTTOMRIGHT', -2, 16 },
 			growDirection = 'LEFT',
 			spacing       = 1,
-			glowType      = 'Pixel',
+			glowType      = 'Proc',
 			glowColor     = { 1, 0.8, 0, 1 },
 		},
 		lossOfControl = {
@@ -399,12 +401,13 @@ function F.AuraDefaults.Group(sizes)
 			anchor        = { 'BOTTOMRIGHT', nil, 'BOTTOMRIGHT', -2, 16 },
 			growDirection  = 'LEFT',
 			spacing       = 1,
-			glowType      = 'Pixel',
+			glowType      = 'Proc',
 			glowColor     = { 1, 0.8, 0, 1 },
 		},
 		privateAuras = {
 			enabled        = true,
 			iconSize       = s.privateAurasIcon or 16,
+			durationScale  = 1,
 			maxDisplayed   = 3,
 			orientation    = 'RIGHT',
 			showDispelType = true,
@@ -503,6 +506,7 @@ function F.AuraDefaults.Arena()
 		privateAuras = {
 			enabled        = false,
 			iconSize       = 14,
+			durationScale  = 1,
 			maxDisplayed   = 3,
 			orientation    = 'RIGHT',
 			showDispelType = true,
@@ -516,7 +520,7 @@ function F.AuraDefaults.Arena()
 			anchor        = { 'BOTTOMRIGHT', nil, 'BOTTOMRIGHT', -2, 16 },
 			growDirection = 'LEFT',
 			spacing       = 1,
-			glowType      = 'Pixel',
+			glowType      = 'Proc',
 			glowColor     = { 1, 0.8, 0, 1 },
 		},
 		lossOfControl = {
@@ -617,6 +621,7 @@ function F.AuraDefaults.Boss()
 		privateAuras = {
 			enabled        = false,
 			iconSize       = 16,
+			durationScale  = 1,
 			maxDisplayed   = 3,
 			orientation    = 'RIGHT',
 			showDispelType = true,
@@ -630,7 +635,7 @@ function F.AuraDefaults.Boss()
 			anchor        = { 'BOTTOMRIGHT', nil, 'BOTTOMRIGHT', -2, 16 },
 			growDirection = 'LEFT',
 			spacing       = 1,
-			glowType      = 'Pixel',
+			glowType      = 'Proc',
 			glowColor     = { 1, 0.8, 0, 1 },
 		},
 		lossOfControl = {

--- a/Settings/Builders/IndicatorCardBuilders.lua
+++ b/Settings/Builders/IndicatorCardBuilders.lua
@@ -571,11 +571,13 @@ function Builders.BorderAppearance(parent, width, data, update, get, set)
 		colorPicker:SetColor(glowColor[1], glowColor[2], glowColor[3], glowColor[4] or 1)
 		cardY = placeWidget(colorPicker, inner, cardY, DROPDOWN_H)
 
-		-- Glow type dropdown (frame-level glows only: Pixel and Shine)
+		-- Glow type dropdown (frame-level glows only: Pixel and Shine).
+		-- Both animate particle textures via unthrottled Lua OnUpdate at
+		-- 60 fps (~1.14 ms/s per active glow) — note the cost in the label.
 		local typeDD = Widgets.CreateDropdown(inner, widgetW)
 		typeDD:SetItems({
-			{ text = 'Pixel', value = C.GlowType.PIXEL },
-			{ text = 'Shine', value = C.GlowType.SHINE },
+			{ text = 'Pixel (high CPU)', value = C.GlowType.PIXEL },
+			{ text = 'Shine (high CPU)', value = C.GlowType.SHINE },
 		})
 		typeDD:SetValue(get('glowType') or C.GlowType.PIXEL)
 		typeDD:SetOnSelect(function(value) set('glowType', value) end)

--- a/Settings/Builders/SharedCards.lua
+++ b/Settings/Builders/SharedCards.lua
@@ -116,15 +116,20 @@ function F.Settings.BuildGlowCard(parent, width, yOffset, get, set, opts)
 	if(opts.allowNone) then
 		typeItems[#typeItems + 1] = { text = 'None', value = 'None' }
 	end
+	-- Pixel and Shine animate particle textures via unthrottled Lua OnUpdate
+	-- at 60 fps (~1.14 ms/s per active glow). In raids with many simultaneous
+	-- glows the cost scales linearly — Proc (engine-driven AnimationGroup)
+	-- and Soft (sprite-sheet) are materially cheaper. Label this in the
+	-- dropdown so the choice is informed.
 	if(opts.frameGlowOnly) then
 		-- Only procedural glows that work on non-square frames
-		typeItems[#typeItems + 1] = { text = 'Pixel', value = C.GlowType.PIXEL }
-		typeItems[#typeItems + 1] = { text = 'Shine', value = C.GlowType.SHINE }
+		typeItems[#typeItems + 1] = { text = 'Pixel (high CPU)', value = C.GlowType.PIXEL }
+		typeItems[#typeItems + 1] = { text = 'Shine (high CPU)', value = C.GlowType.SHINE }
 	else
-		typeItems[#typeItems + 1] = { text = 'Proc',  value = C.GlowType.PROC }
-		typeItems[#typeItems + 1] = { text = 'Pixel', value = C.GlowType.PIXEL }
-		typeItems[#typeItems + 1] = { text = 'Soft',  value = C.GlowType.SOFT }
-		typeItems[#typeItems + 1] = { text = 'Shine', value = C.GlowType.SHINE }
+		typeItems[#typeItems + 1] = { text = 'Proc',             value = C.GlowType.PROC }
+		typeItems[#typeItems + 1] = { text = 'Pixel (high CPU)', value = C.GlowType.PIXEL }
+		typeItems[#typeItems + 1] = { text = 'Soft',             value = C.GlowType.SOFT }
+		typeItems[#typeItems + 1] = { text = 'Shine (high CPU)', value = C.GlowType.SHINE }
 	end
 
 	local typeDD = Widgets.CreateDropdown(inner, widgetW)

--- a/Settings/Cards/HealthColor.lua
+++ b/Settings/Cards/HealthColor.lua
@@ -130,7 +130,12 @@ function F.SettingsCards.HealthColor(parent, width, unitType, getConfig, setConf
 	local lossPicker = Widgets.CreateColorPicker(inner, 'Loss Color', false,
 		nil,
 		function(r, g, b) setConfig('health.lossCustomColor', { r, g, b }) end)
-	local savedLoss = getConfig('health.lossCustomColor')
+	-- Defensive fallback mirrors the health.customColor read at line 104.
+	-- Ideally DeepMerge always backfills this leaf key from baseUnitConfig,
+	-- but older SavedVariables or partially-migrated configs can leave it
+	-- nil. Crashing here when the card builds is worse than reading the
+	-- canonical default inline.
+	local savedLoss = getConfig('health.lossCustomColor') or { 0.15, 0.15, 0.15 }
 	lossPicker:SetColor(savedLoss[1], savedLoss[2], savedLoss[3], 1)
 	local lossPickerH = 22
 

--- a/Settings/Cards/HealthColor.lua
+++ b/Settings/Cards/HealthColor.lua
@@ -130,12 +130,7 @@ function F.SettingsCards.HealthColor(parent, width, unitType, getConfig, setConf
 	local lossPicker = Widgets.CreateColorPicker(inner, 'Loss Color', false,
 		nil,
 		function(r, g, b) setConfig('health.lossCustomColor', { r, g, b }) end)
-	-- Defensive fallback mirrors the health.customColor read at line 104.
-	-- Ideally DeepMerge always backfills this leaf key from baseUnitConfig,
-	-- but older SavedVariables or partially-migrated configs can leave it
-	-- nil. Crashing here when the card builds is worse than reading the
-	-- canonical default inline.
-	local savedLoss = getConfig('health.lossCustomColor') or { 0.15, 0.15, 0.15 }
+	local savedLoss = getConfig('health.lossCustomColor')
 	lossPicker:SetColor(savedLoss[1], savedLoss[2], savedLoss[3], 1)
 	local lossPickerH = 22
 

--- a/Settings/FrameSettingsBuilder.lua
+++ b/Settings/FrameSettingsBuilder.lua
@@ -1133,10 +1133,16 @@ function F.FrameSettingsBuilder.Create(parent, unitType)
 	F.EventBus:Register('EDITING_PRESET_CHANGED', function(newPreset)
 		scroll._builtForPreset = nil
 		if(F.Settings and F.Settings._panelFrames) then
-			-- Invalidate cache so panel rebuilds with new preset data
+			-- Invalidate cache so panel rebuilds with new preset data.
+			-- TearDownPanel handles the full release (Hide + SetParent(nil)
+			-- + tracking-table cleanup) so we don't leak the orphaned frame.
 			for panelId, frame in next, F.Settings._panelFrames do
 				if(frame == scroll) then
-					F.Settings._panelFrames[panelId] = nil
+					if(F.Settings.TearDownPanel) then
+						F.Settings.TearDownPanel(panelId)
+					else
+						F.Settings._panelFrames[panelId] = nil
+					end
 					break
 				end
 			end

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -85,8 +85,23 @@ end
 
 --- Set the preset name being edited.
 --- @param presetName string
+--- Temporary diagnostic flag — flip to false before release.
+--- Prints every SetEditingPreset call with the current vs requested
+--- preset so we can see whether the breadcrumb dropdown is actually
+--- firing the state change or being silently dropped / early-returned.
+Settings._debugPresetTransitions = true
+
 function Settings.SetEditingPreset(presetName)
-	if(editingPreset == presetName) then return end
+	if(Settings._debugPresetTransitions) then
+		print(('|cff00ccff[Framed/preset]|r SetEditingPreset called: current=%s -> requested=%s'):format(
+			tostring(editingPreset), tostring(presetName)))
+	end
+	if(editingPreset == presetName) then
+		if(Settings._debugPresetTransitions) then
+			print('|cffff6666[Framed/preset]|r early-return (already at requested preset)')
+		end
+		return
+	end
 	editingPreset = presetName
 	Settings._editingUnitType = nil
 	F.EventBus:Fire('EDITING_PRESET_CHANGED', presetName)

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -562,8 +562,33 @@ function Settings.SetActivePanel(panelId)
 	-- strings (sep1/sep2/sep3) so the text itself is just the label;
 	-- activatePresetHeaderControls handles anchoring after the correct
 	-- upstream separator.
+	--
+	-- The group-frame panel (id='party') is special: its registered label
+	-- is the static "Party Frames", but the actual label depends on the
+	-- current preset's groupLabel ("Raid Frames" / "Arena Frames" / etc.).
+	-- Resolve dynamically so the breadcrumb matches what the sidebar and
+	-- preview show.
+	local panelLabel = info.label or ''
+	if(info.id == 'party') then
+		local presetInfo = C.PresetInfo[Settings.GetEditingPreset()]
+		if(presetInfo and presetInfo.groupLabel) then
+			panelLabel = presetInfo.groupLabel
+		end
+	end
 	if(Settings._headerPanelText) then
-		Settings._headerPanelText:SetText(info.label or '')
+		Settings._headerPanelText:SetText(panelLabel)
+	end
+
+	-- Defensive sidebar-label resync: ensure the group-frame button's
+	-- displayed label matches the current preset, regardless of whether
+	-- EDITING_PRESET_CHANGED fired cleanly. Covers edge cases where the
+	-- sidebar listener was raced past or the button was re-created.
+	local groupBtn = Settings._sidebarButtons and Settings._sidebarButtons['party']
+	if(groupBtn and groupBtn._label) then
+		local presetInfo = C.PresetInfo[Settings.GetEditingPreset()]
+		if(presetInfo and presetInfo.groupLabel) then
+			groupBtn._label:SetText(presetInfo.groupLabel)
+		end
 	end
 
 	-- Show/hide and populate the breadcrumb segments + Copy-to control.
@@ -571,7 +596,7 @@ function Settings.SetActivePanel(panelId)
 
 	-- Restore drill-in breadcrumb if the panel re-entered with an active indicator
 	if(Settings._activePanelFrame and Settings._activePanelFrame._editingIndicatorName) then
-		Settings.UpdateAuraBreadcrumb(info.label or '', Settings._activePanelFrame._editingIndicatorName)
+		Settings.UpdateAuraBreadcrumb(panelLabel, Settings._activePanelFrame._editingIndicatorName)
 	end
 
 	-- ── Show/hide aura sidebar buttons based on active panel ─

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -606,16 +606,17 @@ function Settings.SetActivePanel(panelId)
 		Settings._auraPreview = nil
 	end
 
-	-- ── Reset unit type when switching to aura panels ────────
-	-- Prevents "pet" (or other frame-only types) from leaking into
-	-- the Configure for dropdown on aura panels. Must run before the
-	-- header text decorates itself with the unit label.
-	if(info.subSection == 'auras') then
-		local currentUT = Settings._editingUnitType
-		if(currentUT == 'pet') then
-			Settings._editingUnitType = nil  -- falls back to preset default
-		end
-	end
+	-- Note: a previous reset here wiped _editingUnitType = 'pet' on every
+	-- aura panel activation to prevent pet "leaking" when navigating from
+	-- the Pet frame page to an aura page. That was overreach — it also
+	-- wiped explicit Pet selections made through the unit-type dropdown,
+	-- because SetActivePanel re-runs on every dropdown change. Net effect
+	-- was pet-scope aura editing was impossible. Removed.
+	--
+	-- If the Pet→Buffs navigation default feels wrong (landing on pet-
+	-- scope instead of player-scope), fix that at the navigation boundary
+	-- (sidebar click handler) rather than here, so explicit dropdown
+	-- choices are respected.
 
 	-- Panel name segment. Separators are rendered by dedicated font
 	-- strings (sep1/sep2/sep3) so the text itself is just the label;

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -85,11 +85,12 @@ end
 
 --- Set the preset name being edited.
 --- @param presetName string
---- Temporary diagnostic flag — flip to false before release.
---- Prints every SetEditingPreset call with the current vs requested
---- preset so we can see whether the breadcrumb dropdown is actually
---- firing the state change or being silently dropped / early-returned.
-Settings._debugPresetTransitions = true
+--- Diagnostic flag — set true to surface preset-transition prints in
+--- chat when investigating breadcrumb/dropdown desyncs. Leave false in
+--- normal operation. The gated prints in SetEditingPreset,
+--- reconcileEditingPresetChange, and FramePresets' row-highlight
+--- listener all check this flag.
+Settings._debugPresetTransitions = false
 
 function Settings.SetEditingPreset(presetName)
 	if(Settings._debugPresetTransitions) then

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -699,9 +699,34 @@ F.EventBus:Register('EDITING_PRESET_CHANGED', function()
 		dd:SetValue(Settings.GetEditingUnitType() or getDefaultUnitType())
 	end
 
+	-- Tear down cached preset-scoped panel frames before forgetting them.
+	-- Setting _panelFrames[id] = nil only drops the Lua cache reference;
+	-- the Frame object stays parented to _contentParent with all its
+	-- widgets, textures, and registered event handlers intact. Repeated
+	-- preset switches would orphan one set of panel frames per switch,
+	-- producing steady memory growth across a session. Explicit Hide +
+	-- SetParent(nil) releases WoW's frame ownership and lets GC reclaim
+	-- everything once the last Lua reference is dropped.
 	for _, p in next, registeredPanels do
-		if(p.section == 'PRESET_SCOPED' and Settings._panelFrames[p.id]) then
+		local frame = Settings._panelFrames[p.id]
+		if(p.section == 'PRESET_SCOPED' and frame) then
+			if(frame._anim and frame._anim['panelTransition']) then
+				local anim = frame._anim['panelTransition']
+				if(anim.onComplete) then
+					anim.onComplete(frame)
+				end
+				frame._anim['panelTransition'] = nil
+			end
+			frame:Hide()
+			frame:SetParent(nil)
 			Settings._panelFrames[p.id] = nil
+			Settings._panelRefresh[p.id] = nil
+			if(Settings._panelBuiltUnitType) then
+				Settings._panelBuiltUnitType[p.id] = nil
+			end
+			if(Settings._activePanelFrame == frame) then
+				Settings._activePanelFrame = nil
+			end
 		end
 	end
 	if(not Settings._mainFrame) then return end

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -321,7 +321,7 @@ local function activatePresetHeaderControls(info)
 		Settings.SetEditingUnitType(value)
 		-- Invalidate and rebuild the current panel — matches the
 		-- behavior of the old in-panel "Configure for" dropdown.
-		Settings._panelFrames[currentId] = nil
+		Settings.TearDownPanel(currentId)
 		Settings.SetActivePanel(currentId)
 	end)
 	unitDD:Show()
@@ -360,7 +360,7 @@ local function activatePresetHeaderControls(info)
 				if(Settings.CopyTo(configKey, target)) then
 					-- Invalidate + refresh so the active panel rebuilds
 					-- against the new config.
-					Settings._panelFrames[info.id] = nil
+					Settings.TearDownPanel(info.id)
 					Settings.RefreshActivePanel()
 					-- Friendly chat confirmation (mirrors dialog output).
 					local targetLabel = target
@@ -405,6 +405,50 @@ Settings._activePanelId  = nil
 Settings._activePanelFrame = nil
 Settings._panelFrames    = {}
 Settings._panelRefresh   = {}
+
+-- ============================================================
+-- Panel teardown helper
+-- ============================================================
+
+--- Release all references to a cached panel frame so Lua can GC it.
+---
+--- Dropping _panelFrames[id] = nil alone only removes the Lua cache
+--- reference — the Frame object stays parented to _contentParent with
+--- all its widgets, textures, and event handlers alive. Repeated
+--- invalidate-rebuild cycles (unit-type switches, copy-to, refresh,
+--- preset changes) leak one orphaned panel frame per cycle. Explicit
+--- Hide + SetParent(nil) releases WoW's frame ownership, and clearing
+--- the various tracking tables ensures no dangling references prevent
+--- collection.
+---
+--- Safe to call with an unknown panelId (no-op if nothing cached).
+--- @param panelId string
+function Settings.TearDownPanel(panelId)
+	local frame = Settings._panelFrames[panelId]
+	if(not frame) then return end
+
+	-- Cancel any in-flight panel transition animation so its onComplete
+	-- callback doesn't keep a reference alive past the teardown.
+	if(frame._anim and frame._anim['panelTransition']) then
+		local anim = frame._anim['panelTransition']
+		if(anim.onComplete) then
+			anim.onComplete(frame)
+		end
+		frame._anim['panelTransition'] = nil
+	end
+
+	frame:Hide()
+	frame:SetParent(nil)
+
+	Settings._panelFrames[panelId] = nil
+	Settings._panelRefresh[panelId] = nil
+	if(Settings._panelBuiltUnitType) then
+		Settings._panelBuiltUnitType[panelId] = nil
+	end
+	if(Settings._activePanelFrame == frame) then
+		Settings._activePanelFrame = nil
+	end
+end
 Settings._sidebarButtons = {}
 Settings._contentParent  = nil
 Settings._headerPanelText = nil
@@ -469,9 +513,7 @@ function Settings.SetActivePanel(panelId)
 		local builtFor = Settings._panelBuiltUnitType and Settings._panelBuiltUnitType[panelId]
 		local current = Settings.GetEditingUnitType()
 		if(builtFor and builtFor ~= current) then
-			Settings._panelFrames[panelId]:Hide()
-			Settings._panelFrames[panelId]:SetParent(nil)
-			Settings._panelFrames[panelId] = nil
+			Settings.TearDownPanel(panelId)
 			Settings._auraPreview = nil
 		end
 	end
@@ -704,33 +746,12 @@ local function reconcileEditingPresetChange()
 	end
 
 	-- Tear down cached preset-scoped panel frames before forgetting them.
-	-- Setting _panelFrames[id] = nil only drops the Lua cache reference;
-	-- the Frame object stays parented to _contentParent with all its
-	-- widgets, textures, and registered event handlers intact. Repeated
-	-- preset switches would orphan one set of panel frames per switch,
-	-- producing steady memory growth across a session. Explicit Hide +
-	-- SetParent(nil) releases WoW's frame ownership and lets GC reclaim
-	-- everything once the last Lua reference is dropped.
+	-- See Settings.TearDownPanel for the full rationale; in short, dropping
+	-- _panelFrames[id] = nil alone leaks the Frame object because WoW keeps
+	-- it parented. TearDownPanel does the full release.
 	for _, p in next, registeredPanels do
-		local frame = Settings._panelFrames[p.id]
-		if(p.section == 'PRESET_SCOPED' and frame) then
-			if(frame._anim and frame._anim['panelTransition']) then
-				local anim = frame._anim['panelTransition']
-				if(anim.onComplete) then
-					anim.onComplete(frame)
-				end
-				frame._anim['panelTransition'] = nil
-			end
-			frame:Hide()
-			frame:SetParent(nil)
-			Settings._panelFrames[p.id] = nil
-			Settings._panelRefresh[p.id] = nil
-			if(Settings._panelBuiltUnitType) then
-				Settings._panelBuiltUnitType[p.id] = nil
-			end
-			if(Settings._activePanelFrame == frame) then
-				Settings._activePanelFrame = nil
-			end
+		if(p.section == 'PRESET_SCOPED') then
+			Settings.TearDownPanel(p.id)
 		end
 	end
 	if(not Settings._mainFrame) then return end
@@ -784,7 +805,7 @@ function Settings.RefreshActivePanel()
 	if(Settings._panelRefresh[activeId]) then
 		Settings._panelRefresh[activeId]()
 	else
-		Settings._panelFrames[activeId] = nil
+		Settings.TearDownPanel(activeId)
 		Settings.SetActivePanel(activeId)
 	end
 end

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -579,16 +579,15 @@ function Settings.SetActivePanel(panelId)
 		Settings._headerPanelText:SetText(panelLabel)
 	end
 
-	-- Defensive sidebar-label resync: ensure the group-frame button's
-	-- displayed label matches the current preset, regardless of whether
-	-- EDITING_PRESET_CHANGED fired cleanly. Covers edge cases where the
-	-- sidebar listener was raced past or the button was re-created.
-	local groupBtn = Settings._sidebarButtons and Settings._sidebarButtons['party']
-	if(groupBtn and groupBtn._label) then
-		local presetInfo = C.PresetInfo[Settings.GetEditingPreset()]
-		if(presetInfo and presetInfo.groupLabel) then
-			groupBtn._label:SetText(presetInfo.groupLabel)
-		end
+	-- Defensive sidebar resync: invoke Sidebar's full preset-scoped
+	-- button refresh so visibility, labels, AND container height land
+	-- consistently regardless of whether EDITING_PRESET_CHANGED fired
+	-- cleanly. Covers the case where the group-frame button stays
+	-- visible + stale-labeled after a rapid preset-switch sequence
+	-- (e.g. Mythic Raid → Raid → Arena → Solo leaving "Raid Frames"
+	-- visible in the sidebar under Solo).
+	if(Settings._syncPresetScopedButtons) then
+		Settings._syncPresetScopedButtons()
 	end
 
 	-- Show/hide and populate the breadcrumb segments + Copy-to control.

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -90,8 +90,13 @@ function Settings.SetEditingPreset(presetName)
 	editingPreset = presetName
 	Settings._editingUnitType = nil
 	F.EventBus:Fire('EDITING_PRESET_CHANGED', presetName)
-	-- Update the sub-header preset indicator live
-	if(Settings._updateHeaderPresetText) then Settings._updateHeaderPresetText() end
+	-- Keep the breadcrumb's preset segment in sync. The EDITING_PRESET_CHANGED
+	-- handler already refreshes the unit-type dropdown; this syncs the
+	-- preset dropdown's displayed value for the same event.
+	local presetDD = Settings._headerPresetDD
+	if(presetDD and presetDD:IsShown()) then
+		presetDD:SetValue(presetName)
+	end
 end
 
 -- ============================================================
@@ -162,16 +167,6 @@ local function unitTypeLabel(unitKey)
 	return unitKey
 end
 
---- Look up the active panel's registration info.
-local function getActivePanelInfo()
-	local id = Settings._activePanelId
-	if(not id) then return nil end
-	for _, p in next, registeredPanels do
-		if(p.id == id) then return p end
-	end
-	return nil
-end
-
 --- Convert a raw unit label to a "Frame"-decorated variant:
 ---   'Player'           → 'Player Frame'
 ---   'Target of Target' → 'Target of Target Frame'
@@ -197,20 +192,81 @@ local function buildHeaderUnitTypeItems()
 	return items
 end
 
---- Populate / show / hide the title-card unit-type dropdown, Copy-to
---- button, and drill-in indicator suffix based on the active panel.
---- Called by SetActivePanel after the panel's unit type has been
---- normalized.
-local function activateAuraHeaderControls(info)
-	local dd        = Settings._headerUnitTypeDD
+--- Build breadcrumb-ready preset items — `{ text, value }` pairs drawn
+--- from the ordered PresetOrder list. Text is the preset name as-is;
+--- the inline dropdown doesn't prefix-decorate preset labels since the
+--- preset segment is leftmost in the breadcrumb.
+local function buildPresetItems()
+	local items = {}
+	for _, presetName in next, C.PresetOrder do
+		if(C.PresetInfo[presetName]) then
+			items[#items + 1] = { text = presetName, value = presetName }
+		end
+	end
+	return items
+end
+
+-- Breadcrumb separator gap. Mirrors the SEP_GAP in MainFrame.lua so
+-- downstream re-anchors match the initial layout spacing.
+local SEP_GAP = 6
+
+--- Re-anchor _headerPanelText's LEFT edge to the right edge of the deepest
+--- upstream visible breadcrumb separator (or directly to the preset DD /
+--- titleCard LEFT when no separators are visible). Called from
+--- activatePresetHeaderControls after upstream segments have been shown
+--- or hidden so the label doesn't float over a hidden anchor slot.
+local function anchorPanelTextAfter(prevFrame)
+	local panelText = Settings._headerPanelText
+	if(not panelText or not prevFrame) then return end
+	panelText:ClearAllPoints()
+	Widgets.SetPoint(panelText, 'LEFT', prevFrame, 'RIGHT', SEP_GAP, 0)
+end
+
+--- Populate / show / hide every breadcrumb segment + the Copy-to control
+--- based on the active panel. Called by SetActivePanel after the panel's
+--- unit type has been normalized.
+---
+--- Preset dropdown shows on every PRESET_SCOPED panel (both frame and
+--- aura subsections). Frame-type dropdown shows on aura panels only.
+--- Indicator label shows only while drilled in (managed separately by
+--- UpdateAuraBreadcrumb).
+local function activatePresetHeaderControls(info)
+	local presetDD  = Settings._headerPresetDD
+	local unitDD    = Settings._headerUnitTypeDD
 	local copy      = Settings._headerCopyToBtn
 	local indic     = Settings._headerIndicatorText
 	local copyDD    = Settings._headerCopyToDD
-	if(not dd or not copy or not indic) then return end
+	local sep1      = Settings._headerSep1
+	local sep2      = Settings._headerSep2
+	local sep3      = Settings._headerSep3
+	if(not presetDD or not unitDD or not copy or not indic) then return end
 
+	-- Sep3 (panel → indicator) hides by default; UpdateAuraBreadcrumb shows
+	-- it only while drilled in. Reset here so panel activation always lands
+	-- on the base page.
+	if(sep3) then sep3:Hide() end
+
+	-- ── Preset segment: show on any PRESET_SCOPED panel ──────────
+	local presetScoped = info and info.section == 'PRESET_SCOPED'
+	if(presetScoped) then
+		presetDD:SetItems(buildPresetItems())
+		presetDD:SetValue(Settings.GetEditingPreset())
+		presetDD:SetOnSelect(function(value)
+			Settings.SetEditingPreset(value)
+		end)
+		presetDD:Show()
+		if(sep1) then sep1:Show() end
+	else
+		if(presetDD.Close) then presetDD:Close() end
+		presetDD:Hide()
+		if(sep1) then sep1:Hide() end
+	end
+
+	-- ── Frame / indicator / copy-to segments: aura pages only ────
 	if(not info or info.subSection ~= 'auras') then
-		if(dd.Close) then dd:Close() end
-		dd:Hide()
+		if(unitDD.Close) then unitDD:Close() end
+		unitDD:Hide()
+		if(sep2) then sep2:Hide() end
 		if(copyDD) then
 			if(copyDD.Close) then copyDD:Close() end
 			copyDD:Hide()
@@ -218,16 +274,31 @@ local function activateAuraHeaderControls(info)
 		copy:Hide()
 		indic:Hide()
 		indic:SetText('')
+		-- Panel text anchors to sep1 on preset-scoped non-aura pages
+		-- (frame pages), or to titleCard LEFT on GLOBAL / FRAME_PRESETS
+		-- panels where even the preset segment is hidden.
+		if(presetScoped and sep1) then
+			anchorPanelTextAfter(sep1)
+		else
+			-- Fallback: restore original left-edge anchor for panels
+			-- with no breadcrumb (Global, Frame Presets, Bottom).
+			local panelText = Settings._headerPanelText
+			if(panelText) then
+				panelText:ClearAllPoints()
+				Widgets.SetPoint(panelText, 'LEFT', panelText:GetParent(), 'LEFT', C.Spacing.normal, 0)
+			end
+		end
 		return
 	end
 
-	-- Populate the inline dropdown with "Player Frame" / "Target Frame" /
-	-- etc. items and point its selection at the current unit type. The
-	-- '/ ' prefix renders in the trigger only, not in the menu rows.
-	dd:SetItems(buildHeaderUnitTypeItems())
-	dd:SetLabelPrefix('/ ')
-	dd:SetValue(Settings.GetEditingUnitType() or getDefaultUnitType())
-	dd:SetOnSelect(function(value)
+	-- Populate the frame-type dropdown. The breadcrumb's '/' separator
+	-- lives in sep2 (positioned just before this segment); the trigger
+	-- itself renders without an internal prefix so the padding around
+	-- the separator is consistent with the rest of the breadcrumb.
+	unitDD:SetItems(buildHeaderUnitTypeItems())
+	unitDD:SetLabelPrefix('')
+	unitDD:SetValue(Settings.GetEditingUnitType() or getDefaultUnitType())
+	unitDD:SetOnSelect(function(value)
 		local currentId = Settings._activePanelId
 		if(not currentId) then return end
 		Settings.SetEditingUnitType(value)
@@ -236,7 +307,12 @@ local function activateAuraHeaderControls(info)
 		Settings._panelFrames[currentId] = nil
 		Settings.SetActivePanel(currentId)
 	end)
-	dd:Show()
+	unitDD:Show()
+	if(sep2) then sep2:Show() end
+
+	-- Panel text anchors after sep2 on aura pages so the breadcrumb
+	-- reads "Preset / Frame / Panel / [Indicator]".
+	if(sep2) then anchorPanelTextAfter(sep2) end
 
 	-- Copy-to: visible only when the panel registered a configKey.
 	local configKey = Settings._auraConfigKeys[info.id]
@@ -288,8 +364,10 @@ local function activateAuraHeaderControls(info)
 		copy:Hide()
 	end
 
-	-- Constrain indicator text width so it truncates before right-side controls.
-	local rightAnchor = (copyDD and copy:IsShown()) and copyDD or Settings._headerPresetText
+	-- Constrain indicator text width so it truncates before the right-side
+	-- Copy-to control. When Copy-to is hidden, fall back to copy (the
+	-- button itself), which is anchored to the titleCard RIGHT.
+	local rightAnchor = (copyDD and copy:IsShown()) and copyDD or copy
 	indic:SetPoint('RIGHT', rightAnchor, 'LEFT', -C.Spacing.normal, 0)
 
 	-- Reset drill-in state — SetActivePanel always lands on the base page.
@@ -297,22 +375,7 @@ local function activateAuraHeaderControls(info)
 	indic:SetText('')
 end
 
-Settings._activateAuraHeaderControls = activateAuraHeaderControls
-
---- Recompute the sub-header accent text ("Editing: Preset") and
---- show/hide it based on the active panel's section.
-local function updateHeaderPresetText()
-	if(not Settings._headerPresetText) then return end
-	local info = getActivePanelInfo()
-	if(not info or info.section ~= 'PRESET_SCOPED') then
-		Settings._headerPresetText:Hide()
-		return
-	end
-	Settings._headerPresetText:SetText('Editing: ' .. Settings.GetEditingPreset())
-	Settings._headerPresetText:Show()
-end
-
-Settings._updateHeaderPresetText = updateHeaderPresetText
+Settings._activatePresetHeaderControls = activatePresetHeaderControls
 
 -- ============================================================
 -- Shared State
@@ -495,18 +558,16 @@ function Settings.SetActivePanel(panelId)
 		end
 	end
 
-	-- Update sub-header text — the breadcrumb is always just the panel
-	-- label now; aura panels get their "/ <Unit> Frame" suffix via the
-	-- title-card inline dropdown, not via text concatenation.
+	-- Panel name segment. Separators are rendered by dedicated font
+	-- strings (sep1/sep2/sep3) so the text itself is just the label;
+	-- activatePresetHeaderControls handles anchoring after the correct
+	-- upstream separator.
 	if(Settings._headerPanelText) then
 		Settings._headerPanelText:SetText(info.label or '')
 	end
 
-	-- Update preset indicator (right side of title card)
-	updateHeaderPresetText()
-
-	-- Show/hide and populate the inline unit dropdown + Copy-to button
-	activateAuraHeaderControls(info)
+	-- Show/hide and populate the breadcrumb segments + Copy-to control.
+	activatePresetHeaderControls(info)
 
 	-- Restore drill-in breadcrumb if the panel re-entered with an active indicator
 	if(Settings._activePanelFrame and Settings._activePanelFrame._editingIndicatorName) then
@@ -529,21 +590,25 @@ end
 --- @param indicatorName string|nil  Optional indicator sub-page name
 function Settings.UpdateAuraBreadcrumb(pageLabel, indicatorName)
 	if(not Settings._headerPanelText) then return end
-	Settings._headerPanelText:SetText(pageLabel)
+	-- Separators are rendered separately — the panel text is just the label.
+	Settings._headerPanelText:SetText(pageLabel or '')
 
 	local indic = Settings._headerIndicatorText
 	local copy  = Settings._headerCopyToBtn
 	local copyDD    = Settings._headerCopyToDD
+	local sep3  = Settings._headerSep3
 	if(indicatorName) then
 		if(indic) then
-			indic:SetText('|cff6688cc>|r  ' .. indicatorName)
+			indic:SetText(indicatorName)
 			indic:Show()
 		end
+		if(sep3) then sep3:Show() end
 	else
 		if(indic) then
 			indic:SetText('')
 			indic:Hide()
 		end
+		if(sep3) then sep3:Hide() end
 		-- Restore Copy-to only if this panel has a configKey registered.
 		local activeId = Settings._activePanelId
 		local configKey = activeId and Settings._auraConfigKeys[activeId]

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -686,6 +686,10 @@ end, 'Settings.HeaderUnitTypeSync')
 -- Invalidate all preset-scoped panels so stale frames are rebuilt
 -- when the user navigates to them.
 F.EventBus:Register('EDITING_PRESET_CHANGED', function()
+	if(Settings._debugPresetTransitions) then
+		print(('|cff66ccff[Framed/redirect]|r handler enter — activeId=%s editingPreset=%s'):format(
+			tostring(Settings._activePanelId), tostring(Settings.GetEditingPreset())))
+	end
 	-- Refresh header dropdown items unconditionally — during zone
 	-- transitions the main frame may not be :IsShown() yet, but the
 	-- items must be correct when it reappears.

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -664,16 +664,44 @@ F.EventBus:Register('EDITING_PRESET_CHANGED', function()
 	if(not Settings._mainFrame) then return end
 	local activeId = Settings._activePanelId
 	if(not activeId) then return end
-	-- Redirect away from preset-specific panels that don't exist under the
-	-- new preset (pinned is absent in Solo). Must run even while settings
-	-- is hidden so that Toggle()'s pre-FadeIn sync doesn't leave a stale
-	-- pinned panel active when the user reopens under Solo.
-	if(activeId == 'pinned') then
-		local preset = Settings.GetEditingPreset()
+
+	-- Redirect away from frame-type panels that don't exist under the new
+	-- preset. Must run even while settings is hidden so that Toggle()'s
+	-- pre-FadeIn sync doesn't leave a stale invalid-panel active when the
+	-- user reopens under a narrower preset.
+	--
+	-- Frame-type panels with preset-dependent validity:
+	--   party   — present only when preset has a groupKey (Party/Raid/Arena/…)
+	--   pinned  — present only when preset has a unitConfigs.pinned block
+	-- Other frame panels (player/target/targettarget/focus/pet/boss) exist
+	-- in every preset and don't need a redirect.
+	--
+	-- Without this, switching from Party → Solo while on the Party Frames
+	-- panel leaves the active panel as `party`, and the subsequent rebuild
+	-- crashes reading `unitConfigs.party.health.*` which doesn't exist in
+	-- Solo. Also leaves a stale summary card visible because the rebuild
+	-- fails before the new content is anchored.
+	local preset = Settings.GetEditingPreset()
+	local presetInfo = preset and C.PresetInfo[preset]
+	if(activeId == 'party') then
+		if(not presetInfo or not presetInfo.groupKey) then
+			activeId = 'player'
+		end
+	elseif(activeId == 'pinned') then
 		if(not preset or not F.Config:Get('presets.' .. preset .. '.unitConfigs.pinned')) then
 			activeId = 'player'
 		end
 	end
+
+	if(activeId ~= Settings._activePanelId) then
+		-- Redirect happened: fully clear the stale active frame so the
+		-- slide-in animation starts from a clean slate rather than the
+		-- partially-rendered previous panel.
+		if(Settings._activePanelFrame) then
+			Settings._activePanelFrame:Hide()
+		end
+	end
+
 	if(Settings._panelRefresh[activeId]) then
 		Settings._panelRefresh[activeId]()
 	else

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -96,21 +96,23 @@ function Settings.SetEditingPreset(presetName)
 		print(('|cff00ccff[Framed/preset]|r SetEditingPreset called: current=%s -> requested=%s'):format(
 			tostring(editingPreset), tostring(presetName)))
 	end
-	if(editingPreset == presetName) then
-		if(Settings._debugPresetTransitions) then
-			print('|cffff6666[Framed/preset]|r early-return (already at requested preset)')
-		end
-		return
-	end
 	editingPreset = presetName
 	Settings._editingUnitType = nil
 	F.EventBus:Fire('EDITING_PRESET_CHANGED', presetName)
 	-- Keep the breadcrumb's preset segment in sync. The EDITING_PRESET_CHANGED
-	-- handler already refreshes the unit-type dropdown; this syncs the
-	-- preset dropdown's displayed value for the same event.
+	-- listeners update the unit-type dropdown and sidebar buttons; this syncs
+	-- the preset dropdown's displayed value for the same transition.
 	local presetDD = Settings._headerPresetDD
 	if(presetDD and presetDD:IsShown()) then
 		presetDD:SetValue(presetName)
+	end
+	-- Complete the framework-side preset transition synchronously instead
+	-- of relying on our own EventBus listener ordering. This keeps the
+	-- active panel, cached preset-scoped frames, and sidebar visibility in
+	-- sync even when the user re-selects the current preset as a recovery
+	-- action (no early-return on same-preset — reconcile runs regardless).
+	if(Settings._reconcileEditingPresetChange) then
+		Settings._reconcileEditingPresetChange()
 	end
 end
 
@@ -594,18 +596,11 @@ function Settings.SetActivePanel(panelId)
 		Settings._headerPanelText:SetText(panelLabel)
 	end
 
-	-- Defensive sidebar resync: invoke Sidebar's full preset-scoped
-	-- button refresh so visibility, labels, AND container height land
-	-- consistently regardless of whether EDITING_PRESET_CHANGED fired
-	-- cleanly. Covers the case where the group-frame button stays
-	-- visible + stale-labeled after a rapid preset-switch sequence
-	-- (e.g. Mythic Raid → Raid → Arena → Solo leaving "Raid Frames"
-	-- visible in the sidebar under Solo).
-	if(Settings._syncPresetScopedButtons) then
-		Settings._syncPresetScopedButtons()
-	end
-
 	-- Show/hide and populate the breadcrumb segments + Copy-to control.
+	-- Sidebar preset-scoped button sync happens via the Sidebar's
+	-- EDITING_PRESET_CHANGED listener, which runs as part of the
+	-- synchronous reconcile in SetEditingPreset — no need for a defensive
+	-- call here.
 	activatePresetHeaderControls(info)
 
 	-- Restore drill-in breadcrumb if the panel re-entered with an active indicator
@@ -682,12 +677,21 @@ F.EventBus:Register('EDITING_UNIT_TYPE_CHANGED', function(newType)
 	dd:SetValue(newType or Settings.GetEditingUnitType() or 'player')
 end, 'Settings.HeaderUnitTypeSync')
 
--- Refresh active panel when the editing preset changes.
--- Invalidate all preset-scoped panels so stale frames are rebuilt
--- when the user navigates to them.
-F.EventBus:Register('EDITING_PRESET_CHANGED', function()
+--- Refresh active panel after the editing preset changes.
+--- Invalidate all preset-scoped panels so stale frames are rebuilt
+--- when the user navigates to them.
+---
+--- Called synchronously from SetEditingPreset rather than via an
+--- EventBus listener. This guarantees framework-side state
+--- (activePanelId, panel cache, sidebar visibility) is fully
+--- reconciled before SetEditingPreset returns, eliminating the
+--- listener-order sensitivity that caused half-synced UI states.
+--- Other listeners (sidebar sync, FramePresets row highlight, aura
+--- preview rebuild) still fire on the EDITING_PRESET_CHANGED event
+--- normally.
+local function reconcileEditingPresetChange()
 	if(Settings._debugPresetTransitions) then
-		print(('|cff66ccff[Framed/redirect]|r handler enter — activeId=%s editingPreset=%s'):format(
+		print(('|cff66ccff[Framed/reconcile]|r enter — activeId=%s editingPreset=%s'):format(
 			tostring(Settings._activePanelId), tostring(Settings.GetEditingPreset())))
 	end
 	-- Refresh header dropdown items unconditionally — during zone
@@ -743,12 +747,6 @@ F.EventBus:Register('EDITING_PRESET_CHANGED', function()
 	--   pinned  — present only when preset has a unitConfigs.pinned block
 	-- Other frame panels (player/target/targettarget/focus/pet/boss) exist
 	-- in every preset and don't need a redirect.
-	--
-	-- Without this, switching from Party → Solo while on the Party Frames
-	-- panel leaves the active panel as `party`, and the subsequent rebuild
-	-- crashes reading `unitConfigs.party.health.*` which doesn't exist in
-	-- Solo. Also leaves a stale summary card visible because the rebuild
-	-- fails before the new content is anchored.
 	local preset = Settings.GetEditingPreset()
 	local presetInfo = preset and C.PresetInfo[preset]
 	if(activeId == 'party') then
@@ -775,7 +773,9 @@ F.EventBus:Register('EDITING_PRESET_CHANGED', function()
 	else
 		Settings.SetActivePanel(activeId)
 	end
-end, 'Settings.PanelRefresh')
+end
+
+Settings._reconcileEditingPresetChange = reconcileEditingPresetChange
 
 --- Call the active panel's Refresh callback, if it has one.
 function Settings.RefreshActivePanel()

--- a/Settings/MainFrame.lua
+++ b/Settings/MainFrame.lua
@@ -239,43 +239,85 @@ function Settings.CreateMainFrame()
 	-- Faded accent bar underlining the panel title, separating header from content
 	Widgets.CreateAccentBar(titleCard, 'bottom')
 
-	Settings._headerPanelText = Widgets.CreateFontString(titleCard, C.Font.sizeNormal, C.Colors.textActive)
-	Settings._headerPanelText:ClearAllPoints()
-	Widgets.SetPoint(Settings._headerPanelText, 'LEFT', titleCard, 'LEFT', C.Spacing.normal, 0)
-	Settings._headerPanelText:SetText('')
+	-- ── Breadcrumb title ───────────────────────────────────────
+	-- Left-to-right, preset-scoped panels render as:
+	--   Frame pages: [Preset ▾] / [Panel name]
+	--   Aura pages:  [Preset ▾] / [Frame ▾] / [Panel name] / [Indicator name]
+	-- Framework manages per-page visibility + left-anchor chaining via
+	-- activatePresetHeaderControls.
+	--
+	-- Separators are dedicated muted-color FontStrings rather than prefixes
+	-- embedded inside segment text. This gives them independent padding
+	-- (so they don't collide with the dropdown chevrons) and a distinct
+	-- visual weight (textSecondary vs textActive) so separators read as
+	-- punctuation rather than content.
 
-	-- ── Inline unit-type dropdown for aura panels ───────────────
-	-- Renders as "/ Player Frame ▾" immediately after the breadcrumb.
-	-- Hidden by default; Framework toggles visibility per panel.
+	local SEP_GAP    = 6  -- padding between a segment and its outgoing separator
+	local SEP_TEXT   = '/'
+
+	-- Segment 1: Preset dropdown. Leftmost, shown on every PRESET_SCOPED
+	-- panel, hidden elsewhere.
+	Settings._headerPresetDD = Widgets.CreateInlineDropdown(titleCard)
+	Settings._headerPresetDD:ClearAllPoints()
+	Widgets.SetPoint(Settings._headerPresetDD, 'LEFT', titleCard, 'LEFT', C.Spacing.normal, 0)
+	Settings._headerPresetDD:Hide()
+
+	-- Separator 1: between preset and the next visible segment.
+	Settings._headerSep1 = Widgets.CreateFontString(titleCard, C.Font.sizeNormal, C.Colors.textSecondary)
+	Settings._headerSep1:ClearAllPoints()
+	Widgets.SetPoint(Settings._headerSep1, 'LEFT', Settings._headerPresetDD, 'RIGHT', SEP_GAP, 0)
+	Settings._headerSep1:SetText(SEP_TEXT)
+	Settings._headerSep1:Hide()
+
+	-- Segment 2: Frame-type (unit) dropdown. Aura pages only — selects
+	-- which frame's config is being edited within the active preset.
+	-- Frame pages hide this; the panel name itself is the frame type.
 	Settings._headerUnitTypeDD = Widgets.CreateInlineDropdown(titleCard)
 	Settings._headerUnitTypeDD:ClearAllPoints()
-	Widgets.SetPoint(Settings._headerUnitTypeDD, 'LEFT', Settings._headerPanelText, 'RIGHT', 4, 0)
+	Widgets.SetPoint(Settings._headerUnitTypeDD, 'LEFT', Settings._headerSep1, 'RIGHT', SEP_GAP, 0)
 	Settings._headerUnitTypeDD:Hide()
 
-	-- ── Drill-in breadcrumb suffix (e.g. "  >  Major Cooldowns") ──
-	-- Shown only while editing a specific indicator inside an aura panel.
+	-- Separator 2: between frame dropdown and panel name (aura pages).
+	Settings._headerSep2 = Widgets.CreateFontString(titleCard, C.Font.sizeNormal, C.Colors.textSecondary)
+	Settings._headerSep2:ClearAllPoints()
+	Widgets.SetPoint(Settings._headerSep2, 'LEFT', Settings._headerUnitTypeDD, 'RIGHT', SEP_GAP, 0)
+	Settings._headerSep2:SetText(SEP_TEXT)
+	Settings._headerSep2:Hide()
+
+	-- Segment 3: Panel name ("Buffs", "Player", etc.). Plain label, no
+	-- click behaviour — navigation lives in the sidebar.
+	-- activatePresetHeaderControls re-anchors this to whichever separator
+	-- is currently the deepest-visible upstream one (sep2 on aura pages,
+	-- sep1 on frame pages, titleCard LEFT on non-preset-scoped panels).
+	Settings._headerPanelText = Widgets.CreateFontString(titleCard, C.Font.sizeNormal, C.Colors.textActive)
+	Settings._headerPanelText:ClearAllPoints()
+	Widgets.SetPoint(Settings._headerPanelText, 'LEFT', Settings._headerSep2, 'RIGHT', SEP_GAP, 0)
+	Settings._headerPanelText:SetText('')
+
+	-- Separator 3: between panel name and indicator drill-in.
+	Settings._headerSep3 = Widgets.CreateFontString(titleCard, C.Font.sizeNormal, C.Colors.textSecondary)
+	Settings._headerSep3:ClearAllPoints()
+	Widgets.SetPoint(Settings._headerSep3, 'LEFT', Settings._headerPanelText, 'RIGHT', SEP_GAP, 0)
+	Settings._headerSep3:SetText(SEP_TEXT)
+	Settings._headerSep3:Hide()
+
+	-- Segment 4: Indicator drill-in label. Aura pages only, populated by
+	-- Settings.UpdateAuraBreadcrumb when a panel drills into an indicator.
 	Settings._headerIndicatorText = Widgets.CreateFontString(titleCard, C.Font.sizeNormal, C.Colors.textActive)
 	Settings._headerIndicatorText:ClearAllPoints()
-	Widgets.SetPoint(Settings._headerIndicatorText, 'LEFT', Settings._headerUnitTypeDD, 'RIGHT', 8, 0)
+	Widgets.SetPoint(Settings._headerIndicatorText, 'LEFT', Settings._headerSep3, 'RIGHT', SEP_GAP, 0)
 	Settings._headerIndicatorText:SetText('')
 	Settings._headerIndicatorText:SetWordWrap(false)
 	Settings._headerIndicatorText:SetJustifyH('LEFT')
 	Settings._headerIndicatorText:Hide()
 
-	Settings._headerPresetText = Widgets.CreateFontString(titleCard, C.Font.sizeNormal, C.Colors.accent)
-	Settings._headerPresetText:ClearAllPoints()
-	Widgets.SetPoint(Settings._headerPresetText, 'RIGHT', titleCard, 'RIGHT', -C.Spacing.normal, 0)
-	Settings._headerPresetText:SetText('')
-	Settings._headerPresetText:Hide()
-
-	-- ── Copy-to control (label + dropdown + Copy button) ───────
-	-- Right-aligned stack that sits immediately left of _headerPresetText.
-	-- Visible only on aura panels that registered a configKey.
-	-- Framework.activateAuraHeaderControls populates the dropdown and
-	-- wires the button per panel.
+	-- ── Copy-to control (dropdown + Copy button) ───────────────
+	-- Right-aligned stack. Visible only on aura panels that registered
+	-- a configKey via BuildAuraUnitTypeRow. Framework wires the button
+	-- target list per-panel.
 	Settings._headerCopyToBtn = Widgets.CreateButton(titleCard, 'Copy To', 'accent', 64, 20)
 	Settings._headerCopyToBtn:ClearAllPoints()
-	Widgets.SetPoint(Settings._headerCopyToBtn, 'RIGHT', Settings._headerPresetText, 'LEFT', -C.Spacing.normal, 0)
+	Widgets.SetPoint(Settings._headerCopyToBtn, 'RIGHT', titleCard, 'RIGHT', -C.Spacing.normal, 0)
 	Settings._headerCopyToBtn:Hide()
 
 	Settings._headerCopyToDD = Widgets.CreateDropdown(titleCard, 84)

--- a/Settings/Panels/ClickCasting.lua
+++ b/Settings/Panels/ClickCasting.lua
@@ -661,7 +661,14 @@ F.Settings.RegisterPanel({
 
 F.EventBus:Register('SPEC_CHANGED', function()
 	if(not F.Settings._panelFrames) then return end
-	F.Settings._panelFrames['clickcasting'] = nil
+	-- Full teardown to release the old panel frame's widgets + event hooks
+	-- so GC can reclaim them; dropping the cache key alone leaks the
+	-- orphaned frame.
+	if(F.Settings.TearDownPanel) then
+		F.Settings.TearDownPanel('clickcasting')
+	else
+		F.Settings._panelFrames['clickcasting'] = nil
+	end
 	if(F.Settings._activePanelId == 'clickcasting') then
 		F.Settings.SetActivePanel('clickcasting')
 	end

--- a/Settings/Panels/FramePresets.lua
+++ b/Settings/Panels/FramePresets.lua
@@ -107,6 +107,40 @@ local function PresetsCard(parent, width)
 			Widgets.SetBackdropHighlight(row, false)
 		end)
 
+		-- Active-preset styling: mirrors the Buffs indicator-list
+		-- "selected row" treatment — 2px accent left bar + 25% accent
+		-- tinted background fill. Shown only while this row is the
+		-- editing preset; toggled via row:__setSelected(bool).
+
+		-- Accent left bar (2px)
+		local selectedBar = row:CreateTexture(nil, 'OVERLAY')
+		selectedBar:SetTexture(F.Media.GetPlainTexture())
+		selectedBar:SetVertexColor(C.Colors.accent[1], C.Colors.accent[2], C.Colors.accent[3], 1)
+		selectedBar:SetPoint('TOPLEFT',    row, 'TOPLEFT',    0, 0)
+		selectedBar:SetPoint('BOTTOMLEFT', row, 'BOTTOMLEFT', 0, 0)
+		selectedBar:SetWidth(2)
+		selectedBar:Hide()
+		row.__selectedBar = selectedBar
+
+		-- Solid lighter tint across the row body (offset 2px to clear the bar)
+		local selectedBg = row:CreateTexture(nil, 'BORDER')
+		selectedBg:SetTexture(F.Media.GetPlainTexture())
+		selectedBg:SetVertexColor(C.Colors.accent[1], C.Colors.accent[2], C.Colors.accent[3], 0.25)
+		selectedBg:SetPoint('TOPLEFT',     row, 'TOPLEFT',     2, 0)
+		selectedBg:SetPoint('BOTTOMRIGHT', row, 'BOTTOMRIGHT', 0, 0)
+		selectedBg:Hide()
+		row.__selectedBg = selectedBg
+
+		function row:__setSelected(selected)
+			if(selected) then
+				self.__selectedBar:Show()
+				self.__selectedBg:Show()
+			else
+				self.__selectedBar:Hide()
+				self.__selectedBg:Hide()
+			end
+		end
+
 		row.__nameFS     = nameFS
 		row.__tagFS      = tagFS
 		row.__selectBtn  = selectBtn
@@ -121,9 +155,7 @@ local function PresetsCard(parent, width)
 		local row = buildPresetRow(inner, name, cardY)
 		presetRowPool[#presetRowPool + 1] = row
 
-		if(name == editingPreset) then
-			Widgets.ApplyBackdrop(row, C.Colors.panel, C.Colors.accent)
-		end
+		row:__setSelected(name == editingPreset)
 
 		cardY = cardY - ROW_H - 1
 	end
@@ -208,11 +240,7 @@ local function PresetsCard(parent, width)
 		F.EventBus:Register('EDITING_PRESET_CHANGED', function()
 			local editing = F.Settings.GetEditingPreset()
 			for _, row in next, presetRowPool do
-				if(row.__presetName == editing) then
-					Widgets.ApplyBackdrop(row, C.Colors.panel, C.Colors.accent)
-				else
-					Widgets.ApplyBackdrop(row, C.Colors.panel, C.Colors.border)
-				end
+				row:__setSelected(row.__presetName == editing)
 				row.__tagFS:SetText(getPresetTag(row.__presetName))
 			end
 			updateResetVisibility()

--- a/Settings/Panels/FramePresets.lua
+++ b/Settings/Panels/FramePresets.lua
@@ -239,8 +239,17 @@ local function PresetsCard(parent, width)
 	if(F.EventBus) then
 		F.EventBus:Register('EDITING_PRESET_CHANGED', function()
 			local editing = F.Settings.GetEditingPreset()
+			if(F.Settings._debugPresetTransitions) then
+				print(('|cffffcc00[Framed/presets-list]|r listener fired — editing=%s, rows=%d'):format(
+					tostring(editing), #presetRowPool))
+			end
 			for _, row in next, presetRowPool do
-				row:__setSelected(row.__presetName == editing)
+				local isActive = row.__presetName == editing
+				if(F.Settings._debugPresetTransitions) then
+					print(('  row %s -> setSelected(%s)'):format(
+						tostring(row.__presetName), tostring(isActive)))
+				end
+				row:__setSelected(isActive)
 				row.__tagFS:SetText(getPresetTag(row.__presetName))
 			end
 			updateResetVisibility()

--- a/Settings/Panels/PrivateAuras.lua
+++ b/Settings/Panels/PrivateAuras.lua
@@ -83,6 +83,14 @@ local function buildDisplayCard(parent, width, get, set)
 	sizeSlider:SetAfterValueChanged(function(v) set('iconSize', v) end)
 	cy = placeWidget(sizeSlider, inner, cy, SLIDER_H)
 
+	-- Duration Text Scale. Blizzard's Duration FontString uses a fixed FontObject
+	-- with no anchor-level size override; scaling the anchor's parent is the only
+	-- lever. Icon size is preserved independently via compensating iconInfo.
+	local durSlider = Widgets.CreateSlider(inner, 'Duration Text Scale', widgetW, 0.5, 1.5, 0.05)
+	durSlider:SetValue(get('durationScale') or 1)
+	durSlider:SetAfterValueChanged(function(v) set('durationScale', v) end)
+	cy = placeWidget(durSlider, inner, cy, SLIDER_H)
+
 	-- Max Displayed
 	local maxSlider = Widgets.CreateSlider(inner, 'Max Displayed', widgetW, 1, 5, 1)
 	maxSlider:SetValue(get('maxDisplayed') or 3)

--- a/Settings/Sidebar.lua
+++ b/Settings/Sidebar.lua
@@ -630,12 +630,31 @@ local function buildSidebarContent(sidebar, contentParent)
 		syncPresetScopedButtons()
 	end, 'Sidebar')
 
-	-- ── Hide defensives/externals while the Pet page is active ──
-	-- Matches the preset-change animation: toggle visibility, reposition
-	-- visible children to close gaps, then animate the container height.
+	-- ── Hide defensives/externals when pet is the editing scope ──
+	--
+	-- External defensives and self-cast defensives don't apply to pets,
+	-- so those aura panels hide when:
+	--   (a) the Pet frame panel is the active page, or
+	--   (b) the editing unit type is 'pet' (via the aura page's
+	--       Configure-for dropdown).
+	--
+	-- Fires on both ACTIVE_PANEL_CHANGED and EDITING_UNIT_TYPE_CHANGED so
+	-- the visibility stays correct whether the user navigates into pet
+	-- or picks pet in the dropdown. If the user is currently ON one of
+	-- the hidden panels when pet becomes the scope, they get redirected
+	-- to Buffs so they don't stare at a hidden-but-active panel.
 	local PANELS_HIDDEN_ON_PET = { externals = true, defensives = true }
-	F.EventBus:Register('ACTIVE_PANEL_CHANGED', function(activePanelId)
-		local shouldHide = (activePanelId == 'pet')
+
+	local function syncPetHiddenAuraPanels()
+		local activeId = Settings._activePanelId
+		local unitType = Settings.GetEditingUnitType and Settings.GetEditingUnitType()
+		local shouldHide = (activeId == 'pet') or (unitType == 'pet')
+
+		-- Redirect off a now-hidden panel before toggling button visibility.
+		if(shouldHide and activeId and PANELS_HIDDEN_ON_PET[activeId]) then
+			Settings.SetActivePanel('buffs')
+		end
+
 		local changed = false
 		for panelId, btn in next, hiddenAuraBtns do
 			if(PANELS_HIDDEN_ON_PET[panelId]) then
@@ -667,7 +686,10 @@ local function buildSidebarContent(sidebar, contentParent)
 		if(container._recalc) then
 			container._recalc(true)
 		end
-	end, 'Sidebar.PanelChanged')
+	end
+
+	F.EventBus:Register('ACTIVE_PANEL_CHANGED', syncPetHiddenAuraPanels, 'Sidebar.PanelChanged')
+	F.EventBus:Register('EDITING_UNIT_TYPE_CHANGED', syncPetHiddenAuraPanels, 'Sidebar.UnitTypeChanged')
 
 	-- Deferred highlight fix — button widths aren't final until first layout
 	C_Timer.After(0, function()

--- a/Settings/Sidebar.lua
+++ b/Settings/Sidebar.lua
@@ -582,18 +582,30 @@ local function buildSidebarContent(sidebar, contentParent)
 		end
 	end
 
-	-- ── EDITING_PRESET_CHANGED listener ──────────────────────
-	F.EventBus:Register('EDITING_PRESET_CHANGED', function(presetName)
+	-- Preset-scoped sidebar button visibility + labels. Pulls current
+	-- state from the editing preset and applies it to the group-frame and
+	-- pinned buttons. Exposed via Settings._syncPresetScopedButtons so
+	-- Framework can call it as a belt-and-suspenders resync on panel
+	-- activation, not solely relying on EDITING_PRESET_CHANGED firing.
+	--
+	-- Returns `true` if any button visibility changed so callers can
+	-- decide whether to recalc the container height.
+	local function syncPresetScopedButtons()
 		local changed = false
 		if(groupFrameBtn) then
 			local groupLabel = getGroupFrameLabel()
 			if(groupLabel) then
-				groupFrameBtn:Show()
+				if(not groupFrameBtn:IsShown()) then
+					groupFrameBtn:Show()
+					changed = true
+				end
 				groupFrameBtn._label:SetText(groupLabel)
 			else
-				groupFrameBtn:Hide()
+				if(groupFrameBtn:IsShown()) then
+					groupFrameBtn:Hide()
+					changed = true
+				end
 			end
-			changed = true
 		end
 		if(pinnedFrameBtn) then
 			local shouldShow = hasPinnedConfig()
@@ -605,10 +617,17 @@ local function buildSidebarContent(sidebar, contentParent)
 				changed = true
 			end
 		end
-		-- Recalc FRAMES container height since button visibility changed
 		if(changed and sidebar._framesContainer and sidebar._framesContainer._recalc) then
 			sidebar._framesContainer._recalc(true)
 		end
+		return changed
+	end
+
+	Settings._syncPresetScopedButtons = syncPresetScopedButtons
+
+	-- ── EDITING_PRESET_CHANGED listener ──────────────────────
+	F.EventBus:Register('EDITING_PRESET_CHANGED', function(presetName)
+		syncPresetScopedButtons()
 	end, 'Sidebar')
 
 	-- ── Hide defensives/externals while the Pet page is active ──

--- a/Widgets/SpellList.lua
+++ b/Widgets/SpellList.lua
@@ -505,7 +505,7 @@ end
 -- SpellInput — compact spell ID entry with debounced live preview
 
 local PREVIEW_ICON_SIZE = 16
-local INPUT_WIDTH       = 170
+local INPUT_MIN_WIDTH   = 80   -- narrowest usable edit box (fits a 7-digit spell ID)
 local ADD_BTN_WIDTH     = 60
 local INPUT_ROW_HEIGHT  = 24
 local PREVIEW_HEIGHT    = 20
@@ -513,10 +513,15 @@ local DEBOUNCE_DELAY    = 0.3
 
 --- Create a spell ID input widget with live preview.
 --- @param parent Frame  Parent frame
---- @param width  number Total logical width
+--- @param width  number Total logical width — edit box + gap + Add button fit within this
 --- @return Frame input
 function Widgets.CreateSpellInput(parent, width)
 	local totalHeight = INPUT_ROW_HEIGHT + C.Spacing.tight + PREVIEW_HEIGHT
+
+	-- Edit box consumes whatever's left after the fixed-width Add button
+	-- + gap. At narrow settings widths this keeps the Add button inside
+	-- the container instead of clipping its right edge.
+	local inputWidth = math.max(INPUT_MIN_WIDTH, width - ADD_BTN_WIDTH - C.Spacing.base)
 
 	local container = CreateFrame('Frame', nil, parent)
 	Widgets.SetSize(container, width, totalHeight)
@@ -526,7 +531,7 @@ function Widgets.CreateSpellInput(parent, width)
 	container._onAdd      = nil
 	container._debounce   = nil
 
-	local editBox = Widgets.CreateEditBox(container, nil, INPUT_WIDTH, INPUT_ROW_HEIGHT, 'number')
+	local editBox = Widgets.CreateEditBox(container, nil, inputWidth, INPUT_ROW_HEIGHT, 'number')
 	editBox:SetPoint('TOPLEFT', container, 'TOPLEFT', 0, 0)
 	editBox:SetPlaceholder('Spell ID...')
 	container._editBox = editBox
@@ -537,7 +542,7 @@ function Widgets.CreateSpellInput(parent, width)
 
 	local preview = CreateFrame('Frame', nil, container, 'BackdropTemplate')
 	preview:SetPoint('TOPLEFT', container, 'TOPLEFT', 0, -(INPUT_ROW_HEIGHT + C.Spacing.tight))
-	preview:SetWidth(INPUT_WIDTH)
+	preview:SetWidth(inputWidth)
 	preview:SetHeight(PREVIEW_HEIGHT)
 	local pvBg = C.Colors.widget
 	preview:SetBackdrop({


### PR DESCRIPTION
## Summary

Settings overhaul: breadcrumb title card with preset + frame-type dropdowns, performance fixes for MissingBuffs glow, listener-error isolation, and a raft of preset-switch reliability + memory fixes.

## Highlights

### Perf — #178 resolved
- **Default glow Pixel → Proc** on MissingBuffs across all presets. PixelGlow's per-frame Lua OnUpdate was dominating LFR CPU (~1.14 ms/s per active glow × 25+ frames). Proc uses engine-driven AnimationGroup — zero Lua cost. Measured AddonProfiler impact: Peak 250.9ms → 26.7ms, Over-10ms spikes 47× → 1×, Boss Avg −10%. Pixel/Shine options now annotated `(high CPU)` in the dropdown.
- **MemDiag now tracks ms alongside KB**, with per-μs call attribution. Rewalk cost cut ~99% via cached frame set.

### Settings UI — breadcrumb title card
- Replaced right-side `Editing: <preset>` label with a left-side breadcrumb: `[Preset ▾] / [Frame ▾] / [Panel] / [Indicator]`. Preset dropdown is new; frame-type dropdown was the existing one on aura pages, now also present structurally on frame pages.
- Active-preset row on Frame Presets panel uses the same accent-bar + tinted-fill treatment as the active-indicator row on Buffs/Debuffs lists.
- Muted-color `/` separators as dedicated font strings (instead of embedded prefixes) so chevrons don't crowd.

### Preset-switch reliability
- **Transactional reconcile**: `SetEditingPreset` now calls the framework's own reconciliation synchronously instead of relying on EventBus listener ordering. Half-synced states (dropdown says Solo, Frame Presets says Mythic Raid) are eliminated.
- **Same-preset re-selection is a recovery action** — the early-return was dropped so clicking the current preset now re-runs reconcile.
- **Invalid frame-type panel redirect**: switching Raid → Solo while on Raid Frames auto-redirects to Player (previously crashed reading Solo's non-existent raid config).
- **Group-frame sidebar button** visibility + label stays in sync with the current preset (hides under Solo, shows correct `Raid Frames` / `Arena Frames` / etc. label).
- **Pet-scope aura editing unblocked**: explicit dropdown selection of Pet is now respected. Defensives/Externals correctly hide when pet is the editing scope (via unit-type OR active panel).

### Core robustness
- **EventBus listener isolation** (`Core/EventBus.lua`): each callback runs inside `pcall`, errors route through `geterrorhandler()`. Prevents a throw in one listener from silently breaking the cascade — which was the root cause of "panels freeze on resize" and silent preset-change handlers.

### Memory
- **Shared `Settings.TearDownPanel` helper** now releases cached panel frames properly (Hide + SetParent(nil) + tracking-table cleanup). Seven invalidate sites routed through it. Previously, each invalidate-rebuild cycle (unit-type switch, copy-to, refresh, preset change, spec change) leaked one orphaned frame per cycle. Verified stable memory across session-long repeated switches.

### Dispellable (#163 resolved separately but part of this PR)
- GRADIENT_HALF overlay height no longer baked once at first use — TOP+BOTTOM anchors keep the texture bounded inside the parent.

### Misc
- SpellInput edit-box shrinks to container width so the Add button stops clipping on narrow settings.
- PrivateAuras gets a `durationScale` knob to tame Blizzard's oversized duration text.

## Commit log

```
fc5b1dc chore(settings): disable preset-transition debug prints by default
cdcc839 fix(sidebar): hide defensives/externals when pet is the editing scope
bcee96c fix(settings): allow pet-scope aura editing
5d249be fix(settings): shared TearDownPanel helper for full frame release
b2cbece refactor(settings): transactional preset-change reconcile
3a23089 fix(eventbus): isolate listener errors so one throw does not halt cascade
77ab263 fix(settings): release panel frames on preset-change invalidation
8aed0cd debug(settings): log redirect handler entry for preset-change debugging
dd38ccd debug(presets): log FramePresets listener fires + setSelected calls
0cd67d5 debug(settings): log SetEditingPreset calls + early-returns
d5cdcba fix(settings): full preset-scoped sidebar resync on panel activation
9f0c3de fix(settings): resync group-frame label on panel/preset change
ab42d7a fix(settings): redirect stale frame panels on cross-preset switch
c33cea1 fix(settings): guard lossCustomColor read against missing config key
42beb5f feat(privateauras): add durationScale knob to reduce Blizzard's oversized duration text
fe5b49c fix(widgets): SpellInput edit box shrinks to fit container width
fe951d6 feat(presets): active-preset row uses accent bar + tinted fill
bad162d refactor(settings): breadcrumb title card with preset dropdown
f097314 feat(missingbuffs): default glow Proc, annotate high-CPU options (#178)
3fa51c3 perf(memdiag): add ms tracking, eliminate rewalk tree traversal
```

Debug prints are gated behind `Settings._debugPresetTransitions = false` so no chat noise in normal use; flag can be flipped if something similar surfaces again.

## Test plan

- [x] LFR pull — verify glow change holds (AddonProfiler Boss Avg around 1.1 ms vs prior 1.25, spikes <10ms)
- [x] Preset switching via breadcrumb dropdown: desync gone, state stays consistent across Frame Presets / sidebar / breadcrumb
- [x] Rapid preset switch sequence (Mythic Raid → Arena → Raid → Solo): no crashes, no sticky sidebar buttons, redirects cleanly off invalid panels
- [x] Memory stable across session-long panel navigation (Framed memory should plateau, not climb)
- [x] Pet aura editing works on Buffs/Debuffs/Dispels/MissingBuffs/TargetedSpells/PrivateAuras
- [x] Defensives/Externals hidden when pet is editing scope (via dropdown or frame nav), restored when leaving pet scope
- [x] Settings window resize reflows all cards across all panels (not just some)