### PR TITLE
Promote v0.8.17-alpha: secret-mode regressions (Externals + Icon)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## v0.8.17-alpha
+
+### Bug fixes
+
+- **Externals: Symbiotic Relationship leak in M+** — the RAID secret-aura fallback admitted Symbiotic Relationship in secret-active content because it carries the broad `RAID` classification despite being a passive bond rather than a combat-relevant external. Switched the fallback to Blizzard's tighter `RAID_IN_COMBAT` curation, which excludes passive bonds while still admitting Power Infusion and similar raid-important buffs
+- **Icon: secret-safe DurationObject zero check** — `DurationObject:IsZero()` returns a secret boolean for classified combat auras (e.g. Ironbark on player in M+); the Lua test `not durationObj:IsZero()` then crashed mid-`SetSpell`, halting before the icon was rendered. Affected auras silently disappeared in secret content in addition to spamming the error frame. Wrapped the zero check in a helper that falls through to the C-level timer consumers when `IsZero` is secret
+
 ## v0.8.16-alpha
 
 - **Interface bump to 120005** — TOC interface version raised from 120001 to align with WoW 12.0.5

--- a/Elements/Auras/Externals.lua
+++ b/Elements/Auras/Externals.lua
@@ -111,13 +111,13 @@ local function Update(self, event, unit, updateInfo)
 				show = true
 			end
 
-			-- Step 3: RAID fallback — only for secret auras (combat) where
-			-- spell-level classification isn't available. Catches Power Infusion
-			-- and similar raid-important buffs. Too broad out of combat (catches
-			-- basic HoTs like Rejuvenation). Exclude BIG_DEFENSIVE.
+			-- Step 3: RAID_IN_COMBAT fallback — only for secret auras where
+			-- spell-level classification isn't available. The broader RAID
+			-- fallback lets long maintenance buffs through in M+ when duration
+			-- is secret, so keep this on Blizzard's combat-relevant allowlist.
 			if(not show) then
 				local isSecret = not F.IsValueNonSecret(auraData.spellId)
-				if(isSecret and flags.isRaid and not flags.isBigDefensive) then
+				if(isSecret and flags.isRaidInCombat and not flags.isBigDefensive) then
 					show = true
 				end
 			end
@@ -167,13 +167,13 @@ local function Update(self, event, unit, updateInfo)
 				end
 			end
 
-			-- Step 3: RAID fallback for secret auras — exclude BIG_DEFENSIVE.
+			-- Step 3: RAID_IN_COMBAT fallback for secret auras — exclude BIG_DEFENSIVE.
 			if(not show) then
 				local isSecret = not F.IsValueNonSecret(auraData.spellId)
 				if(isSecret) then
-					local isRaid = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
-						unit, id, 'HELPFUL|RAID')
-					if(isRaid) then
+					local isRaidCombat = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
+						unit, id, 'HELPFUL|RAID_IN_COMBAT')
+					if(isRaidCombat) then
 						local isBigDef = not C_UnitAuras.IsAuraFilteredOutByInstanceID(
 							unit, id, 'HELPFUL|BIG_DEFENSIVE')
 						show = not isBigDef

--- a/Elements/Indicators/Icon.lua
+++ b/Elements/Indicators/Icon.lua
@@ -18,6 +18,19 @@ F.Indicators.Icon = {}
 
 local IconMethods = {}
 
+local function hasUsableDurationObject(durationObj)
+	if(not durationObj) then return false end
+
+	local isZero = durationObj:IsZero()
+	if(F.IsValueNonSecret(isZero)) then
+		return not isZero
+	end
+
+	-- IsZero can be secret for classified combat auras. In that case, avoid
+	-- branching on it and let C-level timer consumers handle the DurationObject.
+	return true
+end
+
 --- Set the displayed spell/aura data on this icon.
 --- @param unit string|nil Unit token
 --- @param auraInstanceID number|nil Aura instance ID
@@ -70,7 +83,7 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 
 	-- Depletion bar
 	if(self._depletionBar) then
-		if(durationObj and not durationObj:IsZero()) then
+		if(hasUsableDurationObject(durationObj)) then
 			self._depletionBar:SetTimerDuration(durationObj, nil, Enum.StatusBarTimerDirection.ElapsedTime)
 			self._depletionBar:Show()
 		else
@@ -81,7 +94,7 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 
 	-- Duration countdown via Cooldown frame
 	if(self._cooldown) then
-		if(durationObj and not durationObj:IsZero()) then
+		if(hasUsableDurationObject(durationObj)) then
 			self._cooldown:SetCooldownFromDurationObject(durationObj)
 
 			-- Reparent and style Blizzard's countdown text once (lazy creation),

--- a/Framed.toc
+++ b/Framed.toc
@@ -2,7 +2,7 @@
 ## Title: Framed
 ## Notes: Modern, customizable unit frames and raid frames
 ## Author: Moodibs
-## Version: 0.8.16-alpha
+## Version: 0.8.17-alpha
 ## X-Curse-Project-ID: 1513359
 ## SavedVariables: FramedDB, FramedBackupDB, FramedSnapshotsDB
 ## SavedVariablesPerCharacter: FramedCharDB

--- a/Settings/Cards/About.lua
+++ b/Settings/Cards/About.lua
@@ -114,6 +114,13 @@ end
 -- BEGIN GENERATED CHANGELOG
 local CHANGELOG = {
 	{
+		version = 'v0.8.17-alpha',
+		entries = {
+			'**Externals: Symbiotic Relationship leak in M+** — the RAID secret-aura fallback admitted Symbiotic Relationship in secret-active content because it carries the broad `RAID` classification despite being a passive bond rather than a combat-relevant external. Switched the fallback to Blizzard\'s tighter `RAID_IN_COMBAT` curation, which excludes passive bonds while still admitting Power Infusion and similar raid-important buffs',
+			'**Icon: secret-safe DurationObject zero check** — `DurationObject:IsZero()` returns a secret boolean for classified combat auras (e.g. Ironbark on player in M+); the Lua test `not durationObj:IsZero()` then crashed mid-`SetSpell`, halting before the icon was rendered. Affected auras silently disappeared in secret content in addition to spamming the error frame. Wrapped the zero check in a helper that falls through to the C-level timer consumers when `IsZero` is secret',
+		},
+	},
+	{
 		version = 'v0.8.16-alpha',
 		entries = {
 			'**Interface bump to 120005** — TOC interface version raised from 120001 to align with WoW 12.0.5',
@@ -155,14 +162,6 @@ local CHANGELOG = {
 			'**Tracked pre-commit hook** running luacheck on staged Lua files; install via `tools/install-hooks.sh`',
 			'Buffs `matchAura` no longer mutates `AuraData` tables — Blizzard fields stay clean for downstream consumers',
 			'Internal MemDiag in-situ probes stripped from `Icon.lua`/`Buffs.lua` hot paths; replaced with broader `OnUpdate` coverage in MemDiag itself',
-		},
-	},
-	{
-		version = 'v0.8.14-alpha',
-		entries = {
-			'**12.0.5 compatibility** — fix `bad argument #2 to \'?\' (Current Field: [isContainer])` error on unit frame spawn; 12.0.5 added a required `isContainer` field to `C_UnitAuras.AddPrivateAuraAnchor`\'s args table',
-			'Add `/framed aurastate [unit]` debug slash — dumps the classified aura flag breakdown for a unit (defaults to target), showing which of `external-defensive`, `important`, `player-cast`, `big-defensive`, `raid`, `boss`, `from-player-or-pet` apply to each aura. Useful for verifying classification correctness as #115\'s B-series migrations land',
-			'Internal: AuraState now exposes shared per-frame classification (`GetHelpfulClassified` / `GetHarmfulClassified` / `GetClassifiedByInstanceID`) with write-path invalidation wired through `FullRefresh` and `ApplyUpdateInfo`. No element yet consumes the new API — infrastructure only in this patch, element migrations follow in subsequent releases (#115 B1-B6)',
 		},
 	},
 }


### PR DESCRIPTION
Promotion of v0.8.17-alpha from working-testing to working.

## Included

- **#193** — Externals: Symbiotic Relationship leak in M+ closed via RAID_IN_COMBAT classification swap; Icon: secret-safe DurationObject zero check fixes Ironbark crash + silent disappearance in secret-active content
- **Bump to v0.8.17-alpha** — CHANGELOG entry, About.lua sync, TOC version

## Verification

PR #193 was tested against the live `secretChallengeModeRestrictionsForced 1` CVar with target dummy combat:

- Symbiotic Relationship no longer appears in Externals frame
- Power Infusion still appears in Externals frame
- Ironbark on player no longer crashes Icon.lua:73
- OOC-applied buffs that persist into combat now render correctly
- luacheck clean across all modified files

## Known limitations carried forward

- Auras whose `spellId` is secret AND first applied during secret combat remain untrackable by ID-based discovery (Blizzard system constraint). Long-term fix tracked in #90 (fingerprinting) — now unblocked at the dependency level since 12.0.5 shipped and #89 / #115 are closed.
- Power Infusion still invisible in non-secret content. Separate problem requiring an allowlist tier; not bundled.