### PR TITLE
health: hoist absorb-prediction fix out of oUF (currently lost on CurseForge releases)

### DIFF
--- a/Elements/Core/Health.lua
+++ b/Elements/Core/Health.lua
@@ -109,6 +109,96 @@ end
 F.Elements.Health.NpcUpdateColor = NpcUpdateColor
 
 -- ============================================================
+-- Update override
+-- Mirrors oUF/elements/health.lua's Update with one change:
+-- UnitGetDetailedHealPrediction is called with casterFilter=nil
+-- (not 'player') so DamageAbsorb/HealAbsorb include absorbs cast
+-- by anyone — otherwise a priest's PW:Shield on the player wouldn't
+-- show because it wasn't cast by the player. HealingAll/Player/Other
+-- still split naturally via the calculator's own segmentation.
+--
+-- Wired via element.Override per oUF's documented public API rather
+-- than mutating Libs/oUF/. If oUF's upstream Update grows new
+-- features (new sub-elements, new callbacks), this override needs
+-- the same additions.
+-- ============================================================
+
+local function HealthUpdate(self, event, unit)
+	if(not unit or self.unit ~= unit) then return end
+	local element = self.Health
+
+	if(element.PreUpdate) then
+		element:PreUpdate(unit)
+	end
+
+	UnitGetDetailedHealPrediction(unit, nil, element.values)
+
+	local max = element.values:GetMaximumHealth()
+	element:SetMinMaxValues(0, max)
+
+	local cur = element.values:GetCurrentHealth()
+	if(UnitIsConnected(unit)) then
+		element:SetValue(cur, element.smoothing)
+	else
+		element:SetValue(max, element.smoothing)
+	end
+
+	element.cur = cur -- DEPRECATED: use element.values
+	element.max = max -- DEPRECATED: use element.values
+
+	if(element.HealingAll or element.HealingPlayer or element.HealingOther or element.OverHealIndicator) then
+		local allHeal, playerHeal, otherHeal, healClamped = element.values:GetIncomingHeals()
+		if(element.HealingAll) then
+			element.HealingAll:SetMinMaxValues(0, max)
+			element.HealingAll:SetValue(allHeal)
+		end
+		if(element.HealingPlayer) then
+			element.HealingPlayer:SetMinMaxValues(0, max)
+			element.HealingPlayer:SetValue(playerHeal)
+		end
+		if(element.HealingOther) then
+			element.HealingOther:SetMinMaxValues(0, max)
+			element.HealingOther:SetValue(otherHeal)
+		end
+		if(element.OverHealIndicator) then
+			element.OverHealIndicator:SetAlphaFromBoolean(healClamped, 1, 0)
+		end
+	end
+
+	if(element.DamageAbsorb or element.OverDamageAbsorbIndicator) then
+		local damageAbsorbAmount, damageAbsorbClamped = element.values:GetDamageAbsorbs()
+		if(element.DamageAbsorb) then
+			element.DamageAbsorb:SetMinMaxValues(0, max)
+			element.DamageAbsorb:SetValue(damageAbsorbAmount)
+		end
+		if(element.OverDamageAbsorbIndicator) then
+			element.OverDamageAbsorbIndicator:SetAlphaFromBoolean(damageAbsorbClamped, 1, 0)
+		end
+	end
+
+	if(element.HealAbsorb or element.OverHealAbsorbIndicator) then
+		local healAbsorbAmount, healAbsorbClamped = element.values:GetHealAbsorbs()
+		if(element.HealAbsorb) then
+			element.HealAbsorb:SetMinMaxValues(0, max)
+			element.HealAbsorb:SetValue(healAbsorbAmount)
+		end
+		if(element.OverHealAbsorbIndicator) then
+			element.OverHealAbsorbIndicator:SetAlphaFromBoolean(healAbsorbClamped, 1, 0)
+		end
+	end
+
+	local lossPerc = 0
+	if(element.TempLoss) then
+		lossPerc = GetUnitTotalModifiedMaxHealthPercent(unit)
+		element.TempLoss:SetValue(lossPerc, element.smoothing)
+	end
+
+	if(element.PostUpdate) then
+		element:PostUpdate(unit, cur, max, lossPerc)
+	end
+end
+
+-- ============================================================
 -- Health Element Setup
 -- ============================================================
 
@@ -617,6 +707,13 @@ function F.Elements.Health.Setup(self, width, height, config)
 			health._overShieldCalc = CreateUnitHealPredictionCalculator()
 		end
 	end
+
+	-- --------------------------------------------------------
+	-- Override: include absorbs cast by anyone, not just the player.
+	-- See HealthUpdate above for rationale.
+	-- --------------------------------------------------------
+
+	health.Override = HealthUpdate
 
 	-- --------------------------------------------------------
 	-- Assign to oUF — activates the Health element

--- a/Libs/oUF/elements/health.lua
+++ b/Libs/oUF/elements/health.lua
@@ -220,12 +220,7 @@ local function Update(self, event, unit)
 		element:PreUpdate(unit)
 	end
 
-	-- Pass nil casterFilter (not 'player') so DamageAbsorb/HealAbsorb
-	-- include absorbs cast by anyone on the unit — otherwise a priest's
-	-- PW:Shield on the player wouldn't show because it wasn't cast by
-	-- the player. HealingAll/Player/Other still split naturally via
-	-- the calculator's own segmentation.
-	UnitGetDetailedHealPrediction(unit, nil, element.values)
+	UnitGetDetailedHealPrediction(unit, 'player', element.values)
 
 	local max = element.values:GetMaximumHealth()
 	element:SetMinMaxValues(0, max)


### PR DESCRIPTION
## Problem

Commit 7c972c7 (April 19) modified `Libs/oUF/elements/health.lua` to fix absorb visibility — a priest's PW:Shield on the player wasn't showing because oUF passed `casterFilter='player'` to `UnitGetDetailedHealPrediction`, filtering out absorbs cast by anyone else.

The fix was correct in intent but lived in the wrong place. `.pkgmeta` has:

\`\`\`yaml
externals:
  Libs/oUF:
    url: https://github.com/oUF-wow/oUF.git
    tag: latest
\`\`\`

So the packager pulls oUF fresh from upstream on every CurseForge release, silently overwriting the modification. **Every release since v0.8.17 has shipped without the absorb fix** — users downloading from CurseForge / WoWUp have been seeing no priest shields, no shaman Earth Shield, etc.

## Fix

Move the casterFilter change to a Framed-layer Update override per oUF's documented public `element.Override` API:

- Add `HealthUpdate` in `Elements/Core/Health.lua` mirroring upstream `Update` with `nil` casterFilter
- Wire via `health.Override = HealthUpdate` before `self.Health = health` in Setup
- Revert `Libs/oUF/elements/health.lua` to upstream (blob hash matches pre-7c972c7)

## Maintenance contract

The override mirrors the upstream Update body in full (~80 lines). If oUF's upstream Update grows new features (new sub-elements, new callbacks, new APIs), this override needs the same additions. Comment in the override block flags this explicitly.

## Verification

- luacheck clean on `Elements/Core/Health.lua`
- oUF file diff confirmed reverted to upstream blob hash `11182fa`
- Behavior should be identical to current dev (since dev was already running the modified upstream); first CurseForge release with this PR will be the actual verification — users should see absorbs from any caster

## Per `feedback_no_ouf_mods`

> Never edit Libs/oUF/** — hoist fixes to Framed layer, use public oUF APIs (EnableElement, Override)

This PR makes the codebase compliant with that rule.