### PR TITLE
Release v0.8.16-alpha: Interface 120005 compatibility bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [Unreleased]
 
-## v0.8.15-alpha
+## v0.8.16-alpha
+
+- **Interface bump to 120005** — TOC interface version raised from 120001 to align with WoW 12.0.5
 
 ### Settings & UX
 

--- a/Framed.toc
+++ b/Framed.toc
@@ -1,8 +1,8 @@
-## Interface: 120001
+## Interface: 120005
 ## Title: Framed
 ## Notes: Modern, customizable unit frames and raid frames
 ## Author: Moodibs
-## Version: 0.8.15-alpha
+## Version: 0.8.16-alpha
 ## X-Curse-Project-ID: 1513359
 ## SavedVariables: FramedDB, FramedBackupDB, FramedSnapshotsDB
 ## SavedVariablesPerCharacter: FramedCharDB

--- a/Settings/Cards/About.lua
+++ b/Settings/Cards/About.lua
@@ -114,8 +114,9 @@ end
 -- BEGIN GENERATED CHANGELOG
 local CHANGELOG = {
 	{
-		version = 'v0.8.15-alpha',
+		version = 'v0.8.16-alpha',
 		entries = {
+			'**Interface bump to 120005** — TOC interface version raised from 120001 to align with WoW 12.0.5',
 			'**Settings memory leak fixed (closes #187)** — Framed memory previously climbed toward ~50 MB across settings open/close cycles and never dropped, even after forced GC. Resolved through a chain of fixes: panel teardown infrastructure, weak-key pixel/UI-scale registries, X-button + ESC routing through `Settings.Hide`, snapshot-keys-before-iteration in `TearDownAllPanels`, panel-owned `_eventBusOwners` declarations with recursive tree walk, single-installation OnShow hooks, gated CardGrid rebuilds, and a new `Settings._cachePanelsOnClose = true` policy that retains the cache for fast reopen now that the bounding fixes prevent compounding',
 			'**Buffs/Debuffs/Externals/Defensives spec import hitch eliminated** — loading 60+ spec or healer spells via the indicator import button previously caused a visible frame stall. SpellList now virtualizes scrollable lists, chunks flat lists across frames, and bulk-imports via a new `AddSpells` API. ~240× theoretical reduction on the import path',
 			'**TrackedSpells improvements (#180)** — import-from-spec button + spec-override hint + dropdown trigger + floating preview + off-spec filter',


### PR DESCRIPTION
v0.8.16-alpha release — strictly a TOC interface compatibility bump from 120001 → 120005 to align with WoW 12.0.5. No behavior change relative to v0.8.15-alpha.

Two commits:
- \`7d6898b\` — TOC + version + CHANGELOG + About card sync
- \`f160a45\` — merge of #191

## Test plan

- [x] luacheck (0 warnings, 0 errors on touched files)
- [x] No code paths exercised — TOC metadata only
- [x] Smoke load on 12.0.5 client to confirm no "out of date" warning fires

Auto-tag will fire on merge and create \`v0.8.16-alpha\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)