### PR TITLE
ci: trim CHANGELOG.md before packager so CurseForge gets only current release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,21 +14,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: BigWigsMods/packager@v2
-        with:
-          args: -g retail
-        env:
-          CF_API_KEY: ${{ secrets.CF_API_KEY }}
-          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
-
-      # Packager embeds the entire CHANGELOG.md as the release body, which
-      # pulls in previous version blocks too. Replace the body with just the
-      # top version block so the GitHub release page and the Discord post
-      # show only the current release.
-      - name: Trim release notes to current version
-        env:
-          GH_TOKEN: ${{ github.token }}
+      # Trim CHANGELOG.md to just the top version block before the packager
+      # runs. The packager uses CHANGELOG.md verbatim per .pkgmeta's
+      # `manual-changelog`, so trimming in place ensures both CurseForge AND
+      # the GitHub release body get only the current release's notes — not
+      # the entire cumulative history. Original is restored after upload.
+      - name: Trim CHANGELOG.md to current version
         run: |
+          cp CHANGELOG.md /tmp/full-changelog.md
           awk '
             /^## v/ {
               count++
@@ -36,10 +29,23 @@ jobs:
               next
             }
             count == 1 { print }
-          ' CHANGELOG.md > /tmp/release-notes.md
-          echo '--- trimmed release notes ---'
-          cat /tmp/release-notes.md
-          gh release edit "${GITHUB_REF_NAME}" --notes-file /tmp/release-notes.md
+          ' /tmp/full-changelog.md > CHANGELOG.md
+          echo '--- trimmed CHANGELOG.md ---'
+          cat CHANGELOG.md
+
+      - uses: BigWigsMods/packager@v2
+        with:
+          args: -g retail
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore CHANGELOG.md
+        if: always()
+        run: |
+          if [ -f /tmp/full-changelog.md ]; then
+            mv /tmp/full-changelog.md CHANGELOG.md
+          fi
 
       # Packager creates the GitHub release under the default token, which
       # means the `release: [published]` event is suppressed (GitHub's


### PR DESCRIPTION
Promotion of v0.8.18-alpha from working to main.

## Included

- **#196** — Aura/indicator secret-mode hardening pass + edit mode + element fixes (20 commits)
- **#197** — Promote v0.8.18-alpha (CHANGELOG + sync + TOC bump)

## Highlights

- Bar depleted area now shows bg color (StatusBar-level bg texture)
- Long-duration filter extended to track-all OVERLAY/RECTANGLE/BAR/BORDER
- Health/Power/Name/CrowdControl/LossOfControl secret-value hardening
- BorderIcon dispel-color is now opt-in (Externals/Defensives keep custom borders)
- Edit mode: inline panel shows frame name; group click catchers live-resize from EditCache
- Settings: RECTANGLE indicator gets Cast By + Tracked Spells cards
- Color.lua → Rectangle.lua rename to match user-facing labels
- Centralized stack-text rendering helper across all indicator types

## Known limitations

- Solo frame inner wrappers (Health/Power) don't resize during edit mode — `FrameConfigLayout` width handler only fires on CONFIG_CHANGED, not EDIT_CACHE_VALUE_CHANGED.
- Dispellable "all" mode in classified content: works for typed dispels via secret-string truthy-check; no curve-based color resolution. Long-term answer is fingerprinting (#90).

## Release

Once merged, `auto-tag.yml` should fire the v0.8.18-alpha tag, which triggers `release.yml` (packager + Discord notification) per the standard release workflow.