### PR TITLE
Aura/indicator secret-mode hardening pass + edit mode + element fixes

### DIFF
--- a/EditMode/ClickCatchers.lua
+++ b/EditMode/ClickCatchers.lua
@@ -85,6 +85,66 @@ local function getGroupBounds(config, frameKey)
 	return F.PreviewManager.GetGroupBounds(config, frameKey)
 end
 
+--- Build a config table with EditCache overlaid on the saved config.
+--- Mirrors PreviewManager's getUnitConfig so click catchers and the
+--- preview frame size from the same source of truth during edit mode.
+local function getEditedConfig(frameKey)
+	local preset = F.Settings.GetEditingPreset()
+	local saved = F.Config:Get('presets.' .. preset .. '.unitConfigs.' .. frameKey)
+	if(not saved) then return nil end
+	if(not EditCache or not EditCache.IsActive()) then return saved end
+
+	local edits = EditCache.GetEditsForFrame(frameKey)
+	if(not edits) then return saved end
+
+	local config = F.DeepCopy(saved)
+	for path, value in next, edits do
+		local keys = {}
+		for k in path:gmatch('[^%.]+') do
+			keys[#keys + 1] = k
+		end
+		local target = config
+		for i = 1, #keys - 1 do
+			if(type(target[keys[i]]) ~= 'table') then
+				target[keys[i]] = {}
+			end
+			target = target[keys[i]]
+		end
+		target[keys[#keys]] = value
+	end
+	return config
+end
+
+--- Re-apply size + anchor for a group catcher based on the current
+--- (EditCache-overlaid) config. No-op for solo catchers since they
+--- use SetAllPoints which already follows the real frame.
+local function applyGroupCatcherLayout(catcher)
+	local def = catcher and catcher._def
+	if(not def or not def.isGroup) then return end
+	local frame = def.getter()
+	local frameKey = def.key
+	local config = getEditedConfig(frameKey)
+	if(not config) then return end
+
+	local totalW, totalH = getGroupBounds(config, frameKey)
+	local anchor = config.anchorPoint
+	if(not totalW or not anchor) then
+		if(frame) then catcher:SetAllPoints(frame) end
+		return
+	end
+
+	catcher:SetSize(totalW, totalH)
+	catcher:ClearAllPoints()
+	if(frame) then
+		catcher:SetPoint(anchor, frame, anchor, 0, 0)
+	else
+		local posAnchor = (config.position and config.position.anchor) or 'CENTER'
+		local posX = (config.position and config.position.x) or 0
+		local posY = (config.position and config.position.y) or 0
+		catcher:SetPoint(anchor, UIParent, posAnchor, posX, posY)
+	end
+end
+
 -- ── Catcher creation ─────────────────────────────────────────
 
 local function CreateCatcher(def, overlay)
@@ -399,6 +459,22 @@ F.EventBus:Register('EDIT_MODE_FRAME_SELECTED', function(frameKey)
 			-- Keep above preview so unselected frames stay clickable
 			catcher:SetFrameLevel(overlay:GetFrameLevel() + 10)
 		end
+		-- Re-sync group catchers to current EditCache values so a deselected
+		-- catcher reflects edits made while it was hidden behind the preview.
+		applyGroupCatcherLayout(catcher)
 		catcher:Show()
 	end
 end, 'ClickCatchers')
+
+-- Live-resize group catchers when EditCache values change. Solo catchers
+-- use SetAllPoints(frame) and follow the real frame automatically once
+-- ResizeHandles applies frame:SetSize, so they don't need this path.
+F.EventBus:Register('EDIT_CACHE_VALUE_CHANGED', function(frameKey, configPath, value)
+	local affectsLayout = (configPath == 'width' or configPath == 'height'
+		or configPath == 'columns' or configPath == 'spacing'
+		or configPath == 'anchorPoint')
+	if(not affectsLayout) then return end
+	local catcher = catchers[frameKey]
+	if(not catcher) then return end
+	applyGroupCatcherLayout(catcher)
+end, 'ClickCatchers.cacheChanged')

--- a/EditMode/InlinePanel.lua
+++ b/EditMode/InlinePanel.lua
@@ -149,12 +149,24 @@ local function BuildPanel(frameKey, targetFrame)
 	local setCfg = function(path, value) F.EditCache.Set(unitType, path, value) end
 	local onResize = function() end  -- Preview auto-updates via EDIT_CACHE_VALUE_CHANGED
 
+	-- Title: shows which frame the panel is editing. Once a frame is
+	-- selected its highlight is suppressed during drag, so without this
+	-- the user has no on-screen confirmation of what they're moving.
+	local titleText = (F.Settings and F.Settings.GetFrameUnitLabel and F.Settings.GetFrameUnitLabel(unitType))
+		or unitType
+	local title = Widgets.CreateFontString(panel, C.Font.sizeTitle, C.Colors.textActive)
+	title:SetPoint('TOPLEFT', panel, 'TOPLEFT', C.Spacing.normal, -C.Spacing.normal)
+	title:SetJustifyH('LEFT')
+	title:SetText(titleText)
+
+	local titleH = title:GetStringHeight()
+
 	local card = F.SettingsCards.PositionAndLayout(panel, widgetW, unitType, getCfg, setCfg, onResize)
 	card:ClearAllPoints()
-	card:SetPoint('TOPLEFT', panel, 'TOPLEFT', C.Spacing.normal, -C.Spacing.normal)
+	card:SetPoint('TOPLEFT', panel, 'TOPLEFT', C.Spacing.normal, -(C.Spacing.normal + titleH + C.Spacing.tight))
 
-	-- Fit panel height to card, then sync shield to the final rect
-	panel:SetHeight(card:GetHeight() + C.Spacing.normal * 2)
+	-- Fit panel height to card + title, then sync shield to the final rect
+	panel:SetHeight(card:GetHeight() + titleH + C.Spacing.tight + C.Spacing.normal * 2)
 	shield:SetHeight(panel:GetHeight())
 	shield:ClearAllPoints()
 	shield:SetAllPoints(panel)

--- a/Elements/Auras/Buffs.lua
+++ b/Elements/Auras/Buffs.lua
@@ -152,12 +152,15 @@ end
 --- function stays at module scope — no nested-closure allocation per event.
 --- BARS is a timer display — showing a static fill for an infinite or
 --- near-infinite duration aura (Arcane Intellect, Mark of the Wild,
---- world buffs, long-lived consumables) wastes a bar slot and confuses
---- users ("why isn't this bar depleting?"). Skip auras where we can
---- confirm the duration is zero or >= 10 minutes. Mirrors the skip
---- pattern in Debuffs.lua:128. Secret durations pass through since we
---- can't evaluate them Lua-side; the C-level timer handles depletion.
-local function shouldSkipForBars(auraData)
+--- world buffs, long-lived consumables) wastes a slot and confuses
+--- users ("why isn't this bar depleting?"). Used by BARS and by
+--- track-all OVERLAY/RECTANGLE indicators where the matched aura
+--- would otherwise be an arbitrary long-duration buff. Skip auras
+--- where we can confirm the duration is zero or >= 10 minutes.
+--- Mirrors the skip pattern in Debuffs.lua:128. Secret durations
+--- pass through since we can't evaluate them Lua-side; the C-level
+--- timer handles depletion.
+local function shouldSkipLongDuration(auraData)
 	local dur = auraData.duration
 	if(not F.IsValueNonSecret(dur)) then return false end
 	return dur == 0 or dur >= 600
@@ -184,7 +187,7 @@ local function matchAura(auraData)
 					local list = iconsAurasPool[idx]
 					list[#list + 1] = auraData
 				elseif(ind._type == C.IndicatorType.BARS) then
-					if(not shouldSkipForBars(auraData)) then
+					if(not shouldSkipLongDuration(auraData)) then
 						local list = iconsAurasPool[idx]
 						list[#list + 1] = auraData
 					end
@@ -203,9 +206,13 @@ local function matchAura(auraData)
 				local list = iconsAurasPool[idx]
 				list[#list + 1] = auraData
 			elseif(ind._type == C.IndicatorType.BARS) then
-				if(not shouldSkipForBars(auraData)) then
+				if(not shouldSkipLongDuration(auraData)) then
 					local list = iconsAurasPool[idx]
 					list[#list + 1] = auraData
+				end
+			elseif(ind._type == C.IndicatorType.OVERLAY or ind._type == C.IndicatorType.RECTANGLE) then
+				if(not matchedPool[idx] and not shouldSkipLongDuration(auraData)) then
+					matchedPool[idx] = auraData
 				end
 			elseif(not matchedPool[idx]) then
 				matchedPool[idx] = auraData

--- a/Elements/Auras/Buffs.lua
+++ b/Elements/Auras/Buffs.lua
@@ -16,7 +16,7 @@ local RENDERERS = {
 	[C.IndicatorType.BAR]       = F.Indicators.Bar,
 	[C.IndicatorType.BARS]      = F.Indicators.Bars,
 	[C.IndicatorType.BORDER]    = F.Indicators.BorderGlow,
-	[C.IndicatorType.RECTANGLE] = F.Indicators.Color,
+	[C.IndicatorType.RECTANGLE] = F.Indicators.Rectangle,
 	[C.IndicatorType.OVERLAY]   = F.Indicators.Overlay,
 }
 

--- a/Elements/Auras/Buffs.lua
+++ b/Elements/Auras/Buffs.lua
@@ -210,7 +210,13 @@ local function matchAura(auraData)
 					local list = iconsAurasPool[idx]
 					list[#list + 1] = auraData
 				end
-			elseif(ind._type == C.IndicatorType.OVERLAY or ind._type == C.IndicatorType.RECTANGLE) then
+			elseif(ind._type == C.IndicatorType.OVERLAY
+				or ind._type == C.IndicatorType.RECTANGLE
+				or ind._type == C.IndicatorType.BORDER
+				or ind._type == C.IndicatorType.BAR) then
+				-- Long-duration auras (flasks, food) leave these visual-only
+				-- indicators stuck since they don't show identifying info.
+				-- ICON is excluded — the icon itself reveals what's matched.
 				if(not matchedPool[idx] and not shouldSkipLongDuration(auraData)) then
 					matchedPool[idx] = auraData
 				end

--- a/Elements/Auras/Buffs.lua
+++ b/Elements/Auras/Buffs.lua
@@ -338,7 +338,7 @@ local function Update(self, event, unit, updateInfo)
 				else
 					renderer:SetValue(1, 1)
 				end
-				if(aura.applications) then renderer:SetStacks(aura.applications) end
+				renderer:SetStacks(aura.applications, unit, aura.auraInstanceID)
 				-- Glow
 				if(ind._glowType and ind._glowType ~= 'None') then
 					renderer:StartGlow(ind._glowColor, ind._glowType, ind._glowConfig)
@@ -356,7 +356,7 @@ local function Update(self, event, unit, updateInfo)
 					sortPriority = ind._spellPriority
 					table.sort(list, prioritySort)
 				end
-				renderer:SetBars(list)
+				renderer:SetBars(unit, list)
 				renderer:Show()
 				-- Glow
 				if(ind._glowType and ind._glowType ~= 'None') then
@@ -401,7 +401,7 @@ local function Update(self, event, unit, updateInfo)
 				else
 					renderer:SetValue(1, 1)
 				end
-				if(aura.applications) then renderer:SetStacks(aura.applications) end
+				renderer:SetStacks(aura.applications, unit, aura.auraInstanceID)
 			else
 				renderer:Clear()
 			end

--- a/Elements/Auras/Debuffs.lua
+++ b/Elements/Auras/Debuffs.lua
@@ -83,7 +83,13 @@ local function shouldShowDispelColor(auraData, force)
 	if(force) then return true end
 
 	local dispelName = auraData.dispelName
-	return F.IsValueNonSecret(dispelName) and dispelName ~= nil and dispelName ~= ''
+	if(not F.IsValueNonSecret(dispelName)) then
+		-- Classified combat can hide the type from Lua. Still ask the
+		-- C-level curve path to resolve the correct color for the icon.
+		return true
+	end
+
+	return dispelName ~= nil and dispelName ~= ''
 end
 
 local function updateIndicator(self, unit, ind)

--- a/Elements/Auras/Debuffs.lua
+++ b/Elements/Auras/Debuffs.lua
@@ -25,7 +25,7 @@ local FILTER_MAP = {
 
 --- Display one aura directly from auraData fields (no intermediate table).
 --- Returns the new running pixel offset for the next icon.
-local function displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, showDispelColor)
+local function displayAura(self, unit, pool, displayed, runOffset, cfg, auraData)
 	local iconSize    = cfg.iconSize
 	local bigIconSize = cfg.bigIconSize
 	local orientation = cfg.orientation
@@ -71,25 +71,11 @@ local function displayAura(self, unit, pool, displayed, runOffset, cfg, auraData
 		auraData.icon,
 		auraData.duration,
 		auraData.expirationTime,
-		auraData.applications,
-		showDispelColor
+		auraData.applications
 	)
 	bi:Show()
 
 	return runOffset + size + 2
-end
-
-local function shouldShowDispelColor(auraData, force)
-	if(force) then return true end
-
-	local dispelName = auraData.dispelName
-	if(not F.IsValueNonSecret(dispelName)) then
-		-- Classified combat can hide the type from Lua. Still ask the
-		-- C-level curve path to resolve the correct color for the icon.
-		return true
-	end
-
-	return dispelName ~= nil and dispelName ~= ''
 end
 
 local function updateIndicator(self, unit, ind)
@@ -141,16 +127,15 @@ local function updateIndicator(self, unit, ind)
 				local skip = F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)
 				if(not skip) then
 					displayed = displayed + 1
-					local showDispelColor = shouldShowDispelColor(auraData, filterMode == 'dispellable')
-					runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, showDispelColor)
+					runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData)
 				end
 			end
 		end
 
 		-- Dispellable supplementary pass: RAID_PLAYER_DISPELLABLE excludes
 		-- Physical/bleeds, so iterate raid-flagged entries and include any
-		-- whose dispelName is nil/empty/Physical. Pass nil dispelType — these
-		-- aren't dispellable, no overlay color.
+		-- whose dispelName is nil/empty/Physical. BorderIcon resolves the
+		-- actual type color through C_UnitAuras, so secret bleeds still color.
 		if(filterMode == 'dispellable' and displayed < maxDisplayed) then
 			for _, entry in next, classified do
 				if(displayed >= maxDisplayed) then break end
@@ -162,7 +147,7 @@ local function updateIndicator(self, unit, ind)
 					local isPhysical = F.IsValueNonSecret(dn) and (not dn or dn == '' or dn == 'Physical')
 					if(isPhysical) then
 						displayed = displayed + 1
-						runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, false)
+						runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData)
 					end
 				end
 			end
@@ -182,8 +167,7 @@ local function updateIndicator(self, unit, ind)
 
 			if(not skip) then
 				displayed = displayed + 1
-				local showDispelColor = shouldShowDispelColor(auraData, filterMode == 'dispellable')
-				runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, showDispelColor)
+				runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData)
 			end
 		end
 
@@ -196,7 +180,7 @@ local function updateIndicator(self, unit, ind)
 				local isPhysical = F.IsValueNonSecret(dn) and (not dn or dn == '' or dn == 'Physical')
 				if(isPhysical) then
 					displayed = displayed + 1
-					runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, false)
+					runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData)
 				end
 			end
 		end

--- a/Elements/Auras/Debuffs.lua
+++ b/Elements/Auras/Debuffs.lua
@@ -25,7 +25,7 @@ local FILTER_MAP = {
 
 --- Display one aura directly from auraData fields (no intermediate table).
 --- Returns the new running pixel offset for the next icon.
-local function displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, dispelType)
+local function displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, showDispelColor)
 	local iconSize    = cfg.iconSize
 	local bigIconSize = cfg.bigIconSize
 	local orientation = cfg.orientation
@@ -72,11 +72,18 @@ local function displayAura(self, unit, pool, displayed, runOffset, cfg, auraData
 		auraData.duration,
 		auraData.expirationTime,
 		auraData.applications,
-		dispelType
+		showDispelColor
 	)
 	bi:Show()
 
 	return runOffset + size + 2
+end
+
+local function shouldShowDispelColor(auraData, force)
+	if(force) then return true end
+
+	local dispelName = auraData.dispelName
+	return F.IsValueNonSecret(dispelName) and dispelName ~= nil and dispelName ~= ''
 end
 
 local function updateIndicator(self, unit, ind)
@@ -128,7 +135,8 @@ local function updateIndicator(self, unit, ind)
 				local skip = F.IsValueNonSecret(dur) and (dur == 0 or dur >= 600)
 				if(not skip) then
 					displayed = displayed + 1
-					runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, auraData.dispelName)
+					local showDispelColor = shouldShowDispelColor(auraData, filterMode == 'dispellable')
+					runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, showDispelColor)
 				end
 			end
 		end
@@ -148,7 +156,7 @@ local function updateIndicator(self, unit, ind)
 					local isPhysical = F.IsValueNonSecret(dn) and (not dn or dn == '' or dn == 'Physical')
 					if(isPhysical) then
 						displayed = displayed + 1
-						runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, nil)
+						runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, false)
 					end
 				end
 			end
@@ -168,7 +176,8 @@ local function updateIndicator(self, unit, ind)
 
 			if(not skip) then
 				displayed = displayed + 1
-				runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, auraData.dispelName)
+				local showDispelColor = shouldShowDispelColor(auraData, filterMode == 'dispellable')
+				runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, showDispelColor)
 			end
 		end
 
@@ -181,7 +190,7 @@ local function updateIndicator(self, unit, ind)
 				local isPhysical = F.IsValueNonSecret(dn) and (not dn or dn == '' or dn == 'Physical')
 				if(isPhysical) then
 					displayed = displayed + 1
-					runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, nil)
+					runOffset = displayAura(self, unit, pool, displayed, runOffset, cfg, auraData, false)
 				end
 			end
 		end

--- a/Elements/Auras/Debuffs.lua
+++ b/Elements/Auras/Debuffs.lua
@@ -71,7 +71,8 @@ local function displayAura(self, unit, pool, displayed, runOffset, cfg, auraData
 		auraData.icon,
 		auraData.duration,
 		auraData.expirationTime,
-		auraData.applications
+		auraData.applications,
+		true
 	)
 	bi:Show()
 

--- a/Elements/Auras/Dispellable.lua
+++ b/Elements/Auras/Dispellable.lua
@@ -230,15 +230,23 @@ local function Update(self, event, unit, updateInfo)
 
 	local onlyDispellableByMe = element._onlyDispellableByMe
 
-	-- Find the first dispellable debuff. Non-nil dispelName (may be
-	-- secret) means the aura is dispellable. auraInstanceID is
-	-- NeverSecret — safe to store and pass to curve APIs.
+	-- Find the first dispellable debuff. In "by me" mode, the server-side
+	-- filter has already done the dispelability check, so the first aura is
+	-- enough. In "all" mode, raw dispelName can be secret, so only branch on
+	-- it after a non-secret guard; secret unknowns are skipped rather than
+	-- risking a tainted boolean test.
 	local dispelAuraID = nil
 	local primaryFilter = onlyDispellableByMe and 'HARMFUL|RAID_PLAYER_DISPELLABLE' or 'HARMFUL'
 	local allAuras = auraState and auraState:GetHarmful(primaryFilter) or F.AuraCache.GetUnitAuras(unit, primaryFilter)
 
 	for _, auraData in next, allAuras do
-		if(auraData.dispelName) then
+		if(onlyDispellableByMe) then
+			dispelAuraID = auraData.auraInstanceID
+			break
+		end
+
+		local dispelName = auraData.dispelName
+		if(F.IsValueNonSecret(dispelName) and dispelName and dispelName ~= '') then
 			dispelAuraID = auraData.auraInstanceID
 			break
 		end

--- a/Elements/Auras/Dispellable.lua
+++ b/Elements/Auras/Dispellable.lua
@@ -231,10 +231,12 @@ local function Update(self, event, unit, updateInfo)
 	local onlyDispellableByMe = element._onlyDispellableByMe
 
 	-- Find the first dispellable debuff. In "by me" mode, the server-side
-	-- filter has already done the dispelability check, so the first aura is
-	-- enough. In "all" mode, raw dispelName can be secret, so only branch on
-	-- it after a non-secret guard; secret unknowns are skipped rather than
-	-- risking a tainted boolean test.
+	-- filter (RAID_PLAYER_DISPELLABLE) has already restricted the list to
+	-- auras the active player can dispel, so the first entry is sufficient.
+	-- In "all" mode, a non-nil dispelName means the aura has a dispel type
+	-- (may be secret userdata in classified content — Lua truthy-checks on
+	-- secret strings are safe, only secret booleans crash). auraInstanceID
+	-- is NeverSecret so it's safe to store and pass to the curve API.
 	local dispelAuraID = nil
 	local primaryFilter = onlyDispellableByMe and 'HARMFUL|RAID_PLAYER_DISPELLABLE' or 'HARMFUL'
 	local allAuras = auraState and auraState:GetHarmful(primaryFilter) or F.AuraCache.GetUnitAuras(unit, primaryFilter)
@@ -244,9 +246,7 @@ local function Update(self, event, unit, updateInfo)
 			dispelAuraID = auraData.auraInstanceID
 			break
 		end
-
-		local dispelName = auraData.dispelName
-		if(F.IsValueNonSecret(dispelName) and dispelName and dispelName ~= '') then
+		if(auraData.dispelName) then
 			dispelAuraID = auraData.auraInstanceID
 			break
 		end

--- a/Elements/Auras/Dispellable.lua
+++ b/Elements/Auras/Dispellable.lua
@@ -208,6 +208,18 @@ local function showDispelIcons(element, unit, auraInstanceID)
 	end
 end
 
+local function getHighlightColor(unit, auraInstanceID)
+	return C_UnitAuras.GetAuraDispelTypeColor(unit, auraInstanceID, highlightCurve)
+end
+
+local function isTypedDispelAura(unit, auraInstanceID)
+	local color = getHighlightColor(unit, auraInstanceID)
+	if(not color) then return false end
+
+	local _, _, _, a = color:GetRGBA()
+	return F.IsValueNonSecret(a) and a > 0
+end
+
 -- ============================================================
 -- Update
 -- ============================================================
@@ -230,24 +242,18 @@ local function Update(self, event, unit, updateInfo)
 
 	local onlyDispellableByMe = element._onlyDispellableByMe
 
-	-- Find the first dispellable debuff. In "by me" mode, the server-side
-	-- filter has already done the dispelability check, so the first aura is
-	-- enough. In "all" mode, raw dispelName can be secret, so only branch on
-	-- it after a non-secret guard; secret unknowns are skipped rather than
-	-- risking a tainted boolean test.
+	-- Find the first matching debuff. In "by me" mode, the server-side filter
+	-- has already done the dispelability check. In "all" mode, resolve the
+	-- typed/none decision through the C-level dispel color curve so secret
+	-- combat auras still count without Lua reading aura.dispelName.
 	local dispelAuraID = nil
 	local primaryFilter = onlyDispellableByMe and 'HARMFUL|RAID_PLAYER_DISPELLABLE' or 'HARMFUL'
 	local allAuras = auraState and auraState:GetHarmful(primaryFilter) or F.AuraCache.GetUnitAuras(unit, primaryFilter)
 
 	for _, auraData in next, allAuras do
-		if(onlyDispellableByMe) then
-			dispelAuraID = auraData.auraInstanceID
-			break
-		end
-
-		local dispelName = auraData.dispelName
-		if(F.IsValueNonSecret(dispelName) and dispelName and dispelName ~= '') then
-			dispelAuraID = auraData.auraInstanceID
+		local auraInstanceID = auraData.auraInstanceID
+		if(onlyDispellableByMe or isTypedDispelAura(unit, auraInstanceID)) then
+			dispelAuraID = auraInstanceID
 			break
 		end
 	end
@@ -260,7 +266,7 @@ local function Update(self, event, unit, updateInfo)
 		-- Ignore the curve's alpha (1.0) — use our own overlayAlpha
 		-- to avoid a bright/washed overlay with ADD blend mode.
 		local overlayAlpha = element.__config.highlightAlpha
-		local hlColor = C_UnitAuras.GetAuraDispelTypeColor(unit, dispelAuraID, highlightCurve)
+		local hlColor = getHighlightColor(unit, dispelAuraID)
 		if(hlColor and element._highlightType) then
 			local cr, cg, cb = hlColor:GetRGB()
 			showOverlay(element, element._highlightType, cr, cg, cb, overlayAlpha)

--- a/Elements/Auras/Dispellable.lua
+++ b/Elements/Auras/Dispellable.lua
@@ -208,24 +208,6 @@ local function showDispelIcons(element, unit, auraInstanceID)
 	end
 end
 
-local function getHighlightColor(unit, auraInstanceID)
-	return C_UnitAuras.GetAuraDispelTypeColor(unit, auraInstanceID, highlightCurve)
-end
-
-local function isTypedDispelAura(unit, auraInstanceID)
-	local color = getHighlightColor(unit, auraInstanceID)
-	if(not color) then return false end
-
-	local _, _, _, a = color:GetRGBA()
-	if(F.IsValueNonSecret(a)) then
-		return a > 0
-	end
-
-	-- Classified combat can make the curve result secret. Treat unknown
-	-- alpha as a possible typed dispel so the C-level render path can decide.
-	return true
-end
-
 -- ============================================================
 -- Update
 -- ============================================================
@@ -248,18 +230,24 @@ local function Update(self, event, unit, updateInfo)
 
 	local onlyDispellableByMe = element._onlyDispellableByMe
 
-	-- Find the first matching debuff. In "by me" mode, the server-side filter
-	-- has already done the dispelability check. In "all" mode, resolve the
-	-- typed/none decision through the C-level dispel color curve so secret
-	-- combat auras still count without Lua reading aura.dispelName.
+	-- Find the first dispellable debuff. In "by me" mode, the server-side
+	-- filter has already done the dispelability check, so the first aura is
+	-- enough. In "all" mode, raw dispelName can be secret, so only branch on
+	-- it after a non-secret guard; secret unknowns are skipped rather than
+	-- risking a tainted boolean test.
 	local dispelAuraID = nil
 	local primaryFilter = onlyDispellableByMe and 'HARMFUL|RAID_PLAYER_DISPELLABLE' or 'HARMFUL'
 	local allAuras = auraState and auraState:GetHarmful(primaryFilter) or F.AuraCache.GetUnitAuras(unit, primaryFilter)
 
 	for _, auraData in next, allAuras do
-		local auraInstanceID = auraData.auraInstanceID
-		if(onlyDispellableByMe or isTypedDispelAura(unit, auraInstanceID)) then
-			dispelAuraID = auraInstanceID
+		if(onlyDispellableByMe) then
+			dispelAuraID = auraData.auraInstanceID
+			break
+		end
+
+		local dispelName = auraData.dispelName
+		if(F.IsValueNonSecret(dispelName) and dispelName and dispelName ~= '') then
+			dispelAuraID = auraData.auraInstanceID
 			break
 		end
 	end
@@ -272,7 +260,7 @@ local function Update(self, event, unit, updateInfo)
 		-- Ignore the curve's alpha (1.0) — use our own overlayAlpha
 		-- to avoid a bright/washed overlay with ADD blend mode.
 		local overlayAlpha = element.__config.highlightAlpha
-		local hlColor = getHighlightColor(unit, dispelAuraID)
+		local hlColor = C_UnitAuras.GetAuraDispelTypeColor(unit, dispelAuraID, highlightCurve)
 		if(hlColor and element._highlightType) then
 			local cr, cg, cb = hlColor:GetRGB()
 			showOverlay(element, element._highlightType, cr, cg, cb, overlayAlpha)

--- a/Elements/Auras/Dispellable.lua
+++ b/Elements/Auras/Dispellable.lua
@@ -217,7 +217,13 @@ local function isTypedDispelAura(unit, auraInstanceID)
 	if(not color) then return false end
 
 	local _, _, _, a = color:GetRGBA()
-	return F.IsValueNonSecret(a) and a > 0
+	if(F.IsValueNonSecret(a)) then
+		return a > 0
+	end
+
+	-- Classified combat can make the curve result secret. Treat unknown
+	-- alpha as a possible typed dispel so the C-level render path can decide.
+	return true
 end
 
 -- ============================================================

--- a/Elements/Core/Health.lua
+++ b/Elements/Core/Health.lua
@@ -356,9 +356,10 @@ function F.Elements.Health.Setup(self, width, height, config)
 			end
 		end
 
-		-- Health text formatting — uses secret-safe APIs throughout.
+		-- Health text formatting.
 		-- AbbreviateNumbers (C-level) handles secret values from UnitHealth.
-		-- UnitHealthPercent (C-level) returns non-secret percentage.
+		-- UnitHealthPercent can return a secret curve result, so only
+		-- Lua-format it after confirming the value is inspectable.
 		if(h.text and h.text:IsShown()) then
 			local fmt = h._textFormat or config.textFormat
 			local prefix = h._attachedToName and ' - ' or ''
@@ -366,7 +367,11 @@ function F.Elements.Health.Setup(self, width, height, config)
 				h.text:SetText('')
 			elseif(fmt == 'percent') then
 				local pct = UnitHealthPercent(unit, true, CurveConstants.ScaleTo100)
-				h.text:SetText(prefix .. string.format('%d', pct) .. '%')
+				if(F.IsValueNonSecret(pct)) then
+					h.text:SetText(prefix .. string.format('%d', pct) .. '%')
+				else
+					h.text:SetText('')
+				end
 			elseif(fmt == 'current') then
 				h.text:SetText(prefix .. F.AbbreviateNumber(UnitHealth(unit)))
 			elseif(fmt == 'deficit') then

--- a/Elements/Core/Health.lua
+++ b/Elements/Core/Health.lua
@@ -358,8 +358,8 @@ function F.Elements.Health.Setup(self, width, height, config)
 
 		-- Health text formatting.
 		-- AbbreviateNumbers (C-level) handles secret values from UnitHealth.
-		-- UnitHealthPercent can return a secret curve result, so only
-		-- Lua-format it after confirming the value is inspectable.
+		-- UnitHealthPercent can return a secret curve result, so pass it
+		-- directly to C-level SetFormattedText instead of Lua-formatting it.
 		if(h.text and h.text:IsShown()) then
 			local fmt = h._textFormat or config.textFormat
 			local prefix = h._attachedToName and ' - ' or ''
@@ -367,11 +367,7 @@ function F.Elements.Health.Setup(self, width, height, config)
 				h.text:SetText('')
 			elseif(fmt == 'percent') then
 				local pct = UnitHealthPercent(unit, true, CurveConstants.ScaleTo100)
-				if(F.IsValueNonSecret(pct)) then
-					h.text:SetText(prefix .. string.format('%d', pct) .. '%')
-				else
-					h.text:SetText('')
-				end
+				h.text:SetFormattedText('%s%d%%', prefix, pct)
 			elseif(fmt == 'current') then
 				h.text:SetText(prefix .. F.AbbreviateNumber(UnitHealth(unit)))
 			elseif(fmt == 'deficit') then

--- a/Elements/Core/Name.lua
+++ b/Elements/Core/Name.lua
@@ -7,38 +7,6 @@ F.Elements = F.Elements or {}
 F.Elements.Name = {}
 
 -- ============================================================
--- Name Truncation Helper
--- ============================================================
-
---- Truncate a UTF-8 string to maxChars codepoints, appending '...' if cut.
---- @param str string
---- @param maxChars number
---- @return string
-local function TruncateUTF8(str, maxChars)
-	if(not str) then return '' end
-	local chars = 0
-	local bytePos = 1
-	local len = #str
-	while(bytePos <= len and chars < maxChars) do
-		local byte = str:byte(bytePos)
-		if(byte < 128) then
-			bytePos = bytePos + 1
-		elseif(byte < 224) then
-			bytePos = bytePos + 2
-		elseif(byte < 240) then
-			bytePos = bytePos + 3
-		else
-			bytePos = bytePos + 4
-		end
-		chars = chars + 1
-	end
-	if(bytePos <= len) then
-		return str:sub(1, bytePos - 1) .. '...'
-	end
-	return str
-end
-
--- ============================================================
 -- Name Element Setup
 -- ============================================================
 
@@ -91,13 +59,9 @@ function F.Elements.Name.Setup(self, config)
 	nameText._anchorX     = anchor[4] or 0
 	nameText._anchorY     = anchor[5] or 0
 
-	-- Native C-level auto-ellipsis on overflow. Our Lua-side TruncateUTF8
-	-- in ApplyNameUpdate runs inside a HookScript('OnAttributeChanged'),
-	-- which fires BEFORE oUF's [name] tag writes the new unit's name —
-	-- it truncates stale text that the tag then overwrites with an
-	-- untruncated long name (visibly spilling past the frame, especially
-	-- on narrow pinned frames). SetWordWrap(false) + a bounded width makes
-	-- the renderer append '...' on every SetText regardless of caller.
+	-- Native C-level auto-ellipsis on overflow. Avoid Lua-side string
+	-- truncation here: UnitName can be identity-restricted, and native
+	-- bounded FontString rendering keeps restricted text out of Lua logic.
 	--
 	-- Bounded width is skipped in attach-to-name mode: StyleBuilder anchors
 	-- Health.text to Name's RIGHT edge and Health.PostUpdate shifts the
@@ -142,7 +106,7 @@ function F.Elements.Name.Setup(self, config)
 	self:Tag(nameText, '[name]')
 
 	-- --------------------------------------------------------
-	-- PostUpdate: apply class color and truncation.
+	-- PostUpdate: apply class color.
 	-- oUF calls this whenever the unit's info refreshes.
 	-- --------------------------------------------------------
 
@@ -155,21 +119,6 @@ function F.Elements.Name.Setup(self, config)
 
 	local function ApplyNameUpdate(unit)
 		if(not unit) then return end
-
-		-- Auto-truncate: fit name to available frame width
-		local raw = nameText:GetText() or ''
-		local availableWidth = (self:GetWidth() or 0) - 8  -- 4px padding each side
-		nameText:SetText(raw)
-		if(availableWidth > 0 and nameText:GetStringWidth() > availableWidth) then
-			local len = #raw
-			for i = len, 1, -1 do
-				local truncated = TruncateUTF8(raw, i)
-				nameText:SetText(truncated)
-				if(nameText:GetStringWidth() <= availableWidth) then
-					break
-				end
-			end
-		end
 
 		-- Class coloring
 		if(config.colorMode == 'class') then

--- a/Elements/Core/Power.lua
+++ b/Elements/Core/Power.lua
@@ -136,9 +136,10 @@ function F.Elements.Power.Setup(self, width, height, config)
 			end
 		end
 
-		-- Power text formatting — uses secret-safe APIs throughout.
+		-- Power text formatting.
 		-- AbbreviateNumbers (C-level) handles secret values from UnitPower.
-		-- UnitPowerPercent (C-level) returns non-secret percentage.
+		-- UnitPowerPercent can return a secret curve result, so only
+		-- Lua-format it after confirming the value is inspectable.
 		if(p.text and p.text:IsShown()) then
 			local powerType = UnitPowerType(unit)
 			local fmt = p._textFormat or config.textFormat
@@ -146,7 +147,11 @@ function F.Elements.Power.Setup(self, width, height, config)
 				p.text:SetText('')
 			elseif(fmt == 'percent') then
 				local pct = UnitPowerPercent(unit, nil, true, CurveConstants.ScaleTo100)
-				p.text:SetText(string.format('%d', pct) .. '%')
+				if(F.IsValueNonSecret(pct)) then
+					p.text:SetText(string.format('%d', pct) .. '%')
+				else
+					p.text:SetText('')
+				end
 			elseif(fmt == 'current') then
 				p.text:SetText(F.AbbreviateNumber(UnitPower(unit, powerType)))
 			elseif(fmt == 'deficit') then

--- a/Elements/Core/Power.lua
+++ b/Elements/Core/Power.lua
@@ -138,8 +138,8 @@ function F.Elements.Power.Setup(self, width, height, config)
 
 		-- Power text formatting.
 		-- AbbreviateNumbers (C-level) handles secret values from UnitPower.
-		-- UnitPowerPercent can return a secret curve result, so only
-		-- Lua-format it after confirming the value is inspectable.
+		-- UnitPowerPercent can return a secret curve result, so pass it
+		-- directly to C-level SetFormattedText instead of Lua-formatting it.
 		if(p.text and p.text:IsShown()) then
 			local powerType = UnitPowerType(unit)
 			local fmt = p._textFormat or config.textFormat
@@ -147,11 +147,7 @@ function F.Elements.Power.Setup(self, width, height, config)
 				p.text:SetText('')
 			elseif(fmt == 'percent') then
 				local pct = UnitPowerPercent(unit, nil, true, CurveConstants.ScaleTo100)
-				if(F.IsValueNonSecret(pct)) then
-					p.text:SetText(string.format('%d', pct) .. '%')
-				else
-					p.text:SetText('')
-				end
+				p.text:SetFormattedText('%d%%', pct)
 			elseif(fmt == 'current') then
 				p.text:SetText(F.AbbreviateNumber(UnitPower(unit, powerType)))
 			elseif(fmt == 'deficit') then

--- a/Elements/Indicators/Bar.lua
+++ b/Elements/Indicators/Bar.lua
@@ -279,9 +279,9 @@ function F.Indicators.Bar.Create(parent, config)
 		statusBar:SetOrientation('VERTICAL')
 	end
 
-	-- Stack text (optional)
+	-- Stack text (optional, default off — opposite of ICON/ICONS)
 	local stackText
-	if(config.showStacks ~= false) then
+	if(config.showStacks == true) then
 		local sf = config.stackFont or {}
 		stackText = Widgets.CreateFontString(frame, sf.size or 10, { 1, 1, 1, 1 })
 		stackText:SetPoint('BOTTOMRIGHT', frame, 'BOTTOMRIGHT', -1, 1)

--- a/Elements/Indicators/Bar.lua
+++ b/Elements/Indicators/Bar.lua
@@ -208,14 +208,8 @@ function BarMethods:GetStatusBar()
 	return self._statusBar
 end
 
-function BarMethods:SetStacks(count)
-	if(not self._stackText) then return end
-	if(count and count > 1) then
-		self._stackText:SetText(count)
-		self._stackText:Show()
-	else
-		self._stackText:Hide()
-	end
+function BarMethods:SetStacks(count, unit, auraInstanceID)
+	F.Indicators.SetAuraStackText(self._stackText, unit, auraInstanceID, count)
 end
 
 --- Format duration as seconds (with tenths below 10s).

--- a/Elements/Indicators/Bar.lua
+++ b/Elements/Indicators/Bar.lua
@@ -247,7 +247,9 @@ function F.Indicators.Bar.Create(parent, config)
 	frame:SetFrameLevel(parent:GetFrameLevel() + 5)
 	frame:Hide()
 
-	-- Dark background
+	-- Dark background on the container. The StatusBar also gets its own
+	-- background below so the depleted portion remains visible even when the
+	-- StatusBar frame covers the container texture.
 	local bg = frame:CreateTexture(nil, 'BACKGROUND')
 	bg:SetAllPoints(frame)
 	bg:SetColorTexture(bgColor[1], bgColor[2], bgColor[3], bgColor[4] or 0.5)
@@ -261,6 +263,10 @@ function F.Indicators.Bar.Create(parent, config)
 	statusBar:SetStatusBarColor(0, 0, 0, 0)
 	statusBar:SetMinMaxValues(0, 1)
 	statusBar:SetValue(0)
+
+	local statusBg = statusBar:CreateTexture(nil, 'BACKGROUND')
+	statusBg:SetAllPoints(statusBar)
+	statusBg:SetColorTexture(bgColor[1], bgColor[2], bgColor[3], bgColor[4] or 0.5)
 
 	-- 0.5px border overlay
 	local border = CreateFrame('Frame', nil, frame, 'BackdropTemplate')
@@ -302,6 +308,7 @@ function F.Indicators.Bar.Create(parent, config)
 	local bar = {
 		_frame        = frame,
 		_statusBar    = statusBar,
+		_bg           = statusBg,
 		_stackText    = stackText,
 		_durationText = durationText,
 		_lowTimeColor = config.lowTimeColor,   -- { enabled, threshold, color }

--- a/Elements/Indicators/Bars.lua
+++ b/Elements/Indicators/Bars.lua
@@ -11,9 +11,10 @@ F.Indicators.Bars = {}
 
 local BarsMethods = {}
 
---- Set bars from aura data list. Each entry: { spellId, icon, duration, expirationTime, count, color }
+--- Set bars from aura data list. Each entry: { auraInstanceID, spellId, icon, duration, expirationTime, applications, color }
+--- @param unit string|nil Unit token for secret-safe stack display
 --- @param auraList table[]
-function BarsMethods:SetBars(auraList)
+function BarsMethods:SetBars(unit, auraList)
 	local count = math.min(#auraList, self._maxDisplayed)
 	local spellColors = self._config.spellColors
 	local defaultColor = self._config.color
@@ -36,9 +37,7 @@ function BarsMethods:SetBars(auraList)
 		else
 			bar:SetValue(1, 1)
 		end
-		if(aura.applications) then
-			bar:SetStacks(aura.applications)
-		end
+		bar:SetStacks(aura.applications, unit, aura.auraInstanceID)
 		bar:Show()
 		-- Apply per-bar glow if active
 		if(self._glowType and self._glowType ~= 'None') then

--- a/Elements/Indicators/BorderIcon.lua
+++ b/Elements/Indicators/BorderIcon.lua
@@ -12,31 +12,24 @@ F.Indicators.BorderIcon = {}
 
 local dispelColorCurve
 
---- Build a dispel color curve from C.Colors.dispel using oUF's
---- DispelType enum indices. Lazy-initialized on first use.
+--- Build a dispel color curve using oUF's own dispel color table.
+--- This mirrors oUF/elements/auras.lua so the x-values match
+--- C_UnitAuras.GetAuraDispelTypeColor's dispel type IDs.
 local function getDispelColorCurve()
 	if(dispelColorCurve) then return dispelColorCurve end
 	if(not C_CurveUtil or not C_CurveUtil.CreateColorCurve) then return nil end
 
 	local oUF = F.oUF
-	if(not oUF or not oUF.Enum or not oUF.Enum.DispelType) then return nil end
+	if(not oUF or not oUF.Enum or not oUF.Enum.DispelType or not oUF.colors or not oUF.colors.dispel) then return nil end
 	local dispelTypes = oUF.Enum.DispelType
 
 	dispelColorCurve = C_CurveUtil.CreateColorCurve()
 	dispelColorCurve:SetType(Enum.LuaCurveType.Step)
 
-	if(dispelTypes.None) then
-		dispelColorCurve:AddPoint(dispelTypes.None, CreateColor(1, 0, 0, 1))
-	end
-
-	-- Map oUF DispelType enum indices to C.Colors.dispel color keys.
-	-- oUF uses 'Bleed' but C.Colors.dispel uses 'Physical' for that type.
-	local COLOR_KEY = { Bleed = 'Physical' }
-	for name, index in next, dispelTypes do
-		local colorKey = COLOR_KEY[name] or name
-		local rgb = C.Colors.dispel[colorKey]
-		if(rgb) then
-			dispelColorCurve:AddPoint(index, CreateColor(rgb[1], rgb[2], rgb[3], 1))
+	for _, index in next, dispelTypes do
+		local color = oUF.colors.dispel[index]
+		if(color) then
+			dispelColorCurve:AddPoint(index, color)
 		end
 	end
 
@@ -51,7 +44,7 @@ local BorderIconMethods = {}
 
 --- Set the displayed aura data on this border icon.
 --- Supports two calling conventions:
----   New (secret-safe): SetAura(unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, showDispelColor)
+---   New (secret-safe): SetAura(unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count)
 ---   Legacy:            SetAura(spellId, iconTexture, duration, expirationTime, count, dispelType)
 --- When unit + auraInstanceID are provided, C-level APIs are used for
 --- cooldown (DurationObject), stacks, and dispel color (secret-safe).
@@ -59,15 +52,15 @@ local BorderIconMethods = {}
 --- via SetCooldownFromDurationObject — secret-safe, no Lua math needed.
 --- Without unit + auraInstanceID, falls back to legacy behavior.
 function BorderIconMethods:SetAura(...)
-	local unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, showDispelColor
+	local unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, dispelType
 
 	local arg1, arg2 = ...
 	-- Detect new vs legacy signature: if first arg is a string (unit token)
 	-- and second arg is a number (auraInstanceID), it's the new signature.
 	if(type(arg1) == 'string' and type(arg2) == 'number') then
-		unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, showDispelColor = ...
+		unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, dispelType = ...
 	else
-		spellId, iconTexture, duration, expirationTime, count, showDispelColor = ...
+		spellId, iconTexture, duration, expirationTime, count, dispelType = ...
 	end
 
 	-- Store for OnUpdate and other deferred lookups
@@ -89,26 +82,24 @@ function BorderIconMethods:SetAura(...)
 		self.icon:SetTexture(tex)
 	end
 
-	-- Border color from dispel type. The secret-safe path takes an addon-owned
-	-- boolean rather than raw aura.dispelName, then lets the C API resolve color.
+	-- Border color from dispel type. In the unit/auraInstanceID path, do not
+	-- inspect aura.dispelName in Lua. Ask the C API to map the aura's dispel
+	-- type through the oUF-shaped curve; no-type auras evaluate to None/red.
 	if(unit and auraInstanceID) then
-		if(F.IsValueNonSecret(showDispelColor) and showDispelColor == true) then
-			local curve = getDispelColorCurve()
-			if(curve) then
-				local color = C_UnitAuras.GetAuraDispelTypeColor(unit, auraInstanceID, curve)
-				if(color) then
-					self:SetBorderColor(color:GetRGBA())
-				end
+		local curve = getDispelColorCurve()
+		if(curve) then
+			local color = C_UnitAuras.GetAuraDispelTypeColor(unit, auraInstanceID, curve)
+			if(color == nil) then
+				color = curve:Evaluate(0)
+			end
+			if(color) then
+				self:SetBorderColor(color:GetRGBA())
 			end
 		end
-	else
-		-- Legacy path: callers may still pass a concrete dispel type string.
-		local dispelType = showDispelColor
-		if(F.IsValueNonSecret(dispelType) and dispelType) then
-			local color = C.Colors.dispel[dispelType]
-			if(color) then
-				self:SetBorderColor(color[1], color[2], color[3], 1)
-			end
+	elseif(F.IsValueNonSecret(dispelType) and dispelType) then
+		local color = C.Colors.dispel[dispelType]
+		if(color) then
+			self:SetBorderColor(color[1], color[2], color[3], 1)
 		end
 	end
 

--- a/Elements/Indicators/BorderIcon.lua
+++ b/Elements/Indicators/BorderIcon.lua
@@ -20,14 +20,18 @@ local function getDispelColorCurve()
 
 	local oUF = F.oUF
 	if(not oUF or not oUF.Enum or not oUF.Enum.DispelType) then return nil end
+	local dispelTypes = oUF.Enum.DispelType
 
 	dispelColorCurve = C_CurveUtil.CreateColorCurve()
 	dispelColorCurve:SetType(Enum.LuaCurveType.Step)
 
+	if(dispelTypes.None) then
+		dispelColorCurve:AddPoint(dispelTypes.None, CreateColor(1, 0, 0, 1))
+	end
+
 	-- Map oUF DispelType enum indices to C.Colors.dispel color keys.
 	-- oUF uses 'Bleed' but C.Colors.dispel uses 'Physical' for that type.
 	local COLOR_KEY = { Bleed = 'Physical' }
-	local dispelTypes = oUF.Enum.DispelType
 	for name, index in next, dispelTypes do
 		local colorKey = COLOR_KEY[name] or name
 		local rgb = C.Colors.dispel[colorKey]
@@ -92,7 +96,7 @@ function BorderIconMethods:SetAura(...)
 			local curve = getDispelColorCurve()
 			if(curve) then
 				local color = C_UnitAuras.GetAuraDispelTypeColor(unit, auraInstanceID, curve)
-				if(color and F.IsValueNonSecret(color)) then
+				if(color) then
 					self:SetBorderColor(color:GetRGBA())
 				end
 			end

--- a/Elements/Indicators/BorderIcon.lua
+++ b/Elements/Indicators/BorderIcon.lua
@@ -120,7 +120,7 @@ function BorderIconMethods:SetAura(...)
 				self.cooldown:SetReverse(true)
 			end
 		elseif(self.cooldown) then
-			self.cooldown:Clear()
+			F.Indicators.ClearCooldownCountdown(self.cooldown, self._cdText)
 		end
 	elseif(self.cooldown) then
 		-- Legacy path: raw SetCooldown (works in untainted contexts only)
@@ -131,7 +131,7 @@ function BorderIconMethods:SetAura(...)
 			self.cooldown:SetCooldown(startTime, duration)
 			self.cooldown:SetReverse(true)
 		else
-			self.cooldown:Clear()
+			F.Indicators.ClearCooldownCountdown(self.cooldown, self._cdText)
 		end
 	end
 
@@ -156,8 +156,10 @@ function BorderIconMethods:SetAura(...)
 			end
 			-- Re-apply position after every cooldown set (Blizzard resets to CENTER)
 			cdText:ClearAllPoints()
-			local df = self._durationFont
-			cdText:SetPoint(df.anchor, self._iconFrame, df.anchor, df.xOffset, df.yOffset)
+			local df = self._durationFont or {}
+			local anchor = df.anchor or 'CENTER'
+			cdText:SetPoint(anchor, self._iconFrame, anchor, df.xOffset or 0, df.yOffset or 0)
+			self._cdText = cdText
 		end
 	end
 
@@ -191,7 +193,7 @@ function BorderIconMethods:Clear()
 	self._unit = nil
 	self._auraInstanceID = nil
 	if(self.cooldown) then
-		self.cooldown:Clear()
+		F.Indicators.ClearCooldownCountdown(self.cooldown, self._cdText)
 	end
 	if(self.stacks) then
 		self.stacks:SetText('')
@@ -235,6 +237,7 @@ function BorderIconMethods:Destroy()
 	self._frame._biRef = nil
 	self._unit = nil
 	self._auraInstanceID = nil
+	F.Indicators.ClearCooldownCountdown(self.cooldown, self._cdText)
 	self._frame:Hide()
 	self._frame:SetParent(nil)
 end
@@ -331,6 +334,7 @@ function F.Indicators.BorderIcon.Create(parent, size, config)
 		_countdownReparented = false,
 		_unit            = nil,
 		_auraInstanceID  = nil,
+		_cdText          = nil,
 
 		icon          = icon,
 		cooldown      = cooldown,

--- a/Elements/Indicators/BorderIcon.lua
+++ b/Elements/Indicators/BorderIcon.lua
@@ -44,7 +44,7 @@ local BorderIconMethods = {}
 
 --- Set the displayed aura data on this border icon.
 --- Supports two calling conventions:
----   New (secret-safe): SetAura(unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count)
+---   New (secret-safe): SetAura(unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, useDispelColor)
 ---   Legacy:            SetAura(spellId, iconTexture, duration, expirationTime, count, dispelType)
 --- When unit + auraInstanceID are provided, C-level APIs are used for
 --- cooldown (DurationObject), stacks, and dispel color (secret-safe).
@@ -52,15 +52,15 @@ local BorderIconMethods = {}
 --- via SetCooldownFromDurationObject — secret-safe, no Lua math needed.
 --- Without unit + auraInstanceID, falls back to legacy behavior.
 function BorderIconMethods:SetAura(...)
-	local unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, dispelType
+	local unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, useDispelColor
 
 	local arg1, arg2 = ...
 	-- Detect new vs legacy signature: if first arg is a string (unit token)
 	-- and second arg is a number (auraInstanceID), it's the new signature.
 	if(type(arg1) == 'string' and type(arg2) == 'number') then
-		unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, dispelType = ...
+		unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, useDispelColor = ...
 	else
-		spellId, iconTexture, duration, expirationTime, count, dispelType = ...
+		spellId, iconTexture, duration, expirationTime, count, useDispelColor = ...
 	end
 
 	-- Store for OnUpdate and other deferred lookups
@@ -82,10 +82,10 @@ function BorderIconMethods:SetAura(...)
 		self.icon:SetTexture(tex)
 	end
 
-	-- Border color from dispel type. In the unit/auraInstanceID path, do not
-	-- inspect aura.dispelName in Lua. Ask the C API to map the aura's dispel
-	-- type through the oUF-shaped curve; no-type auras evaluate to None/red.
-	if(unit and auraInstanceID) then
+	-- Border color from dispel type. Debuffs opt in with useDispelColor=true.
+	-- Helpful-aura consumers (Defensives/Externals) paint their own custom
+	-- borders before SetAura and should not be overwritten by None/red.
+	if(unit and auraInstanceID and useDispelColor == true) then
 		local curve = getDispelColorCurve()
 		if(curve) then
 			local color = C_UnitAuras.GetAuraDispelTypeColor(unit, auraInstanceID, curve)
@@ -96,8 +96,8 @@ function BorderIconMethods:SetAura(...)
 				self:SetBorderColor(color:GetRGBA())
 			end
 		end
-	elseif(F.IsValueNonSecret(dispelType) and dispelType) then
-		local color = C.Colors.dispel[dispelType]
+	elseif(F.IsValueNonSecret(useDispelColor) and useDispelColor) then
+		local color = C.Colors.dispel[useDispelColor]
 		if(color) then
 			self:SetBorderColor(color[1], color[2], color[3], 1)
 		end

--- a/Elements/Indicators/BorderIcon.lua
+++ b/Elements/Indicators/BorderIcon.lua
@@ -47,7 +47,7 @@ local BorderIconMethods = {}
 
 --- Set the displayed aura data on this border icon.
 --- Supports two calling conventions:
----   New (secret-safe): SetAura(unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, dispelType)
+---   New (secret-safe): SetAura(unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, showDispelColor)
 ---   Legacy:            SetAura(spellId, iconTexture, duration, expirationTime, count, dispelType)
 --- When unit + auraInstanceID are provided, C-level APIs are used for
 --- cooldown (DurationObject), stacks, and dispel color (secret-safe).
@@ -55,15 +55,15 @@ local BorderIconMethods = {}
 --- via SetCooldownFromDurationObject — secret-safe, no Lua math needed.
 --- Without unit + auraInstanceID, falls back to legacy behavior.
 function BorderIconMethods:SetAura(...)
-	local unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, dispelType
+	local unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, showDispelColor
 
 	local arg1, arg2 = ...
 	-- Detect new vs legacy signature: if first arg is a string (unit token)
 	-- and second arg is a number (auraInstanceID), it's the new signature.
 	if(type(arg1) == 'string' and type(arg2) == 'number') then
-		unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, dispelType = ...
+		unit, auraInstanceID, spellId, iconTexture, duration, expirationTime, count, showDispelColor = ...
 	else
-		spellId, iconTexture, duration, expirationTime, count, dispelType = ...
+		spellId, iconTexture, duration, expirationTime, count, showDispelColor = ...
 	end
 
 	-- Store for OnUpdate and other deferred lookups
@@ -85,13 +85,10 @@ function BorderIconMethods:SetAura(...)
 		self.icon:SetTexture(tex)
 	end
 
-	-- Border color from dispel type (only when dispelType is non-nil).
-	-- Non-dispellable auras have dispelName = nil (not secret-nil), so
-	-- the truthiness check safely skips them — callers set their own
-	-- default border color before SetAura.
-	if(dispelType) then
-		if(unit and auraInstanceID) then
-			-- New path: C-level dispel color via curve (handles secret dispelType)
+	-- Border color from dispel type. The secret-safe path takes an addon-owned
+	-- boolean rather than raw aura.dispelName, then lets the C API resolve color.
+	if(unit and auraInstanceID) then
+		if(F.IsValueNonSecret(showDispelColor) and showDispelColor == true) then
 			local curve = getDispelColorCurve()
 			if(curve) then
 				local color = C_UnitAuras.GetAuraDispelTypeColor(unit, auraInstanceID, curve)
@@ -99,8 +96,11 @@ function BorderIconMethods:SetAura(...)
 					self:SetBorderColor(color:GetRGBA())
 				end
 			end
-		elseif(F.IsValueNonSecret(dispelType)) then
-			-- Legacy path: manual color lookup
+		end
+	else
+		-- Legacy path: callers may still pass a concrete dispel type string.
+		local dispelType = showDispelColor
+		if(F.IsValueNonSecret(dispelType) and dispelType) then
 			local color = C.Colors.dispel[dispelType]
 			if(color) then
 				self:SetBorderColor(color[1], color[2], color[3], 1)
@@ -116,7 +116,7 @@ function BorderIconMethods:SetAura(...)
 		local durationObj = C_UnitAuras.GetAuraDuration(unit, auraInstanceID)
 		if(durationObj) then
 			if(self.cooldown) then
-				self.cooldown:SetCooldownFromDurationObject(durationObj)
+				self.cooldown:SetCooldownFromDurationObject(durationObj, true)
 				self.cooldown:SetReverse(true)
 			end
 		elseif(self.cooldown) then
@@ -164,28 +164,9 @@ function BorderIconMethods:SetAura(...)
 	-- Stacks
 	if(self.stacks) then
 		if(unit and auraInstanceID) then
-			-- New path: C-level formatted display count.
-			-- SetText is a C-level API that accepts secret values, so we
-			-- pass the result directly without IsValueNonSecret. Always
-			-- show when non-nil — an empty secret string is invisible.
-			local displayCount = C_UnitAuras.GetAuraApplicationDisplayCount(
-				unit, auraInstanceID, 2, 99)
-			if(displayCount) then
-				self.stacks:SetText(displayCount)
-				self.stacks:Show()
-			else
-				self.stacks:SetText('')
-				self.stacks:Hide()
-			end
+			F.Indicators.SetAuraStackText(self.stacks, unit, auraInstanceID, count)
 		else
-			-- Legacy path
-			if(count and count > 1) then
-				self.stacks:SetText(count)
-				self.stacks:Show()
-			else
-				self.stacks:SetText('')
-				self.stacks:Hide()
-			end
+			F.Indicators.SetAuraStackText(self.stacks, nil, nil, count)
 		end
 	end
 

--- a/Elements/Indicators/Color.lua
+++ b/Elements/Indicators/Color.lua
@@ -35,14 +35,8 @@ function ColorMethods:SetValue(current, max)
 	self:Show()
 end
 
-function ColorMethods:SetStacks(count)
-	if(not self._stackText) then return end
-	if(count and count > 1) then
-		self._stackText:SetText(count)
-		self._stackText:Show()
-	else
-		self._stackText:Hide()
-	end
+function ColorMethods:SetStacks(count, unit, auraInstanceID)
+	F.Indicators.SetAuraStackText(self._stackText, unit, auraInstanceID, count)
 end
 
 function ColorMethods:Clear()

--- a/Elements/Indicators/Color.lua
+++ b/Elements/Indicators/Color.lua
@@ -106,9 +106,9 @@ function F.Indicators.Color.Create(parent, config)
 	texture:SetPoint('BOTTOMRIGHT', frame, 'BOTTOMRIGHT', -1, 1)
 	texture:SetColorTexture(color[1], color[2], color[3], color[4] or 1)
 
-	-- Stack text (optional)
+	-- Stack text (optional, default off — opposite of ICON/ICONS)
 	local stackText
-	if(config.showStacks ~= false) then
+	if(config.showStacks == true) then
 		local sf = config.stackFont or {}
 		stackText = Widgets.CreateFontString(frame, sf.size or 10, { 1, 1, 1, 1 })
 		stackText:SetPoint('CENTER', frame, 'CENTER', 0, 0)

--- a/Elements/Indicators/Icon.lua
+++ b/Elements/Indicators/Icon.lua
@@ -69,7 +69,7 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 
 	-- Stacks
 	if(self._config.showStacks) then
-		self:SetStacks(stacks)
+		F.Indicators.SetAuraStackText(self.stacks, unit, auraInstanceID, stacks)
 	end
 
 	-- Get DurationObject
@@ -95,7 +95,7 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 	-- Duration countdown via Cooldown frame
 	if(self._cooldown) then
 		if(hasUsableDurationObject(durationObj)) then
-			self._cooldown:SetCooldownFromDurationObject(durationObj)
+			self._cooldown:SetCooldownFromDurationObject(durationObj, true)
 
 			-- Reparent and style Blizzard's countdown text once (lazy creation),
 			-- then re-apply anchor after every cooldown set (Blizzard re-centers it).
@@ -176,15 +176,10 @@ end
 
 --- Show/update stack count text. Hidden when stacks <= 1.
 --- @param count number|nil
-function IconMethods:SetStacks(count)
-	if(not self.stacks) then return end
-	if(count and count > 1) then
-		self.stacks:SetText(count)
-		self.stacks:Show()
-	else
-		self.stacks:SetText('')
-		self.stacks:Hide()
-	end
+--- @param unit string|nil Unit token for secret-safe stack display
+--- @param auraInstanceID number|nil Aura instance ID for secret-safe stack display
+function IconMethods:SetStacks(count, unit, auraInstanceID)
+	F.Indicators.SetAuraStackText(self.stacks, unit, auraInstanceID, count)
 end
 
 --- Set up a manual DurationObject for preview/manual use.

--- a/Elements/Indicators/Icon.lua
+++ b/Elements/Indicators/Icon.lua
@@ -155,7 +155,7 @@ function IconMethods:SetSpell(unit, auraInstanceID, spellID, iconTexture, durati
 				F.Indicators.IconTicker_Register(self)
 			end
 		else
-			self._cooldown:Clear()
+			F.Indicators.ClearCooldownCountdown(self._cooldown, self._cdText)
 			F.Indicators.IconTicker_Unregister(self)
 		end
 	end
@@ -209,7 +209,7 @@ function IconMethods:Clear()
 		self._depletionBar:Hide()
 	end
 	if(self._cooldown) then
-		self._cooldown:Clear()
+		F.Indicators.ClearCooldownCountdown(self._cooldown, self._cdText)
 	end
 	self:StopGlow()
 	self._durationObj = nil

--- a/Elements/Indicators/Rectangle.lua
+++ b/Elements/Indicators/Rectangle.lua
@@ -3,10 +3,12 @@ local F = Framed
 local Widgets = F.Widgets
 
 F.Indicators = F.Indicators or {}
-F.Indicators.Color = {}
+F.Indicators.Rectangle = {}
 
 -- ============================================================
--- Color (Positioned Rectangle) methods
+-- Rectangle (positioned colored rectangle) methods
+-- Backs the RECTANGLE indicator type. Distinct from the user-facing
+-- "Color / Duration Overlay" label which is backed by Overlay.lua.
 -- ============================================================
 
 local DURATION_UPDATE_INTERVAL = 0.1
@@ -82,7 +84,7 @@ end
 -- Factory
 -- ============================================================
 
-function F.Indicators.Color.Create(parent, config)
+function F.Indicators.Rectangle.Create(parent, config)
 	config = config or {}
 	local color   = config.color or { 1, 1, 1, 1 }
 	local rectW   = config.rectWidth or 10

--- a/Elements/Indicators/Shared.lua
+++ b/Elements/Indicators/Shared.lua
@@ -74,3 +74,23 @@ function F.Indicators.SetAuraStackText(fontString, unit, auraInstanceID, fallbac
 		fontString:Hide()
 	end
 end
+
+--- Clear a cooldown and any countdown text that was reparented for styling.
+--- Cooldown:Clear() resets the cooldown state, but a moved FontString can keep
+--- rendering stale text unless we explicitly blank it.
+--- @param cooldown Cooldown|nil
+--- @param countdownText FontString|nil
+function F.Indicators.ClearCooldownCountdown(cooldown, countdownText)
+	if(cooldown) then
+		cooldown:Clear()
+	end
+
+	local text = countdownText
+	if(not text and cooldown and cooldown.GetCountdownFontString) then
+		text = cooldown:GetCountdownFontString()
+	end
+	if(text) then
+		text:SetText('')
+		text:Hide()
+	end
+end

--- a/Elements/Indicators/Shared.lua
+++ b/Elements/Indicators/Shared.lua
@@ -48,3 +48,29 @@ function F.Indicators.UpdateThresholdColor(self, remaining, duration, setColorFn
 		setColorFn(base[1], base[2], base[3], base[4] or 1)
 	end
 end
+
+--- Set aura stack/count text without branching on secret AuraData fields.
+--- When unit + auraInstanceID are available, the display string comes from
+--- C_UnitAuras and is passed straight into FontString:SetText.
+--- @param fontString FontString|nil
+--- @param unit string|nil
+--- @param auraInstanceID number|nil
+--- @param fallbackCount number|nil
+function F.Indicators.SetAuraStackText(fontString, unit, auraInstanceID, fallbackCount)
+	if(not fontString) then return end
+
+	if(unit and auraInstanceID and C_UnitAuras and C_UnitAuras.GetAuraApplicationDisplayCount) then
+		local displayCount = C_UnitAuras.GetAuraApplicationDisplayCount(unit, auraInstanceID, 2, 99)
+		fontString:SetText(displayCount)
+		fontString:Show()
+		return
+	end
+
+	if(F.IsValueNonSecret(fallbackCount) and fallbackCount and fallbackCount > 1) then
+		fontString:SetText(fallbackCount)
+		fontString:Show()
+	else
+		fontString:SetText('')
+		fontString:Hide()
+	end
+end

--- a/Elements/Status/CrowdControl.lua
+++ b/Elements/Status/CrowdControl.lua
@@ -51,8 +51,9 @@ local function Update(self, event, unit, updateInfo)
 		element.icon:SetTexture(foundIcon)
 		element.icon:Show()
 
-		if(foundExpiry and foundExpiry > 0) then
-			local remaining = foundExpiry - GetTime()
+		local expiry = F.IsValueNonSecret(foundExpiry) and foundExpiry or nil
+		if(expiry and expiry > 0) then
+			local remaining = expiry - GetTime()
 			if(remaining > 0) then
 				element.duration:SetText(F.FormatDuration(remaining))
 				element.duration:Show()
@@ -63,8 +64,12 @@ local function Update(self, event, unit, updateInfo)
 			element.duration:Hide()
 		end
 
-		element._expiry = foundExpiry
-		StartTimer(element)
+		element._expiry = expiry
+		if(expiry) then
+			StartTimer(element)
+		else
+			StopTimer(element)
+		end
 		element:Show()
 	else
 		element._expiry = nil

--- a/Elements/Status/LossOfControl.lua
+++ b/Elements/Status/LossOfControl.lua
@@ -149,8 +149,9 @@ local function Update(self, event, unit, updateInfo)
 			element.icon:Hide()
 		end
 
-		if(bestExpiry and bestExpiry > 0) then
-			local remaining = bestExpiry - GetTime()
+		local expiry = F.IsValueNonSecret(bestExpiry) and bestExpiry or nil
+		if(expiry and expiry > 0) then
+			local remaining = expiry - GetTime()
 			if(remaining > 0) then
 				element.duration:SetText(F.FormatDuration(remaining))
 				element.duration:Show()
@@ -162,8 +163,12 @@ local function Update(self, event, unit, updateInfo)
 		end
 
 		-- Store expiry for OnUpdate ticker
-		element._expiry = bestExpiry
-		StartTimer(element)
+		element._expiry = expiry
+		if(expiry) then
+			StartTimer(element)
+		else
+			StopTimer(element)
+		end
 
 		element:Show()
 	else

--- a/Framed.toc
+++ b/Framed.toc
@@ -94,7 +94,7 @@ Elements/Indicators/FrameBar.lua
 Elements/Indicators/Bar.lua
 Elements/Indicators/Bars.lua
 Elements/Indicators/BorderGlow.lua
-Elements/Indicators/Color.lua
+Elements/Indicators/Rectangle.lua
 Elements/Indicators/Overlay.lua
 Elements/Indicators/BorderIcon.lua
 

--- a/Settings/Builders/IndicatorCardBuilders.lua
+++ b/Settings/Builders/IndicatorCardBuilders.lua
@@ -676,11 +676,13 @@ Builders.CARDS_FOR_TYPE = {
 		{ 'glow',             'Border Glow',     'SharedGlow' },
 	},
 	[C.IndicatorType.RECTANGLE] = {
-		{ 'size',             'Size',       Builders.Size },
-		{ 'thresholdColors',  nil,          'SharedThresholdColors' },
-		{ 'stacks',           'Stacks',     Builders.Stacks },
-		{ 'glow',             'Border Glow', 'SharedGlow' },
-		{ 'position',         'Position',   'SharedPosition' },
+		{ 'castBy',           'Cast By',        Builders.CastBy },
+		{ 'trackedSpells',    'Tracked Spells', Builders.TrackedSpells },
+		{ 'size',             'Size',           Builders.Size },
+		{ 'thresholdColors',  nil,              'SharedThresholdColors' },
+		{ 'stacks',           'Stacks',         Builders.Stacks },
+		{ 'glow',             'Border Glow',    'SharedGlow' },
+		{ 'position',         'Position',       'SharedPosition' },
 	},
 	[C.IndicatorType.OVERLAY] = {
 		{ 'castBy',           'Cast By',    Builders.CastBy },

--- a/Settings/Framework.lua
+++ b/Settings/Framework.lua
@@ -198,6 +198,8 @@ local function frameUnitLabel(unitKey)
 	return label
 end
 
+Settings.GetFrameUnitLabel = frameUnitLabel
+
 --- Build the item list for the header inline dropdown. Reuses the
 --- Configure-for items but decorates each label with " Frame" so the
 --- menu rows read "Player Frame", "Target Frame", etc.


### PR DESCRIPTION
20-commit hardening pass surfaced by forced-secret-mode testing. All commits scoped narrowly so individual reverts are easy if needed.

## Categories

### Secret-value hardening
- Centralize secret-safe stack rendering (`F.Indicators.SetAuraStackText`); unify `SetStacks(count, unit, auraInstanceID)` across Bar/Color/Icon/BorderIcon
- IsZero crash fix on Icon/BorderIcon DurationObject path; pass `clearIfZero=true` to `SetCooldownFromDurationObject`
- Health/Power: use `SetFormattedText` (C-level) for percent text instead of Lua `string.format`
- Name: drop Lua-side UTF-8 truncation, rely on `SetWordWrap(false)` + bounded width for native ellipsis
- CrowdControl/LossOfControl: guard expiry against secret-tagged values
- Restore truthy-check on dispelName for Dispellable "all" mode (initial guard was over-defensive — secret strings are safe to truthy-check, only secret booleans crash)

### Visual artifact fixes
- Blank reparented countdown text on Cooldown:Clear (depleted text wasn't being cleared)
- StatusBar-level bg texture on Bar so depleted area shows the bg color (parent's BACKGROUND was being masked by the StatusBar frame)
- Long-duration aura filter extended from BARS to track-all OVERLAY/RECTANGLE/BAR/BORDER (flask/food no longer pins the bar)

### Edit mode
- Inline position panel now shows the frame's display name (e.g. "Player Frame", "Boss 1 Frame") so the user can confirm what's being edited
- Group click catchers (party/raid/boss/arena/pinned) live-resize when EditCache values change — previously snapped back to original size on deselect

### Settings UX
- RECTANGLE indicator gets Cast By + Tracked Spells cards (was missing from the new card-grid panel — preview rendered but live didn't)
- BAR/Color showStacks defaults to off (matches UI checkbox default; ICON/ICONS still default on)

### Cleanup
- Externals: RAID_IN_COMBAT classification swap (Symbiotic Relationship leak in M+) — was already on working-testing
- BorderIcon: `useDispelColor` opt-in flag so Externals/Defensives custom borders don't get overwritten by curve-resolved color
- Color.lua → Rectangle.lua rename (file was misnamed, colliding with user-facing "Color / Duration Overlay" label)

## Verification

- luacheck clean across all modified files (pre-commit hook ran on every commit)
- Symbiotic Relationship verified hidden in `secretCombatRestrictionsForced 1` testing
- Ironbark icon verified renders correctly in forced-secret combat (was crashing IsZero)
- Dispellable highlight verified in both "by me" and "all" modes after the truthy-check restore
- BAR depletion verified to show shaded bg with explicit bgColor
- RECTANGLE indicator verified to render live with newly-added Tracked Spells card

## Known limitations not addressed

- Solo frame inner wrappers (Health/Power) don't resize during edit mode — `FrameConfigLayout` width handler only fires on CONFIG_CHANGED, not EDIT_CACHE_VALUE_CHANGED. Click catcher fix here only addresses group catchers; solo's wrappers stay stale until commit.
- Dispellable "all" mode in classified content: works for typed dispels (truthy-check on secret string), but no curve-based color resolution. Long-term answer is fingerprinting (#90).