### PR TITLE
ci: trim CHANGELOG.md before packager so CurseForge gets only current release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,21 +14,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: BigWigsMods/packager@v2
-        with:
-          args: -g retail
-        env:
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
-
-      # Packager embeds the entire CHANGELOG.md as the release body, which
-      # pulls in previous version blocks too. Replace the body with just the
-      # top version block so the GitHub release page and the Discord post
-      # show only the current release.
-      - name: Trim release notes to current version
-        env:
-          GH_TOKEN: ${{ github.token }}
+      # Trim CHANGELOG.md to just the top version block before the packager
+      # runs. The packager uses CHANGELOG.md verbatim per .pkgmeta's
+      # `manual-changelog`, so trimming in place ensures both CurseForge AND
+      # the GitHub release body get only the current release's notes — not
+      # the entire cumulative history. Original is restored after upload.
+      - name: Trim CHANGELOG.md to current version
         run: |
+          cp CHANGELOG.md /tmp/full-changelog.md
           awk '
             /^## v/ {
               count++
@@ -36,10 +29,23 @@ jobs:
               next
             }
             count == 1 { print }
-          ' CHANGELOG.md > /tmp/release-notes.md
-          echo '--- trimmed release notes ---'
-          cat /tmp/release-notes.md
-          gh release edit "${GITHUB_REF_NAME}" --notes-file /tmp/release-notes.md
+          ' /tmp/full-changelog.md > CHANGELOG.md
+          echo '--- trimmed CHANGELOG.md ---'
+          cat CHANGELOG.md
+
+      - uses: BigWigsMods/packager@v2
+        with:
+          args: -g retail
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore CHANGELOG.md
+        if: always()
+        run: |
+          if [ -f /tmp/full-changelog.md ]; then
+            mv /tmp/full-changelog.md CHANGELOG.md
+          fi
 
       # Packager creates the GitHub release under the default token, which
       # means the `release: [published]` event is suppressed (GitHub's


### PR DESCRIPTION
## Problem

CurseForge release pages were showing the entire cumulative CHANGELOG.md content (every version block back to v0.8.0+) on each release. GitHub release body was correctly trimmed but CurseForge wasn't.

## Root cause

`release.yml` ran the awk trim step *after* `BigWigsMods/packager@v2`. The packager uploads to CurseForge using CHANGELOG.md verbatim per `.pkgmeta`'s `manual-changelog: CHANGELOG.md`, so it sent the full cumulative content to CurseForge. The post-packager `gh release edit` only patched the GitHub release body.

## Fix

Move the trim before the packager and apply it to CHANGELOG.md in place. The packager then uploads the trimmed file to both CurseForge and the GitHub release. A post-step restores the original CHANGELOG.md for any subsequent steps that read it (the runner discards the workspace anyway, so this is cosmetic).

The post-packager `gh release edit` step is removed since the GitHub release body now lands trimmed from the start.

## Verified

- awk extract sanity-checked locally on current CHANGELOG.md — extracts exactly the v0.8.18-alpha block, stops at v0.8.17-alpha
- `if: always()` on the restore step ensures CHANGELOG.md is restored even if the packager fails

## Doesn't affect

- In-game About card still pulls full history from CHANGELOG.md via `tools/sync-changelog.lua` — sync runs at commit time, not at release time
- Local CHANGELOG.md stays as-is